### PR TITLE
fix: unblock deploy + standardize workflow fallback contracts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -69,7 +69,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          # swisseph currently fails to compile on arm64 in this Docker build path
+          # (libswisseph-sys pointer type mismatch under buildx/qemu). Keep deploys
+          # deterministic on amd64 until arm64 toolchain/dependency parity is fixed.
+          platforms: linux/amd64
       
       - name: Check image size
         run: |

--- a/docs/api/LLM_AGENT_GUIDE.md
+++ b/docs/api/LLM_AGENT_GUIDE.md
@@ -5,9 +5,13 @@ Provide a compact, deterministic API guide for LLMs and agents (Claude Code, Ope
 # Current State
 
 - Base URL: `https://selemene.tryambakam.space`
-- Auth: `X-API-Key` or `Authorization: Bearer <jwt>`
+- Auth:
+  - `X-API-Key: nk_<api_key>` for API key auth
+  - `Authorization: Bearer <jwt>` for JWT auth
 - Engines: `POST /api/v1/engines/{engine_id}/calculate`
-- Workflows: `POST /api/v1/workflows/{workflow_id}/execute`
+- Workflows:
+  - Canonical: `POST /api/v1/workflows/{workflow_id}/execute`, `GET /api/v1/workflows/{workflow_id}/info`
+  - Compatibility aliases: `POST/GET /api/v1/workflows/{workflow_id}`
 - Shared request schema: `EngineInput`
 - API key is a unique user identity; if `birth_data` is present, user profile is auto-populated.
 
@@ -18,6 +22,7 @@ Provide a compact, deterministic API guide for LLMs and agents (Claude Code, Ope
 3. Prefer `precision: "Standard"` unless a user asks otherwise.
 4. When unsure, include only `birth_data` and omit `options`.
 5. Handle non-200 responses using the standard error schema.
+6. For workflow calls, treat `engine_outputs` as partial-by-design and handle missing engines gracefully.
 
 # Verification
 
@@ -113,3 +118,11 @@ curl -s -X POST https://selemene.tryambakam.space/api/v1/workflows/birth-bluepri
   "details": {"auth_method": "api_key"}
 }
 ```
+
+# Engine Compatibility and Fallbacks
+
+- Numerology requires `birth_data.name`; missing name returns `422 VALIDATION_ERROR`.
+- Sigil Forge intention aliases accepted in `options`: `question`, `intention`, `intent`, `intent_text`.
+- Gene Keys fallback:
+  1. First try `POST /api/v1/engines/gene-keys/calculate` with `birth_data`.
+  2. On `500 CALCULATION_ERROR`, call Human Design, extract Sun/Earth gates, retry Gene Keys with `options.hd_gates`.

--- a/docs/api/MCP_INTEGRATION.md
+++ b/docs/api/MCP_INTEGRATION.md
@@ -1,0 +1,117 @@
+# Purpose
+
+Provide a deterministic MCP-facing integration contract for Noesis engines and workflows.
+
+# Base Contract
+
+- Base URL: `https://selemene.tryambakam.space`
+- Auth:
+  - API key: `X-API-Key: nk_<api_key>`
+  - JWT: `Authorization: Bearer <jwt>`
+- Content type: `application/json`
+- Shared payload: `EngineInput`
+
+# Recommended MCP Tool Surface
+
+Expose these tool-level actions from your MCP server:
+
+1. `noesis_list_engines`
+   - `GET /api/v1/engines`
+2. `noesis_calculate_engine`
+   - `POST /api/v1/engines/{engine_id}/calculate`
+3. `noesis_validate_engine`
+   - `POST /api/v1/engines/{engine_id}/validate`
+4. `noesis_list_workflows`
+   - `GET /api/v1/workflows`
+5. `noesis_workflow_info`
+   - Prefer `GET /api/v1/workflows/{workflow_id}/info`
+   - Compat alias: `GET /api/v1/workflows/{workflow_id}`
+6. `noesis_execute_workflow`
+   - Prefer `POST /api/v1/workflows/{workflow_id}/execute`
+   - Compat alias: `POST /api/v1/workflows/{workflow_id}`
+
+# Output Semantics
+
+- Engine calls return normalized `EngineOutput`.
+- Workflow calls return `WorkflowResult`.
+- `WorkflowResult.engine_outputs` may be partial:
+  - successful engine outputs are present
+  - failed/phase-gated engines are omitted
+
+Strict-mode client behavior:
+
+1. fetch expected engines via workflow info
+2. diff against `engine_outputs` keys
+3. run targeted fallback calls for missing engines
+
+# Fallback Patterns
+
+## Gene Keys Fallback (birth_data -> hd_gates)
+
+If `POST /api/v1/engines/gene-keys/calculate` with `birth_data` returns `500 CALCULATION_ERROR`:
+
+1. Call Human Design:
+   - `POST /api/v1/engines/human-design/calculate`
+2. Extract gates:
+   - `result.personality_activations.sun.gate`
+   - `result.personality_activations.earth.gate`
+   - `result.design_activations.sun.gate`
+   - `result.design_activations.earth.gate`
+3. Retry Gene Keys with `options.hd_gates`.
+
+## Sigil Forge Input Compatibility
+
+For `sigil-forge`, intention can be passed as:
+- `options.question`
+- `options.intention`
+- `options.intent`
+- `options.intent_text`
+
+## Numerology Validation
+
+`numerology` requires:
+- `birth_data`
+- `birth_data.name`
+
+Missing required fields return `422 VALIDATION_ERROR`.
+
+# Bridge Engines (TS Sidecar)
+
+Bridged engine IDs:
+- `tarot`
+- `i-ching`
+- `enneagram`
+- `sacred-geometry`
+- `sigil-forge`
+
+All are called through the same Noesis API endpoint:
+
+```http
+POST /api/v1/engines/{engine_id}/calculate
+```
+
+No MCP-side direct call to the TS sidecar is required.
+
+# Minimal MCP Request Example
+
+```json
+{
+  "engine_id": "daily-practice",
+  "input": {
+    "birth_data": {
+      "date": "1991-08-13",
+      "time": "13:31",
+      "latitude": 12.9716,
+      "longitude": 77.5946,
+      "timezone": "Asia/Kolkata"
+    },
+    "options": {}
+  }
+}
+```
+
+Map to:
+
+```http
+POST /api/v1/workflows/daily-practice/execute
+```

--- a/docs/api/OPENCLAW_INTEGRATION.md
+++ b/docs/api/OPENCLAW_INTEGRATION.md
@@ -7,7 +7,9 @@ Provide a concrete, OpenClaw-ready integration guide for calling Noesis APIs fro
 - Base URL: `https://selemene.tryambakam.space`
 - Auth header: `X-API-Key: nk_<api_key>`
 - Engine endpoint: `POST /api/v1/engines/{engine_id}/calculate`
-- Workflow endpoint: `POST /api/v1/workflows/{workflow_id}/execute`
+- Workflow endpoints:
+  - Canonical: `POST /api/v1/workflows/{workflow_id}/execute`, `GET /api/v1/workflows/{workflow_id}/info`
+  - Compatibility aliases: `POST/GET /api/v1/workflows/{workflow_id}`
 - Shared request schema: `EngineInput` (see below)
 - API key is a unique user identity; `birth_data` auto-populates the user profile.
 
@@ -20,6 +22,7 @@ Provide a concrete, OpenClaw-ready integration guide for calling Noesis APIs fro
 3. Use the Noesis base URL and headers in tool calls:
    - Header: `X-API-Key: $NOESIS_API_KEY`
    - Header: `Content-Type: application/json`
+   - Do not send API keys in `Authorization: Bearer`; Bearer is JWT-only.
 4. Use the `EngineInput` JSON body for engines and workflows.
 5. Handle errors using the standard error schema.
 
@@ -28,6 +31,51 @@ Provide a concrete, OpenClaw-ready integration guide for calling Noesis APIs fro
 1. `GET /health/live` returns `{"status":"ok"...}`.
 2. `GET /api/v1/engines` returns 16 engines.
 3. `POST /api/v1/engines/numerology/calculate` succeeds with `engine_id`, `result`, `witness_prompt`.
+
+# Runtime Contract for OpenClaw Agents
+
+- `workflow_id` + `total_time_ms` are stable on successful workflow execution.
+- `engine_outputs` may be partial; missing engines are omitted (not null-filled).
+- To enforce strict completeness:
+  1. call `GET /api/v1/workflows/{workflow_id}/info`
+  2. compare `engine_ids` with `engine_outputs` keys
+  3. run fallback calls for missing engines as needed.
+
+# Bridge Engine Inputs (TS sidecar)
+
+For bridged engines (`tarot`, `i-ching`, `enneagram`, `sacred-geometry`, `sigil-forge`):
+- Pass engine options via `EngineInput.options`.
+- For `sigil-forge`, intention aliases are supported:
+  - `options.question`
+  - `options.intention`
+  - `options.intent`
+  - `options.intent_text`
+
+# Gene Keys Fallback Flow
+
+If `gene-keys` birth-data mode fails in a workflow or direct call:
+
+1. Call Human Design:
+   - `POST /api/v1/engines/human-design/calculate`
+2. Extract gates from response:
+   - `result.personality_activations.sun.gate`
+   - `result.personality_activations.earth.gate`
+   - `result.design_activations.sun.gate`
+   - `result.design_activations.earth.gate`
+3. Retry Gene Keys in `hd_gates` mode:
+
+```json
+{
+  "options": {
+    "hd_gates": {
+      "personality_sun": 41,
+      "personality_earth": 31,
+      "design_sun": 45,
+      "design_earth": 26
+    }
+  }
+}
+```
 
 # EngineInput
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -15,6 +15,7 @@ Not prediction. Reflection. Inquiry. Witness.
 - **Authentication**: [authentication.md](./authentication.md)
 - **LLM and Agent Guide**: [LLM_AGENT_GUIDE.md](./LLM_AGENT_GUIDE.md)
 - **OpenClaw Integration**: [OPENCLAW_INTEGRATION.md](./OPENCLAW_INTEGRATION.md)
+- **MCP Integration**: [MCP_INTEGRATION.md](./MCP_INTEGRATION.md)
 
 ## Base URLs
 
@@ -87,8 +88,15 @@ Notes:
 ### Workflows
 
 - `GET /api/v1/workflows`
+- `GET /api/v1/workflows/{workflow_id}` (compat alias for `.../info`)
+- `POST /api/v1/workflows/{workflow_id}` (compat alias for `.../execute`)
 - `POST /api/v1/workflows/{workflow_id}/execute`
 - `GET /api/v1/workflows/{workflow_id}/info`
+
+Workflow output contract:
+- `workflow_id` and `total_time_ms` are always present on success.
+- `engine_outputs` contains successful engine results only.
+- For strict completeness checks, compare `engine_outputs` keys to `GET /api/v1/workflows/{workflow_id}/info.engine_ids`.
 
 ### User Profile
 

--- a/docs/api/engines.md
+++ b/docs/api/engines.md
@@ -44,6 +44,7 @@ X-API-Key: nk_<api_key>
 
 Notes:
 - `birth_data` is optional, but required for birth-chart engines.
+- `birth_data.name` is required for numerology.
 - `current_time` defaults to now if omitted.
 - `precision` is one of: `Standard`, `High`, `Extreme`.
 - `options` is engine-specific.
@@ -55,16 +56,16 @@ Notes:
 | Engine ID | Name | Required Phase |
 |-----------|------|----------------|
 | human-design | Human Design | 1 |
-| gene-keys | Gene Keys | 1 |
-| vimshottari | Vimshottari Dasha | 1 |
+| gene-keys | Gene Keys | 2 |
+| vimshottari | Vimshottari Dasha | 2 |
 | panchanga | Panchanga | 0 |
 | numerology | Numerology | 0 |
 | biorhythm | Biorhythm | 0 |
 | vedic-clock | Vedic Clock | 0 |
-| biofield | Biofield | 2 |
-| face-reading | Face Reading | 2 |
-| nadabrahman | Nadabrahman | 1 |
-| transits | Transits | 1 |
+| biofield | Biofield | 1 |
+| face-reading | Face Reading | 1 |
+| nadabrahman | Nadabrahman | 0 |
+| transits | Transits | 0 |
 
 ### TypeScript Engines (Bridged)
 
@@ -72,11 +73,17 @@ Notes:
 
 | Engine ID | Name | Required Phase |
 |-----------|------|----------------|
-| tarot | Tarot | 1 |
-| i-ching | I-Ching | 1 |
+| tarot | Tarot | 0 |
+| i-ching | I-Ching | 0 |
 | enneagram | Enneagram | 1 |
-| sacred-geometry | Sacred Geometry | 2 |
-| sigil-forge | Sigil Forge | 2 |
+| sacred-geometry | Sacred Geometry | 0 |
+| sigil-forge | Sigil Forge | 1 |
+
+Sigil Forge compatibility aliases:
+- `options.question`
+- `options.intention`
+- `options.intent`
+- `options.intent_text`
 
 ---
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -234,6 +234,66 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowListResponse"
 
+  /api/v1/workflows/{workflow_id}:
+    get:
+      tags: [workflows]
+      summary: Workflow metadata (compatibility alias)
+      description: Alias of GET /api/v1/workflows/{workflow_id}/info.
+      security:
+        - bearer_auth: []
+        - api_key: []
+      parameters:
+        - name: workflow_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Workflow information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowInfoResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      tags: [workflows]
+      summary: Execute workflow (compatibility alias)
+      description: Alias of POST /api/v1/workflows/{workflow_id}/execute.
+      security:
+        - bearer_auth: []
+        - api_key: []
+      parameters:
+        - name: workflow_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EngineInput"
+      responses:
+        "200":
+          description: Workflow execution successful (engine_outputs may be partial)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "429":
+          $ref: "#/components/responses/RateLimit"
+
   /api/v1/workflows/{workflow_id}/execute:
     post:
       tags: [workflows]
@@ -255,7 +315,7 @@ paths:
               $ref: "#/components/schemas/EngineInput"
       responses:
         "200":
-          description: Workflow execution successful
+          description: Workflow execution successful (engine_outputs may be partial)
           content:
             application/json:
               schema:
@@ -715,6 +775,7 @@ components:
           type: string
         engine_outputs:
           type: object
+          description: Map of successful engine results. Engines that fail or are phase-gated may be omitted.
           additionalProperties:
             $ref: "#/components/schemas/EngineOutput"
         synthesis:

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -9,8 +9,16 @@ For body-paced narrative practice aligned to cycles, see [Somatic Canticles](htt
 ## Base Path
 
 ```
-/api/v1/workflows/{workflow_id}/execute
+/api/v1/workflows/{workflow_id}
 ```
+
+Canonical workflow routes:
+- `POST /api/v1/workflows/{workflow_id}/execute`
+- `GET /api/v1/workflows/{workflow_id}/info`
+
+Compatibility aliases (same handler behavior):
+- `POST /api/v1/workflows/{workflow_id}` → execute
+- `GET /api/v1/workflows/{workflow_id}` → info
 
 ## Authentication
 
@@ -91,6 +99,39 @@ curl -X POST http://localhost:8080/api/v1/workflows/birth-blueprint/execute \
   "synthesis": {"primary_themes": []},
   "total_time_ms": 45.2,
   "timestamp": "2026-02-16T00:00:01Z"
+}
+```
+
+## Workflow Output Semantics
+
+- A successful workflow response can still be partial.
+- `engine_outputs` includes engines that completed successfully.
+- Engines that fail or are phase-gated are omitted from `engine_outputs`.
+- To detect omissions, fetch `GET /api/v1/workflows/{workflow_id}/info` and diff `engine_ids` vs. `engine_outputs` keys.
+- Treat omission as a soft failure and continue with available outputs unless your use case requires strict completeness.
+
+## Fallback Pattern for Agent Callers
+
+If a downstream flow requires Gene Keys but it is absent in a workflow output:
+
+1. Call `POST /api/v1/engines/human-design/calculate` with the same `birth_data`.
+2. Extract:
+   - `result.personality_activations.sun.gate`
+   - `result.personality_activations.earth.gate`
+   - `result.design_activations.sun.gate`
+   - `result.design_activations.earth.gate`
+3. Call `POST /api/v1/engines/gene-keys/calculate` with:
+
+```json
+{
+  "options": {
+    "hd_gates": {
+      "personality_sun": 41,
+      "personality_earth": 31,
+      "design_sun": 45,
+      "design_earth": 26
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
## Why
Production remained stale because CD run `22376262106` failed building the API image on arm64 (`libswisseph-sys` pointer-type mismatch), so deploy never rolled out merged runtime fixes.

## What Changed
- Deploy workflow: API docker build now targets `linux/amd64` only (documented reason in workflow).
- API docs: added workflow compatibility aliases (`GET/POST /api/v1/workflows/{workflow_id}`) alongside canonical routes.
- Standardized workflow output contract for agents: `engine_outputs` may be partial; added strict completeness diff strategy.
- Added deterministic fallback guidance for Gene Keys (`birth_data` -> Human Design gates -> `hd_gates` retry).
- Added Sigil Forge bridge alias guidance (`question`, `intention`, `intent`, `intent_text`).
- Added MCP integration guide and linked it from API docs index.
- Corrected engine required-phase values in `docs/api/engines.md` to runtime-aligned values.

## Verification
- `cargo test -p noesis-api --test integration_tests test_workflow_info_alias_without_info_suffix_success -- --test-threads=1`
- `cargo test -p noesis-api --test integration_tests test_workflow_execute_alias_without_execute_suffix_success -- --test-threads=1`
- `cargo test -p noesis-api --test integration_tests test_gene_keys_directly_from_birth_data -- --test-threads=1`
- `cargo test -p noesis-api --test integration_tests test_calculate_numerology_without_optional_name_returns_validation_error -- --test-threads=1`
- `cargo test -p noesis-bridge bridge_engine_to_ts_request_extracts_question_aliases -- --test-threads=1`
- `cd ts-engines && bun test src/engines/sigil-forge/engine.test.ts`
- `cargo fmt --all -- --check`
- `cd ts-engines && bun run lint`

## Expected Outcome
Once merged, CD should publish/deploy the updated API image successfully, and production will expose both workflow alias routes plus the latest documented fallback contracts for OpenClaw/MCP/bridge callers.
