### PR TITLE
docs/tests: merge-ready runtime-aligned docs + bridge phase test fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Tryambakam Noesis Engine project.
 
+## [3.0.1] - 2026-02-24
+
+### Added
+- Consciousness level auto-promotion docs with reading-count thresholds and XP accrual notes in [authentication.md](docs/api/authentication.md).
+- API surface docs for `GET /api/v1/status` in [docs/api/README.md](docs/api/README.md).
+
+### Fixed
+- Corrected workflow docs to match runtime: `birth-blueprint` uses `numerology + human-design + gene-keys`.
+- Corrected engine `required_phase` values in [docs/api/engines.md](docs/api/engines.md) to match current engine implementations.
+- Updated stale `noesis-bridge` unit tests for TS engine phase values (`i-ching`, `sacred-geometry`, `sigil-forge`).
+
 ## [3.0.0] - 2026-02-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -424,8 +424,8 @@ True to the name *Noesis* (the act of knowing), workflows train direct intellect
 <tr>
 <td width="50%">
 
-**`birth-blueprint`** — *Numerology + Human Design + Vimshottari*
-> Your natal imprint. Life path numbers, bodygraph, 120-year timeline.
+**`birth-blueprint`** — *Numerology + Human Design + Gene Keys*
+> Your natal imprint. Life path numbers, bodygraph, activation sequences.
 
 **`daily-practice`** — *Panchanga + Vedic Clock + Biorhythm*
 > Optimal timing. Cosmic tide aligned with personal rhythm.

--- a/docs/API_QUICKSTART.md
+++ b/docs/API_QUICKSTART.md
@@ -196,7 +196,7 @@ curl -s .../api/v1/workflows \
 
 | Workflow | Engines | Purpose |
 |----------|---------|---------|
-| **birth-blueprint** | numerology + human-design + vimshottari | Core identity mapping |
+| **birth-blueprint** | numerology + human-design + gene-keys | Core identity mapping |
 | **daily-practice** | panchanga + vedic-clock + biorhythm | Daily rhythm & timing |
 | **decision-support** | tarot + i-ching + HD authority | Multi-perspective guidance |
 | **self-inquiry** | gene-keys + enneagram | Shadow work + patterns |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -77,6 +77,7 @@ Notes:
 - `GET /health/ready`
 - `GET /ready`
 - `GET /metrics` (Prometheus)
+- `GET /api/v1/status` (list engines and workflows; auth required)
 
 ### Engines
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -103,6 +103,27 @@ POST /api/v1/auth/change-password
 }
 ```
 
+## Consciousness Level And Auto-Promotion
+
+Each user starts at consciousness level 0 (Dormant). As readings accumulate from engine calculations and workflow executions, level promotion is automatic based on total reading count:
+
+| Readings | Level | State |
+|----------|-------|-------|
+| 0-4 | 0 | Dormant |
+| 5+ | 1 | Glimpsing |
+| 15+ | 2 | Practicing |
+| 40+ | 3 | Integrated |
+| 80+ | 4 | Embodied |
+| 150+ | 5 | Embodied |
+
+Promotion is one-way (levels do not decrease). Higher levels unlock phase-gated engines. In workflows, engines above the current level may be skipped.
+
+If a single-engine endpoint is called below an engine's `required_phase`, the API returns `403` with `PHASE_ACCESS_DENIED`.
+
+XP is tracked separately from levels:
+- 10 XP per engine calculation
+- 25 XP per workflow execution
+
 ## Error Format
 
 ```json


### PR DESCRIPTION
## Summary
- keeps only runtime-correct docs updates from prior doc branches
- corrects workflow docs: `birth-blueprint` uses `gene-keys`
- adds `GET /api/v1/status` to API endpoint docs
- adds consciousness auto-promotion + XP docs
- aligns engine `required_phase` docs with runtime implementations
- updates stale `noesis-bridge` unit tests for TS phase values

## Validation
- `cargo test -p noesis-api test_birth_blueprint_workflow_includes_gene_keys -- --nocapture` ✅
- `cargo test -p noesis-bridge bridge_engine_factory_ -- --nocapture` ✅
- `cargo test -p noesis-bridge` ✅
- `cargo test --workspace` ❌ (pre-existing failures in `crates/engine-human-design/tests/reference_validation_tests.rs`)

## Notes
- No runtime behavior changes were introduced for engines/workflows.
- This PR intentionally excludes incorrect prior-doc claims (`birth-blueprint` + vimshottari, `full-spectrum` as 14 engines).
