### PR TITLE
docs: fix engine phases, workflow engine lists, add consciousness auto-promotion docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the Tryambakam Noesis Engine project.
 
+## [3.0.1] - 2026-02-23
+
+### Added
+- Consciousness level auto-promotion: users are promoted based on reading count (5→L1, 15→L2, 40→L3, 80→L4, 150→L5)
+- XP awards: 10 XP per engine calculation, 25 XP per workflow execution
+- Promotion cascades to `api_keys` table and logs to `progression_logs`
+- Documentation for consciousness levels and auto-promotion in `authentication.md` and `engines.md`
+
+### Fixed
+- `engines.md`: corrected `required_phase` for 9 engines (biofield 2→1, face-reading 2→1, nadabrahman 1→0, transits 1→0, gene-keys 1→2, vimshottari 1→2, tarot 1→0, i-ching 1→0, sacred-geometry 2→0, sigil-forge 2→1)
+- `workflows.md`: corrected `birth-blueprint` engine list (`gene-keys` → `vimshottari`)
+- `workflows.md` + `API_QUICKSTART.md`: corrected `full-spectrum` engine count (16 → 14, excludes nadabrahman and transits)
+
+---
+
 ## [3.0.0] - 2026-02-16
 
 ### Added

--- a/docs/API_QUICKSTART.md
+++ b/docs/API_QUICKSTART.md
@@ -201,7 +201,7 @@ curl -s .../api/v1/workflows \
 | **decision-support** | tarot + i-ching + HD authority | Multi-perspective guidance |
 | **self-inquiry** | gene-keys + enneagram | Shadow work + patterns |
 | **creative-expression** | sigil-forge + sacred-geometry | Intent visualization |
-| **full-spectrum** | all 16 engines | Complete consciousness portrait |
+| **full-spectrum** | 14 engines (all except nadabrahman, transits) | Complete consciousness portrait |
 
 ```bash
 # Execute a workflow

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -103,6 +103,23 @@ POST /api/v1/auth/change-password
 }
 ```
 
