### PR TITLE
docs: fix workflow engine lists, phase values, and missing status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,8 @@ True to the name *Noesis* (the act of knowing), workflows train direct intellect
 <tr>
 <td width="50%">
 
-**`birth-blueprint`** — *Numerology + Human Design + Vimshottari*
-> Your natal imprint. Life path numbers, bodygraph, 120-year timeline.
+**`birth-blueprint`** — *Numerology + Human Design + Gene Keys*
+> Your natal imprint. Life path numbers, bodygraph, activation sequences.
 
 **`daily-practice`** — *Panchanga + Vedic Clock + Biorhythm*
 > Optimal timing. Cosmic tide aligned with personal rhythm.

--- a/docs/API_QUICKSTART.md
+++ b/docs/API_QUICKSTART.md
@@ -196,7 +196,7 @@ curl -s .../api/v1/workflows \
 
 | Workflow | Engines | Purpose |
 |----------|---------|---------|
-| **birth-blueprint** | numerology + human-design + vimshottari | Core identity mapping |
+| **birth-blueprint** | numerology + human-design + gene-keys | Core identity mapping |
 | **daily-practice** | panchanga + vedic-clock + biorhythm | Daily rhythm & timing |
 | **decision-support** | tarot + i-ching + HD authority | Multi-perspective guidance |
 | **self-inquiry** | gene-keys + enneagram | Shadow work + patterns |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -76,6 +76,7 @@ Notes:
 - `GET /health/ready`
 - `GET /ready`
 - `GET /metrics` (Prometheus)
+- `GET /api/v1/status` (list engines and workflows; auth required)
 
 ### Engines
 

--- a/docs/api/engines.md
+++ b/docs/api/engines.md
@@ -55,16 +55,16 @@ Notes:
 | Engine ID | Name | Required Phase |
 |-----------|------|----------------|
 | human-design | Human Design | 1 |
-| gene-keys | Gene Keys | 1 |
-| vimshottari | Vimshottari Dasha | 1 |
+| gene-keys | Gene Keys | 2 |
+| vimshottari | Vimshottari Dasha | 2 |
 | panchanga | Panchanga | 0 |
 | numerology | Numerology | 0 |
 | biorhythm | Biorhythm | 0 |
 | vedic-clock | Vedic Clock | 0 |
-| biofield | Biofield | 2 |
-| face-reading | Face Reading | 2 |
-| nadabrahman | Nadabrahman | 1 |
-| transits | Transits | 1 |
+| biofield | Biofield | 1 |
+| face-reading | Face Reading | 1 |
+| nadabrahman | Nadabrahman | 0 |
+| transits | Transits | 0 |
 
 ### TypeScript Engines (Bridged)
 
@@ -72,11 +72,11 @@ Notes:
 
 | Engine ID | Name | Required Phase |
 |-----------|------|----------------|
-| tarot | Tarot | 1 |
-| i-ching | I-Ching | 1 |
+| tarot | Tarot | 0 |
+| i-ching | I-Ching | 0 |
 | enneagram | Enneagram | 1 |
-| sacred-geometry | Sacred Geometry | 2 |
-| sigil-forge | Sigil Forge | 2 |
+| sacred-geometry | Sacred Geometry | 0 |
+| sigil-forge | Sigil Forge | 1 |
 
 ---
 


### PR DESCRIPTION
## Documentation Consistency Health Check

Ran the documentation health-check workflow against the source of truth files and found several drifts.

### Facts Extracted

**Source of truth**: `crates/noesis-api/src/lib.rs` (routes), `crates/noesis-orchestrator/src/lib.rs` (workflow definitions), and individual engine `required_phase()` implementations.

- `birth-blueprint` workflow engines: `numerology`, `human-design`, `gene-keys`
- `GET /api/v1/status` exists as an authenticated endpoint
- 10 out of 16 engine phase values in docs did not match code

### Files Changed

| File | Reason |
|------|--------|
| `README.md` | Fixed `birth-blueprint` engines: was "Vimshottari", now "Gene Keys" |
| `docs/API_QUICKSTART.md` | Fixed `birth-blueprint` engines in workflow table |
| `docs/api/engines.md` | Fixed 10 incorrect `required_phase` values to match engine implementations |
| `docs/api/README.md` | Added missing `GET /api/v1/status` to endpoint list |

### Engine Phase Corrections (`docs/api/engines.md`)

| Engine | Was | Now (matches code) |
|--------|-----|---------------------|
| gene-keys | 1 | 2 |
| vimshottari | 1 | 2 |
| biofield | 2 | 1 |
| face-reading | 2 | 1 |
| nadabrahman | 1 | 0 |
| transits | 1 | 0 |
| tarot | 1 | 0 |
| i-ching | 1 | 0 |
| sacred-geometry | 2 | 0 |
| sigil-forge | 2 | 1 |

### User-Impact Summary

- Users relying on `birth-blueprint` workflow documentation now see the correct engine list (`gene-keys`, not `vimshottari`)
- Phase gating documentation now correctly reflects which engines are available at each consciousness level
- The `GET /api/v1/status` endpoint is now discoverable from the API README

### Risk Flags

- `docs/api/openapi.yaml` — already correct, no changes needed
- `docs/api/workflows.md` — already correct for workflow engine lists
- `docs/api/LLM_AGENT_GUIDE.md` and `OPENCLAW_INTEGRATION.md` — no workflow engine lists, unaffected

_This PR was generated with [Warp](https://www.warp.dev/)._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; no runtime behavior changes, but reduces risk of users calling the wrong engines/endpoints based on stale docs.
> 
> **Overview**
> Updates documentation to match the current API/workflow source of truth.
> 
> Corrects the `birth-blueprint` workflow engine list (replacing `vimshottari` with `gene-keys`) in `README.md` and `docs/API_QUICKSTART.md`, adds the missing authenticated `GET /api/v1/status` endpoint to `docs/api/README.md`, and fixes multiple engines’ documented `Required Phase` values in `docs/api/engines.md` (including `gene-keys`, `vimshottari`, `tarot`, and `i-ching`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3270848ee807b03421f9004c897b9ac46ca67b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->