### PR TITLE
chore(release): align platform versions to 3.0.0 + launch checklists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "engine-biofield"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "engine-biorhythm"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "engine-face-reading"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "engine-gene-keys"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "engine-human-design"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "engine-nadabrahman"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "engine-numerology"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "engine-panchanga"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "engine-transits"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "engine-vedic-clock"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "engine-vimshottari"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-api"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "axum 0.7.9",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-auth"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "argon2",
  "chrono",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-bridge"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-cache"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "dashmap",
  "lru",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-core"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-data"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "chrono",
  "noesis-core",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-integration"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-metrics"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "lazy_static",
  "opentelemetry 0.22.0",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-orchestrator"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-sdk"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "chrono",
  "config",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-tui"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-vedic-api"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-western-api"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "noesis-witness"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "noesis-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 default-members = ["crates/noesis-api"]
 
 [workspace.package]
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 license = "MIT"
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -105,7 +105,7 @@ FROM debian:bookworm-slim AS runtime
 LABEL org.opencontainers.image.title="Selemene Engine" \
       org.opencontainers.image.description="High-performance astronomical calculation engine for Vedic astrology" \
       org.opencontainers.image.vendor="WitnessOS" \
-      org.opencontainers.image.version="0.1.0"
+      org.opencontainers.image.version="3.0.0"
 
 WORKDIR /app
 

