### PR TITLE
fix(admin-web): route / to /admin/login and improve login misconfig diagnostics

### DIFF
--- a/apps/admin-web/README.md
+++ b/apps/admin-web/README.md
@@ -5,6 +5,7 @@ This app is the Vercel-hosted admin dashboard for Selemene Engine.
 ## Runtime contract
 
 - App base path: `/admin` (configured in `next.config.mjs`)
+- Root `/` is redirected to `/admin/login` via `next.config.mjs` redirects
 - Backend API origin: `NEXT_PUBLIC_API_BASE_URL`
 - Auth flow:
   - Login: `POST /api/v1/auth/login`
@@ -30,6 +31,8 @@ NEXT_PUBLIC_ADMIN_DEV_MODE=false
 ```
 
 `NEXT_PUBLIC_ADMIN_DEV_MODE=true` allows a `basic:access` token to pass UI route guards for local scaffolding only.
+
+If `NEXT_PUBLIC_API_BASE_URL` is missing in a non-local deployment, login/session calls now fail fast with a clear `ADMIN_ENV_MISCONFIG` error instead of silently targeting `http://localhost:8080`.
 
 ## Vercel setup
 

--- a/apps/admin-web/app/(protected)/layout.tsx
+++ b/apps/admin-web/app/(protected)/layout.tsx
@@ -70,9 +70,14 @@ export default function ProtectedLayout({ children }: { children: React.ReactNod
       } catch (err) {
         if (!cancelled) {
           clearAuthToken();
-          if (err instanceof ApiClientError && err.status === 401) {
-            const returnTo = encodeURIComponent(relativePath);
-            router.replace(`/login?redirect=${returnTo}`);
+          if (err instanceof ApiClientError) {
+            if (err.status === 401) {
+              const returnTo = encodeURIComponent(relativePath);
+              router.replace(`/login?redirect=${returnTo}`);
+              return;
+            }
+            setError(err.payload?.error ?? err.message);
+            setLoading(false);
             return;
           }
           setError("Unable to load admin session.");

--- a/apps/admin-web/next.config.mjs
+++ b/apps/admin-web/next.config.mjs
@@ -2,7 +2,17 @@
 const nextConfig = {
   basePath: "/admin",
   output: "standalone",
-  reactStrictMode: true
+  reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "/admin/login",
+        permanent: false,
+        basePath: false
+      }
+    ];
+  }
 };
 
 export default nextConfig;

--- a/apps/admin-web/src/lib/api.ts
+++ b/apps/admin-web/src/lib/api.ts
@@ -21,6 +21,8 @@ import type {
 
 type HttpMethod = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
 
+const LOCALHOST_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0"]);
+
 class ApiClientError extends Error {
   status: number;
   payload?: ApiErrorPayload;
@@ -33,6 +35,50 @@ class ApiClientError extends Error {
   }
 }
 
+function isBrowserRuntime(): boolean {
+  return typeof window !== "undefined";
+}
+
+function isLikelyProductionOrigin(hostname: string): boolean {
+  return !LOCALHOST_HOSTS.has(hostname);
+}
+
+function assertApiBaseUrlRuntimeSafety(baseUrl: string): void {
+  if (!isBrowserRuntime()) {
+    return;
+  }
+
+  try {
+    const resolved = new URL(baseUrl);
+    if (isLikelyProductionOrigin(window.location.hostname) && LOCALHOST_HOSTS.has(resolved.hostname)) {
+      throw new ApiClientError(
+        "Admin dashboard is misconfigured: NEXT_PUBLIC_API_BASE_URL points to localhost.",
+        500,
+        {
+          error: "Admin dashboard is misconfigured: NEXT_PUBLIC_API_BASE_URL points to localhost.",
+          error_code: "ADMIN_ENV_MISCONFIG",
+          details: {
+            configured_api_base_url: baseUrl,
+            current_origin: window.location.origin
+          }
+        }
+      );
+    }
+  } catch {
+    throw new ApiClientError(
+      "Admin dashboard is misconfigured: NEXT_PUBLIC_API_BASE_URL is not a valid URL.",
+      500,
+      {
+        error: "Admin dashboard is misconfigured: NEXT_PUBLIC_API_BASE_URL is not a valid URL.",
+        error_code: "ADMIN_ENV_MISCONFIG",
+        details: {
+          configured_api_base_url: baseUrl
+        }
+      }
+    );
+  }
+}
+
 async function request<T>(
   path: string,
   options: {
@@ -42,17 +88,34 @@ async function request<T>(
   } = {}
 ): Promise<T> {
   const baseUrl = getApiBaseUrl();
+  assertApiBaseUrlRuntimeSafety(baseUrl);
+
   const url = `${baseUrl}${path}`;
 
-  const response = await fetch(url, {
-    method: options.method ?? "GET",
-    headers: {
-      "Content-Type": "application/json",
-      ...(options.token ? { Authorization: `Bearer ${options.token}` } : {})
-    },
-    body: options.body ? JSON.stringify(options.body) : undefined,
-    cache: "no-store"
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: options.method ?? "GET",
+      headers: {
+        "Content-Type": "application/json",
+        ...(options.token ? { Authorization: `Bearer ${options.token}` } : {})
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+      cache: "no-store"
+    });
+  } catch {
+    throw new ApiClientError(
+      "Unable to reach the API service. Check NEXT_PUBLIC_API_BASE_URL and backend CORS settings.",
+      503,
+      {
+        error: "Unable to reach the API service. Check NEXT_PUBLIC_API_BASE_URL and backend CORS settings.",
+        error_code: "API_UNREACHABLE",
+        details: {
+          api_url: url
+        }
+      }
+    );
+  }
 
   const contentType = response.headers.get("content-type");
   const hasJson = contentType?.includes("application/json");


### PR DESCRIPTION
## Summary
- add a Next.js redirect in `apps/admin-web/next.config.mjs` from `/` to `/admin/login` with `basePath: false`
- harden frontend API runtime behavior:
  - fail fast with `ADMIN_ENV_MISCONFIG` if `NEXT_PUBLIC_API_BASE_URL` is invalid or points to localhost on non-local origins
  - fail fast with `API_UNREACHABLE` for fetch/network/CORS failures
- improve protected layout error handling to surface actionable non-401 session errors
- update `apps/admin-web/README.md` with runtime and deployment behavior notes

## Why
This addresses the production troubleshooting loop where:
- users hit root domain and see Vercel/route-level 404 confusion,
- env misconfiguration looked like generic login failure,
- session fetch failures were not explicit enough in UI.

## Verification
Executed locally:
- `npm --prefix apps/admin-web run typecheck`
- `npm --prefix apps/admin-web run lint`
- `npm --prefix apps/admin-web run build`

## Deploy checklist after merge
1. Recreate/import Vercel project from `Sheshiyer/Selemene-engine`
2. Set **Root Directory** to `apps/admin-web`
3. Set env vars:
   - `NEXT_PUBLIC_API_BASE_URL=https://selemene-engine-production.up.railway.app`
   - `NEXT_PUBLIC_ADMIN_DEV_MODE=false`
4. Redeploy and test:
   - `/` redirects to `/admin/login`
   - `/admin/login` loads
   - login/session errors are explicit when env/CORS is wrong
