### PR TITLE
fix(ci): use valid image tag in deploy size check

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -76,8 +76,10 @@ jobs:
       
       - name: Check image size
         run: |
-          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_API }}:${{ github.sha }}
-          SIZE=$(docker image inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_API }}:${{ github.sha }} --format='{{.Size}}')
+          IMAGE_REF=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          echo "Inspecting image: ${IMAGE_REF}"
+          docker pull "${IMAGE_REF}"
+          SIZE=$(docker image inspect "${IMAGE_REF}" --format='{{.Size}}')
           SIZE_MB=$((SIZE / 1024 / 1024))
           echo "Image size: ${SIZE_MB}MB"
           if [ $SIZE_MB -gt 500 ]; then


### PR DESCRIPTION
## Why\nPost-merge CD run 22378210882 failed after successful image build because the `Check image size` step pulled an invalid image reference:\n- mixed-case repo path (`Sheshiyer/...`)\n- full commit SHA tag that is not one of the published metadata tags\n\n## Fix\nUse the first tag emitted by `docker/metadata-action` (`steps.meta.outputs.tags`) as the canonical image ref for pull/inspect.\n\n## Verification\n- Local YAML parse check:\n  - `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy.yaml'); puts 'deploy.yaml parse: ok'"`\n\n## Scope\nOnly updates:\n- `.github/workflows/deploy.yaml`