--- a/apps/admin-web/package-lock.json
+++ b/apps/admin-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin-web",
-  "version": "0.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-web",
-      "version": "0.1.0",
+      "version": "3.0.0",
       "dependencies": {
         "next": "16.1.6",
         "react": "18.3.1",

--- a/apps/admin-web/package.json
+++ b/apps/admin-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-web",
-  "version": "0.1.0",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/bridges/cli/package.json
+++ b/bridges/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selemene/bridge",
-  "version": "0.1.0",
+  "version": "3.0.0",
   "description": "CLI tool for setting up Selemene Engine agent bridges — Claude, OpenAI, LangChain",
   "type": "module",
   "bin": {

--- a/bridges/cli/src/cli.ts
+++ b/bridges/cli/src/cli.ts
@@ -12,7 +12,7 @@ program
   .description(
     "CLI tool for setting up Selemene Engine agent bridges — Claude, OpenAI, LangChain"
   )
-  .version("0.1.0");
+  .version("3.0.0");
 
 program
   .command("init")

--- a/crates/engine-biofield/Cargo.toml
+++ b/crates/engine-biofield/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-biofield"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Biofield consciousness engine — biometric analysis compute core (stub with mock data)"
 

--- a/crates/engine-biorhythm/Cargo.toml
+++ b/crates/engine-biorhythm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-biorhythm"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Biorhythm consciousness engine — physical, emotional, intellectual cycles"
 

--- a/crates/engine-face-reading/Cargo.toml
+++ b/crates/engine-face-reading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-face-reading"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Face Reading consciousness engine — Five Elements constitution analysis"
 

--- a/crates/engine-gene-keys/Cargo.toml
+++ b/crates/engine-gene-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-gene-keys"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Gene Keys consciousness engine — Shadow-Gift-Siddhi transformation sequences"
 

--- a/crates/engine-human-design/Cargo.toml
+++ b/crates/engine-human-design/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-human-design"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Human Design consciousness engine — 88° solar arc, gates, channels, centers"
 

--- a/crates/engine-nadabrahman/Cargo.toml
+++ b/crates/engine-nadabrahman/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-nadabrahman"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "NadaBrahman consciousness engine — raga/sound therapy compute core"
 

--- a/crates/engine-numerology/Cargo.toml
+++ b/crates/engine-numerology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-numerology"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Numerology consciousness engine — Pythagorean + Chaldean systems"
 

--- a/crates/engine-panchanga/Cargo.toml
+++ b/crates/engine-panchanga/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-panchanga"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Panchanga (Vedic almanac) consciousness engine — Tithi, Nakshatra, Yoga, Karana, Vara"
 

--- a/crates/engine-transits/Cargo.toml
+++ b/crates/engine-transits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-transits"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Transit analysis consciousness engine — planetary transits, natal aspects, Sade Sati"
 

--- a/crates/engine-vedic-clock/Cargo.toml
+++ b/crates/engine-vedic-clock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-vedic-clock"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "VedicClock-TCM consciousness engine — organ clock + Vedic time integration"
 

--- a/crates/engine-vimshottari/Cargo.toml
+++ b/crates/engine-vimshottari/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-vimshottari"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Vimshottari Dasha consciousness engine — 120-year planetary period timeline"
 

--- a/crates/noesis-api/Cargo.toml
+++ b/crates/noesis-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-api"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "HTTP API server for the Tryambakam Noesis platform"
 

--- a/crates/noesis-api/src/lib.rs
+++ b/crates/noesis-api/src/lib.rs
@@ -171,7 +171,7 @@ use utoipa_swagger_ui::SwaggerUi;
     modifiers(&SecurityAddon),
     info(
         title = "Noesis API",
-        version = "0.1.0",
+        version = "3.0.0",
         description = "HTTP API for the Tryambakam Noesis consciousness engine platform. Provides endpoints for astrological calculations (Panchanga), numerology, biorhythms, and multi-engine workflows.",
         contact(
             name = "Tryambakam Team",
@@ -532,7 +532,7 @@ async fn health_handler(State(state): State<AppState>) -> Json<HealthResponse> {
 
     Json(HealthResponse {
         status: "ok".to_string(),
-        version: "0.1.0".to_string(),
+        version: "3.0.0".to_string(),
         uptime_seconds: uptime,
         engines_loaded,
         workflows_loaded,

--- a/crates/noesis-api/tests/integration_tests.rs
+++ b/crates/noesis-api/tests/integration_tests.rs
@@ -142,7 +142,7 @@ async fn test_health_check_no_auth_required() {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["status"], "ok");
-    assert_eq!(body["version"], "0.1.0");
+    assert_eq!(body["version"], "3.0.0");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/noesis-auth/Cargo.toml
+++ b/crates/noesis-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-auth"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Authentication and authorization (JWT + API keys) for Noesis platform"
 

--- a/crates/noesis-bridge/Cargo.toml
+++ b/crates/noesis-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-bridge"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "HTTP bridge adapter for TypeScript consciousness engines"
 

--- a/crates/noesis-cache/Cargo.toml
+++ b/crates/noesis-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-cache"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Multi-layer caching system (L1 in-memory, L2 Redis, L3 disk) for Noesis engines"
 

--- a/crates/noesis-core/Cargo.toml
+++ b/crates/noesis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-core"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Core traits and types for the Tryambakam Noesis consciousness engine platform"
 

--- a/crates/noesis-data/Cargo.toml
+++ b/crates/noesis-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-data"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Database layer for User Management and other persistent data"
 

--- a/crates/noesis-integration/Cargo.toml
+++ b/crates/noesis-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-integration"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["Tryambakam Noesis Team"]
 description = "Integration layer for Vedic API, Vimshottari, Numerology, and TCM systems"

--- a/crates/noesis-metrics/Cargo.toml
+++ b/crates/noesis-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-metrics"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Prometheus metrics collection and OpenTelemetry tracing for Noesis platform"
 

--- a/crates/noesis-orchestrator/Cargo.toml
+++ b/crates/noesis-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-orchestrator"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Workflow orchestrator for parallel multi-engine execution"
 

--- a/crates/noesis-sdk/src/render.rs
+++ b/crates/noesis-sdk/src/render.rs
@@ -443,7 +443,7 @@ mod tests {
                 precision_achieved: "Standard".into(),
                 cached: false,
                 timestamp: Utc::now(),
-                engine_version: "0.1.0".into(),
+                engine_version: "3.0.0".into(),
             },
         }
     }

--- a/crates/noesis-vedic-api/Cargo.toml
+++ b/crates/noesis-vedic-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-vedic-api"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["Tryambakam Noesis Team"]
 description = "FreeAstrologyAPI.com integration for Vedic astrology calculations"

--- a/crates/noesis-western-api/Cargo.toml
+++ b/crates/noesis-western-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-western-api"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["Tryambakam Noesis Team"]
 description = "FreeAstrologyAPI.com integration for Western astrology calculations"

--- a/crates/noesis-witness/Cargo.toml
+++ b/crates/noesis-witness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noesis-witness"
-version = "0.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Witness Agent prompt injection for self-consciousness development"
 

--- a/docs/API_QUICKSTART.md
+++ b/docs/API_QUICKSTART.md
@@ -40,7 +40,7 @@ curl -s https://selemene.tryambakam.space/health/live | python3 -m json.tool
 ```json
 {
     "status": "ok",
-    "version": "0.1.0",
+    "version": "3.0.0",
     "engines_loaded": 16,
     "workflows_loaded": 6
 }

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -330,7 +330,7 @@ All engines return this unified structure:
   "metadata": {
     "calculation_time_ms": 0.042,
     "backend": "native",
-    "version": "0.1.0"
+    "version": "3.0.0"
   }
 }
 ```

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Noesis API
-  version: 0.1.0
+  version: 3.0.0
   description: |
     High-performance consciousness calculation platform with 16 engines and multi-engine workflows.
 

--- a/docs/launch/v3.0.0-launch-day-runbook.md
+++ b/docs/launch/v3.0.0-launch-day-runbook.md
@@ -1,0 +1,166 @@
+# v3.0.0 Launch Day Runbook
+
+Status: Ready for dry-run + sign-off  
+Owner: SRE (with Engineering + Product support)
+
+---
+
+## 1) Roles and Contacts
+
+- **Launch Commander (SRE):** drives timeline and go/no-go calls.
+- **Engineering On-Call:** handles API/runtime incidents.
+- **Product Lead:** validates UX/workflow acceptance and customer comms.
+
+> Replace with real contacts before launch:
+- Launch Commander: `<name> / <phone> / <slack>`
+- Engineering On-Call: `<name> / <phone> / <slack>`
+- Product Lead: `<name> / <phone> / <slack>`
+
+---
+
+## 2) Pre-Launch Gate (T-30m)
+
+All must be ✅ before proceeding:
+
+- [ ] GitHub `main` is green (CI passing).
+- [ ] Railway production service healthy (`/health/live` = 200).
+- [ ] Admin protected routes exist (`/api/v1/admin/*` returns 401 unauthenticated, not 404).
+- [ ] No active Sev-1/Sev-2 incidents.
+- [ ] Rollback operator is assigned and online.
+
+### Commands
+
+```bash
+# API live check
+curl -sS -o /dev/null -w "%{http_code}\n" https://selemene-engine-production.up.railway.app/health/live
+
+# Admin endpoint existence checks (auth-protected)
+for p in \
+  /api/v1/admin/session \
+  /api/v1/admin/api-keys \
+  /api/v1/admin/system/health \
+  /api/v1/admin/audit-events; do
+  code=$(curl -sS -o /dev/null -w "%{http_code}" "https://selemene-engine-production.up.railway.app$p")
+  echo "$p -> $code"
+done
+```
+
+---
+
+## 3) Launch Sequence (T0)
+
+### Step 1 — Release tag
+
+```bash
+git checkout main
+git pull origin main
+git tag -a v3.0.0 -m "v3.0.0"
+git push origin v3.0.0
+```
+
+Expected: release workflow triggers and GitHub Release is generated.
+
+### Step 2 — Registry publish checks
+
+- [ ] `noesis-core` 3.0.0 visible on crates.io
+- [ ] `noesis-sdk` 3.0.0 visible on crates.io
+- [ ] `@selemene/sdk` 3.0.0 visible on npm
+
+### Step 3 — Deploy surfaces
+
+- [ ] Railway production running release image/version.
+- [ ] Marketing site deployed on Vercel.
+- [ ] Developer docs portal deployed on Vercel.
+
+### Step 4 — Cache/CDN priming
+
+Run key route warm-up after deploy:
+
+```bash
+curl -sS https://selemene-engine-production.up.railway.app/health/live >/dev/null
+curl -sS https://144.tryambakam.space/admin/login >/dev/null
+```
+
+### Step 5 — Post-launch smoke
+
+```bash
+ADMIN_WEB_URL="https://144.tryambakam.space" \
+API_BASE_URL="https://selemene-engine-production.up.railway.app" \
+bash scripts/smoke_admin_web.sh
+```
+
+---
+
+## 4) Monitoring During Launch (T0 to T+60m)
+
+Use these views:
+- Railway deploy + runtime logs
+- Vercel deployment status (marketing/docs/admin)
+- API health endpoint checks every 5 minutes
+
+Suggested watch metrics:
+- Request success rate
+- p95 latency
+- 5xx spikes
+- auth failures rate
+
+Escalate immediately if:
+- `/health/live` != 200 for >2 minutes
+- error rate > 1% sustained for >5 minutes
+- login/session flows regress on admin portal
+
+---
+
+## 5) Fast Rollback Procedure (Target < 5 minutes)
+
+### Trigger conditions
+- sustained Sev-1 incident post-release
+- broken auth/session flow in production
+- critical endpoint failure with no hotfix in <10 min
+
+### Rollback steps
+
+1. **Railway rollback to previous good deploy**
+   - Open Railway service -> Deployments -> Rollback previous successful deploy.
+2. **Confirm API health**
+   - `GET /health/live` returns 200.
+3. **Validate admin protected endpoints exist (401 expected)**
+4. **If schema change involved, run DB migration revert per migration authority**
+   - Follow: `docs/deployment/DB_MIGRATION_AUTHORITY.md`
+5. **Broadcast rollback complete in incident channel**
+
+### Rollback verification commands
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" https://selemene-engine-production.up.railway.app/health/live
+curl -sS -o /dev/null -w "%{http_code}\n" https://selemene-engine-production.up.railway.app/api/v1/admin/session
+```
+
+### Rollback timing capture
+
+- Rollback start time: `____`
+- Rollback complete time: `____`
+- Total duration: `____` (must be < 5 minutes)
+
+---
+
+## 6) Post-Launch Verification Checklist
+
+- [ ] `/health/live` returns version `v3.0.0` payload.
+- [ ] Core API smoke test passes.
+- [ ] Admin login + session + audit/system pages load correctly.
+- [ ] SDK install smoke tests succeed:
+  - [ ] `cargo add noesis-sdk@3.0.0`
+  - [ ] `npm i @selemene/sdk@3.0.0`
+- [ ] Changelog and release notes published.
+
+---
+
+## 7) Launch Log (Fill During Event)
+
+- T-30 gate complete: `____`
+- Tag pushed: `____`
+- Registry publish complete: `____`
+- Deploy complete: `____`
+- Smoke pass: `____`
+- Final go-live announcement: `____`

--- a/docs/launch/v3.0.0-launch-gate-checklist.md
+++ b/docs/launch/v3.0.0-launch-gate-checklist.md
@@ -1,0 +1,116 @@
+# v3.0.0 Launch Gate Checklist
+
+Status: Draft for sign-off  
+Issue Mapping: #478
+
+---
+
+## Evidence Rules
+
+For every gate item, attach:
+1. **timestamp**
+2. **operator**
+3. **evidence URL or command output snippet**
+
+---
+
+## A) Functional Coverage
+
+### 1) All 16 engines validated
+- [ ] Completed
+- Evidence:
+  - Timestamp: `____`
+  - Operator: `____`
+  - Link/output: `____`
+
+### 2) All 6 workflows tested
+- [ ] Completed
+- Evidence:
+  - Timestamp: `____`
+  - Operator: `____`
+  - Link/output: `____`
+
+---
+
+## B) Security + Reliability
+
+### 3) Security audit findings resolved
+- [ ] Completed
+- Evidence:
+  - Timestamp: `____`
+  - Operator: `____`
+  - Link/output: `____`
+
+### 4) Load test passed
+- [ ] Completed
+- Evidence:
+  - Timestamp: `____`
+  - Operator: `____`
+  - Link/output: `____`
+
+### 5) Runbook reviewed
+- [ ] Completed
+- Evidence:
+  - Runbook: `docs/launch/v3.0.0-launch-day-runbook.md`
+  - Timestamp: `____`
+  - Reviewer(s): `____`
+
+---
+
+## C) Release Assets + Public Surfaces
+
+### 6) SDKs published
+- [ ] `noesis-core@3.0.0` on crates.io
+- [ ] `noesis-sdk@3.0.0` on crates.io
+- [ ] `@selemene/sdk@3.0.0` on npm
+- Evidence:
+  - Timestamp: `____`
+  - Operator: `____`
+  - Links: `____`
+
+### 7) Documentation live
+- [ ] Completed
+- Evidence:
+  - Timestamp: `____`
+  - Operator: `____`
+  - URL(s): `____`
+
+### 8) Changelog published
+- [ ] Completed
+- Evidence:
+  - Timestamp: `____`
+  - Operator: `____`
+  - URL: `____`
+
+### 9) Marketing site live
+- [ ] Completed
+- Evidence:
+  - Timestamp: `____`
+  - Operator: `____`
+  - URL: `____`
+
+---
+
+## D) Final Launch Gate Decision
+
+### Product Sign-off
+- Name: `____`
+- Decision: `GO / NO-GO`
+- Timestamp: `____`
+
+### Engineering Sign-off
+- Name: `____`
+- Decision: `GO / NO-GO`
+- Timestamp: `____`
+
+### SRE Sign-off
+- Name: `____`
+- Decision: `GO / NO-GO`
+- Timestamp: `____`
+
+---
+
+## Notes
+
+- A missing evidence link counts as **not complete**.
+- If any sign-off is NO-GO, launch is blocked until remediation is tracked.

--- a/docs/launch/v3.0.0-release-execution-checklist.md
+++ b/docs/launch/v3.0.0-release-execution-checklist.md
@@ -1,0 +1,121 @@
+# v3.0.0 Release Execution Checklist
+
+Status: Execution-ready draft  
+Issue Mapping: #479
+
+---
+
+## 0) Preconditions
+
+- [ ] `main` is up-to-date and green.
+- [ ] Release notes are finalized (`CHANGELOG.md` + release summary).
+- [ ] Operator has publish permissions (GitHub, crates.io, npm, Railway, Vercel).
+
+---
+
+## 1) Create and Push Tag
+
+```bash
+git checkout main
+git pull origin main
+git tag -a v3.0.0 -m "v3.0.0"
+git push origin v3.0.0
+```
+
+- [ ] Tag exists on origin.
+- [ ] GitHub release workflow started (`.github/workflows/release.yml`).
+
+Rollback: delete tag if immediately aborting before publish
+```bash
+git push --delete origin v3.0.0
+git tag -d v3.0.0
+```
+
+---
+
+## 2) Publish Rust SDKs / crates
+
+- [ ] `noesis-core` published as `3.0.0`
+- [ ] `noesis-sdk` published as `3.0.0`
+- [ ] crates.io pages confirmed
+
+Validation commands:
+```bash
+cargo search noesis-core | head -n 1
+cargo search noesis-sdk | head -n 1
+```
+
+Rollback: crates are immutable; if bad publish, ship `3.0.1` hotfix and update release notes.
+
+---
+
+## 3) Publish NPM SDK
+
+- [ ] `@selemene/sdk` published as `3.0.0`
+- [ ] npm registry page confirms version
+
+Validation command:
+```bash
+npm view @selemene/sdk version
+```
+
+Rollback: deprecate bad package version and publish patch.
+
+---
+
+## 4) Deploy Production Runtime
+
+- [ ] Railway deployment completed successfully.
+- [ ] Docker image for `v3.0.0` available.
+
+Validation:
+```bash
+curl -sS https://selemene-engine-production.up.railway.app/health/live
+```
+
+Expected: payload reports version `v3.0.0`.
+
+Rollback: Railway rollback to previous successful deployment.
+
+---
+
+## 5) Deploy Public Surfaces
+
+- [ ] Marketing site deployed on Vercel production.
+- [ ] Developer portal/docs deployed on Vercel production.
+
+Validation:
+- [ ] marketing URL returns 200
+- [ ] docs URL returns 200
+
+Rollback: Vercel redeploy previous production build.
+
+---
+
+## 6) Post-Deploy Smoke Suite
+
+```bash
+ADMIN_WEB_URL="https://144.tryambakam.space" \
+API_BASE_URL="https://selemene-engine-production.up.railway.app" \
+bash scripts/smoke_admin_web.sh
+```
+
+Additional checks:
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" https://selemene-engine-production.up.railway.app/api/v1/admin/system/health
+curl -sS -o /dev/null -w "%{http_code}\n" https://selemene-engine-production.up.railway.app/api/v1/admin/audit-events
+```
+
+Expected: protected endpoints return `401` unauthenticated (route exists).
+
+---
+
+## 7) Launch Evidence Log
+
+- Tag pushed at: `____`
+- crates publish complete at: `____`
+- npm publish complete at: `____`
+- Railway deploy complete at: `____`
+- Vercel deploys complete at: `____`
+- Smoke checks passed at: `____`
+- Final launch announcement at: `____`

--- a/python-services/biofield_cv_service/health.py
+++ b/python-services/biofield_cv_service/health.py
@@ -28,7 +28,7 @@ def health() -> dict:
     resp = HealthResponse(
         status="healthy",
         service="biofield-cv",
-        version="0.1.0",
+        version="3.0.0",
     )
     return {
         **resp.model_dump(),

--- a/python-services/biofield_cv_service/main.py
+++ b/python-services/biofield_cv_service/main.py
@@ -13,7 +13,7 @@ from biofield_cv_service.analyze import router as analyze_router
 
 app = FastAPI(
     title="Selemene Biofield CV Service",
-    version="0.1.0",
+    version="3.0.0",
     description="Python sidecar service for biofield image analysis using OpenCV.",
 )
 

--- a/python-services/mediapipe_service/health.py
+++ b/python-services/mediapipe_service/health.py
@@ -20,7 +20,7 @@ def health() -> dict:
     resp = HealthResponse(
         status="healthy",
         service="mediapipe-face-mesh",
-        version="0.1.0",
+        version="3.0.0",
     )
     return {
         **resp.model_dump(),

--- a/python-services/mediapipe_service/main.py
+++ b/python-services/mediapipe_service/main.py
@@ -12,7 +12,7 @@ from mediapipe_service.analyze import router as analyze_router
 
 app = FastAPI(
     title="Selemene MediaPipe Face Mesh Service",
-    version="0.1.0",
+    version="3.0.0",
     description="Python sidecar service for MediaPipe Face Mesh landmark detection.",
 )
 

--- a/python-services/openapi/biofield-cv-service.yaml
+++ b/python-services/openapi/biofield-cv-service.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   title: "Selemene Biofield CV Service"
-  version: "0.1.0"
+  version: "3.0.0"
   description: "Python sidecar service for biofield image analysis using OpenCV. Implements spatial algorithms from biofield_spatial_algorithms.json."
 
 servers:
@@ -65,7 +65,7 @@ components:
       properties:
         status: { type: string, enum: [healthy, degraded] }
         service: { type: string, example: "biofield-cv" }
-        version: { type: string, example: "0.1.0" }
+        version: { type: string, example: "3.0.0" }
         opencv_available: { type: boolean }
         numpy_available: { type: boolean }
 

--- a/python-services/openapi/mediapipe-service.yaml
+++ b/python-services/openapi/mediapipe-service.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   title: "Selemene MediaPipe Face Mesh Service"
-  version: "0.1.0"
+  version: "3.0.0"
   description: "Python sidecar service for MediaPipe Face Mesh landmark detection. Called by the Rust face-reading engine via HTTP."
 
 servers:
@@ -62,7 +62,7 @@ components:
       properties:
         status: { type: string, enum: [healthy, degraded] }
         service: { type: string, example: "mediapipe-face-mesh" }
-        version: { type: string, example: "0.1.0" }
+        version: { type: string, example: "3.0.0" }
         mediapipe_available: { type: boolean }
 
     FaceMeshResponse:

--- a/python-services/pyproject.toml
+++ b/python-services/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "selemene-python-services"
-version = "0.1.0"
+version = "3.0.0"
 description = "Python sidecar services for Selemene Engine (MediaPipe + Biofield CV)"
 requires-python = ">=3.11"
 dependencies = [

--- a/python-services/shared/models.py
+++ b/python-services/shared/models.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 class HealthResponse(BaseModel):
     status: str = "healthy"
     service: str
-    version: str = "0.1.0"
+    version: str = "3.0.0"
 
 
 # ---------- MediaPipe service models ----------

--- a/python-services/tests/test_biofield_health.py
+++ b/python-services/tests/test_biofield_health.py
@@ -21,7 +21,7 @@ def test_health_returns_correct_service_name() -> None:
 def test_health_returns_version() -> None:
     response = client.get("/health")
     data = response.json()
-    assert data["version"] == "0.1.0"
+    assert data["version"] == "3.0.0"
 
 
 def test_health_includes_opencv_availability() -> None:

--- a/python-services/tests/test_mediapipe_health.py
+++ b/python-services/tests/test_mediapipe_health.py
@@ -21,7 +21,7 @@ def test_health_returns_correct_service_name() -> None:
 def test_health_returns_version() -> None:
     response = client.get("/health")
     data = response.json()
-    assert data["version"] == "0.1.0"
+    assert data["version"] == "3.0.0"
 
 
 def test_health_includes_mediapipe_availability() -> None:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -285,3 +285,70 @@
 - Issue lifecycle updates:
   - Closed as completed: `#482`, `#483`, `#484`, `#485`.
   - Kept umbrella `#486` open pending merge/deploy confirmation.
+
+---
+
+# Task Plan — v3.0.0 Launch Polish + Issue Status Alignment
+
+## Checklist
+- [x] Re-verify production admin endpoint availability for system/audit routes.
+- [x] Draft launch-day operational runbook with step-by-step commands and rollback drill.
+- [x] Draft launch-gate checklist with evidence placeholders + sign-off section.
+- [x] Draft final release execution checklist (tag, registries, deploy, smoke).
+- [x] Update launch issues `#486`, `#477`, `#478`, `#479` with evidence-backed status comments.
+- [x] Close fully completed issue(s) and leave precise remaining actions on open issues.
+
+## Notes
+- Scope limited to launch polish/docs + GitHub issue hygiene for the v3.0.0 launch track.
+- Do not force-close issues lacking objective evidence for acceptance criteria.
+
+## Review (fill after execution)
+- Production re-verification completed:
+  - `https://selemene-engine-production.up.railway.app/health/live` -> `200`
+  - `https://selemene-engine-production.up.railway.app/api/v1/admin/session` -> `401`
+  - `https://selemene-engine-production.up.railway.app/api/v1/admin/api-keys` -> `401`
+  - `https://selemene-engine-production.up.railway.app/api/v1/admin/system/*` -> `401` (not `404`)
+  - `https://selemene-engine-production.up.railway.app/api/v1/admin/audit-events*` -> `401` (not `404`)
+  - Admin web smoke script passed against production URLs.
+- Added launch polish docs:
+  - `docs/launch/v3.0.0-launch-day-runbook.md`
+  - `docs/launch/v3.0.0-launch-gate-checklist.md`
+  - `docs/launch/v3.0.0-release-execution-checklist.md`
+- Updated GitHub issues with status comments:
+  - `#477` runbook readiness + remaining close conditions
+  - `#478` launch gate evidence/sign-off status
+  - `#479` release execution sequencing + remaining evidence
+- Closed completed issue:
+  - `#486` (admin production blocker resolved)
+- Release preflight blockers documented on launch issues:
+  - Production `/health/live` currently returns `version: 0.1.0` (not `3.0.0`)
+  - Highest git tag present is `v2.4.0` (no `v3.0.0` tag yet)
+  - Launch gate evidence/sign-off remains incomplete for `#478`
+
+---
+
+# Task Plan — v3.0.0 Version Alignment Pass
+
+## Checklist
+- [x] Align Rust workspace + crate package versions from `0.1.0` to `3.0.0`.
+- [x] Align API-reported runtime/openapi version strings to `3.0.0`.
+- [x] Align JS package metadata versions (`apps/admin-web`, `bridges/cli`) to `3.0.0`.
+- [x] Align Python service versions and health/openapi test expectations to `3.0.0`.
+- [x] Run targeted verification across Rust, Python, and admin-web typecheck.
+
+## Notes
+- Scope is version consistency only; no release tag/publish/deploy executed in this pass.
+- `@selemene/sdk` package artifact is still not present in-repo and remains a separate release-track item.
+
+## Review (fill after execution)
+- Updated version metadata to `3.0.0` across:
+  - `Cargo.toml` workspace and all crate package manifests
+  - `crates/noesis-api` OpenAPI info + health endpoint version value
+  - `apps/admin-web/package.json` + lockfile top-level package version
+  - `bridges/cli/package.json` + CLI self-reported version
+  - `python-services` pyproject + service health/openapi/test version values
+  - `Dockerfile.prod` OCI image version label
+- Verification:
+  - `cargo check -p noesis-api` ✅
+  - `pytest -q tests/test_biofield_health.py tests/test_mediapipe_health.py` ✅
+  - `npm run typecheck` (apps/admin-web) ✅


### PR DESCRIPTION
## Summary
This PR performs the v3.0.0 version-alignment pass needed before final tagging/publishing.

### Included changes
- Bumps Rust workspace/crate versions to `3.0.0`
- Aligns API-exposed version strings to `3.0.0`:
  - OpenAPI info version
  - `/health` response version
- Aligns JS package metadata to `3.0.0`:
  - `apps/admin-web`
  - `bridges/cli`
- Aligns Python service version/health/openapi values and tests to `3.0.0`
- Updates Docker OCI image version label to `3.0.0`
- Adds launch operations docs:
  - `docs/launch/v3.0.0-launch-day-runbook.md`
  - `docs/launch/v3.0.0-launch-gate-checklist.md`
  - `docs/launch/v3.0.0-release-execution-checklist.md`

## Validation
- `cargo check -p noesis-api`
- `pytest -q tests/test_biofield_health.py tests/test_mediapipe_health.py`
- `npm run typecheck` (in `apps/admin-web`)

## Launch issue linkage
- Progress toward #479
- Supports evidence prep for #478 / #477