+## Consciousness Level & Auto-Promotion
+
+Each user starts at consciousness level 0 (Dormant). As you make engine calculations and workflow executions, your level is automatically promoted based on your total reading count:
+
+| Readings | Level | State |
+|----------|-------|-------|
+| 0–4 | 0 | Dormant |
+| 5+ | 1 | Glimpsing |
+| 15+ | 2 | Practicing |
+| 40+ | 3 | Integrated |
+| 80+ | 4 | Embodied |
+| 150+ | 5 | Embodied |
+
+Promotion is automatic and one-way (levels never decrease). Higher levels unlock phase-gated engines and workflows. If your level is below an engine's `required_phase`, the API returns `403` with error code `PHASE_ACCESS_DENIED`.
+
+Each engine calculation awards 10 XP and each workflow execution awards 25 XP. XP is tracked separately from level progression.
+
 ## Error Format
 
 ```json

--- a/docs/api/engines.md
+++ b/docs/api/engines.md
@@ -54,17 +54,17 @@ Notes:
 
 | Engine ID | Name | Required Phase |
 |-----------|------|----------------|
-| human-design | Human Design | 1 |
-| gene-keys | Gene Keys | 1 |
-| vimshottari | Vimshottari Dasha | 1 |
 | panchanga | Panchanga | 0 |
 | numerology | Numerology | 0 |
 | biorhythm | Biorhythm | 0 |
 | vedic-clock | Vedic Clock | 0 |
-| biofield | Biofield | 2 |
-| face-reading | Face Reading | 2 |
-| nadabrahman | Nadabrahman | 1 |
-| transits | Transits | 1 |
+| nadabrahman | Nadabrahman | 0 |
+| transits | Transits | 0 |
+| human-design | Human Design | 1 |
+| biofield | Biofield | 1 |
+| face-reading | Face Reading | 1 |
+| gene-keys | Gene Keys | 2 |
+| vimshottari | Vimshottari Dasha | 2 |
 
 ### TypeScript Engines (Bridged)
 
@@ -72,11 +72,17 @@ Notes:
 
 | Engine ID | Name | Required Phase |
 |-----------|------|----------------|
-| tarot | Tarot | 1 |
-| i-ching | I-Ching | 1 |
+| tarot | Tarot | 0 |
+| i-ching | I-Ching | 0 |
+| sacred-geometry | Sacred Geometry | 0 |
 | enneagram | Enneagram | 1 |
-| sacred-geometry | Sacred Geometry | 2 |
-| sigil-forge | Sigil Forge | 2 |
+| sigil-forge | Sigil Forge | 1 |
+
+---
+
+## Consciousness Phases
+
+Engines are gated by consciousness phase. If your account's level is below an engine's `required_phase`, the API returns `403 PHASE_ACCESS_DENIED`. Levels are promoted automatically based on reading count (see [authentication.md](./authentication.md#consciousness-level--auto-promotion)).
 
 ---
 

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -46,12 +46,12 @@ Workflows accept the same `EngineInput` as engines.
 
 | ID | Engines | Purpose |
 | --- | --- | --- |
-| birth-blueprint | numerology, human-design, gene-keys | Core identity mapping |
+| birth-blueprint | numerology, human-design, vimshottari | Core identity mapping |
 | daily-practice | panchanga, vedic-clock, biorhythm | Daily rhythm & timing |
 | decision-support | tarot, i-ching, human-design | Multi-perspective guidance |
 | self-inquiry | gene-keys, enneagram | Shadow work + patterns |
 | creative-expression | sigil-forge, sacred-geometry | Intent visualization |
-| full-spectrum | all 16 engines | Complete consciousness portrait |
+| full-spectrum | 14 engines (all except nadabrahman, transits) | Complete consciousness portrait |
 
 ## Example: Execute Workflow
 


### PR DESCRIPTION
## Documentation Drift Fix — 2026-02-23

### What changed

Automated documentation health check detected significant drift between source-of-truth code and user-facing docs.

### Facts extracted

**Source: `registry.rs`, `lib.rs`, engine `required_phase()` implementations, `consciousness.rs`**

- `birth-blueprint` workflow engines: `numerology, human-design, vimshottari`
- `full-spectrum` workflow includes 14 engines (not 16 — excludes `nadabrahman` and `transits`)
- Consciousness auto-promotion thresholds: 5→L1, 15→L2, 40→L3, 80→L4, 150→L5
- XP awards: 10 per engine calculation, 25 per workflow execution

### Files changed

| File | Reason |
|------|--------|
| `docs/api/engines.md` | Corrected `required_phase` for 9 of 16 engines; added consciousness phases section |
| `docs/api/workflows.md` | Fixed `birth-blueprint` engines (`gene-keys` → `vimshottari`); fixed `full-spectrum` count |
| `docs/API_QUICKSTART.md` | Fixed `full-spectrum` engine count |
| `docs/api/authentication.md` | Added consciousness level auto-promotion and XP documentation |
| `CHANGELOG.md` | Added 3.0.1 entry |

### Engine phase corrections (engines.md)

| Engine | Was | Now (code truth) |
|--------|-----|-------------------|
| biofield | 2 | 1 |
| face-reading | 2 | 1 |
| nadabrahman | 1 | 0 |
| transits | 1 | 0 |
| gene-keys | 1 | 2 |
| vimshottari | 1 | 2 |
| tarot | 1 | 0 |
| i-ching | 1 | 0 |
| sacred-geometry | 2 | 0 |
| sigil-forge | 2 | 1 |

### User-impact summary

- Users consulting engine docs now see correct phase requirements — previously some engines appeared locked at the wrong level.
- Consciousness auto-promotion is now documented so users understand how levels progress.
- `birth-blueprint` workflow now correctly documented with `vimshottari` (was `gene-keys`).

### Risk flags

- `LLM_AGENT_GUIDE.md` and `OPENCLAW_INTEGRATION.md` reference "16 engines" in verification checks — this matches the engine list count and is correct. No change needed.
- `full-spectrum` workflow in code includes 14 engines but README badge says "16 Engines" — the badge refers to total registered engines, not the workflow. No change needed.
- `openapi.yaml` was not checked in this run — may contain stale phase metadata if auto-generated docs use it.

### Triggered by

Commits `3962b3af` (consciousness level persistence + auto-promotion) through `e5132ac5` (docs sweep), which introduced the auto-promotion feature but did not update quickstart/engine/workflow docs with correct phase values.

_This PR was generated with [Warp](https://www.warp.dev/)._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that adjust phase/engine metadata and add progression/XP guidance; no runtime behavior changes.
> 
> **Overview**
> **Fixes documentation drift** by correcting `required_phase` values for multiple engines in `docs/api/engines.md`, and updating workflow docs so `birth-blueprint` uses `vimshottari` and `full-spectrum` is documented as **14 engines** (excluding `nadabrahman` and `transits`) across `docs/api/workflows.md` and `docs/API_QUICKSTART.md`.
> 
> Adds documentation for **consciousness level auto-promotion** thresholds, `PHASE_ACCESS_DENIED` behavior, and XP awards in `docs/api/authentication.md` (with a new *Consciousness Phases* section in `engines.md`), and records these doc fixes in `CHANGELOG.md` as `3.0.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 883395a7b130ea6d3d205c5104a31d5e5e751db2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->