### PR TITLE
chore(release): add registry publish runbook + scaffold @selemene/sdk target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ default-members = ["crates/noesis-api"]
 version = "3.0.0"
 edition = "2021"
 license = "MIT"
+repository = "https://github.com/Sheshiyer/Selemene-engine"
+homepage = "https://selemene.tryambakam.space"
 
 [workspace.dependencies]
 # Async runtime

--- a/crates/noesis-core/Cargo.toml
+++ b/crates/noesis-core/Cargo.toml
@@ -2,7 +2,13 @@
 name = "noesis-core"
 version = "3.0.0"
 edition = "2021"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "Core traits and types for the Tryambakam Noesis consciousness engine platform"
+readme = "README.md"
+keywords = ["selemene", "sdk", "astrology", "workflow", "consciousness"]
+categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/noesis-core/README.md
+++ b/crates/noesis-core/README.md
@@ -1,0 +1,14 @@
+# noesis-core
+
+Core traits and shared data types for the Selemene Engine platform.
+
+## What this crate contains
+- engine input/output contracts
+- workflow and report structures
+- common domain models used by API, SDK, and engine crates
+
+## Install
+
+```bash
+cargo add noesis-core
+```

--- a/crates/noesis-sdk/Cargo.toml
+++ b/crates/noesis-sdk/Cargo.toml
@@ -3,7 +3,12 @@ name = "noesis-sdk"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "Rust SDK for Selemene Engine — typed API client, profile management, credential storage, and report rendering"
+readme = "README.md"
+keywords = ["selemene", "sdk", "astrology", "api-client", "consciousness"]
+categories = ["api-bindings", "asynchronous"]
 
 [features]
 default = ["keychain"]
@@ -11,7 +16,7 @@ keychain = ["keyring"]
 
 [dependencies]
 # Core types from noesis-core
-noesis-core = { path = "../noesis-core" }
+noesis-core = { version = "3.0.0", path = "../noesis-core" }
 
 # Async runtime
 tokio = { workspace = true }

--- a/crates/noesis-sdk/README.md
+++ b/crates/noesis-sdk/README.md
@@ -1,0 +1,27 @@
+# noesis-sdk
+
+Rust SDK for Selemene Engine.
+
+## Features
+- typed client for engine and workflow APIs
+- profile/config helpers
+- optional keychain-backed credential storage
+- report rendering helpers
+
+## Install
+
+```bash
+cargo add noesis-sdk
+```
+
+## Usage
+
+```rust
+use noesis_sdk::NoesisClient;
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let client = NoesisClient::new("https://selemene-engine-production.up.railway.app")?;
+let _health = client.health().await?;
+# Ok(())
+# }
+```

--- a/docs/launch/v3.0.0-registry-publish-commands.md
+++ b/docs/launch/v3.0.0-registry-publish-commands.md
@@ -1,0 +1,100 @@
+# v3.0.0 Registry Publish Commands (Exact Order)
+
+## 0) Preconditions
+
+- local checkout clean and on latest `main`
+- crates.io token set (`CRATES_IO_TOKEN`)
+- npm auth valid (`npm whoami` succeeds)
+
+```bash
+git fetch origin --tags
+git checkout main
+git pull --ff-only origin main
+git status --short
+```
+
+---
+
+## 1) crates.io publish (must be in this order)
+
+`noesis-sdk` depends on `noesis-core`, so publish core first.
+
+### 1.1 login and core dry-run
+
+```bash
+cargo login "$CRATES_IO_TOKEN"
+
+cargo publish --dry-run -p noesis-core
+```
+
+### 1.2 publish `noesis-core`
+
+```bash
+cargo publish -p noesis-core
+```
+
+### 1.3 wait until crates.io index sees `noesis-core@3.0.0`
+
+```bash
+for i in $(seq 1 30); do
+  body=$(curl -sS https://crates.io/api/v1/crates/noesis-core)
+  ver=$(echo "$body" | sed -n 's/.*"newest_version":"\([^"]*\)".*/\1/p')
+  echo "attempt $i: noesis-core=$ver"
+  [ "$ver" = "3.0.0" ] && break
+  sleep 10
+done
+```
+
+### 1.4 dry-run + publish `noesis-sdk`
+
+```bash
+cargo publish --dry-run -p noesis-sdk
+cargo publish -p noesis-sdk
+```
+
+### 1.5 verify both crates
+
+```bash
+curl -sS https://crates.io/api/v1/crates/noesis-core | jq -r '.crate.newest_version'
+curl -sS https://crates.io/api/v1/crates/noesis-sdk | jq -r '.crate.newest_version'
+```
+
+---
+
+## 2) npm publish (`@selemene/sdk`)
+
+Package target location:
+- `packages/noesis-sdk-ts`
+
+### 2.1 login + build
+
+```bash
+npm whoami
+npm --prefix packages/noesis-sdk-ts install
+npm --prefix packages/noesis-sdk-ts run build
+```
+
+### 2.2 publish scoped package
+
+```bash
+npm publish --access public ./packages/noesis-sdk-ts
+```
+
+### 2.3 verify npm version
+
+```bash
+npm view @selemene/sdk version
+```
+
+---
+
+## 3) Evidence to attach in issue #479
+
+- crates links:
+  - https://crates.io/crates/noesis-core
+  - https://crates.io/crates/noesis-sdk
+- npm link:
+  - https://www.npmjs.com/package/@selemene/sdk
+- command outputs:
+  - `npm view @selemene/sdk version`
+  - `/health/live` response showing `3.0.0`

--- a/packages/noesis-sdk-ts/README.md
+++ b/packages/noesis-sdk-ts/README.md
@@ -1,0 +1,26 @@
+# @selemene/sdk
+
+TypeScript SDK for Selemene Engine.
+
+## Install
+
+```bash
+npm i @selemene/sdk
+```
+
+## Quickstart
+
+```ts
+import { NoesisClient } from "@selemene/sdk";
+
+const client = new NoesisClient("https://selemene-engine-production.up.railway.app");
+
+const health = await client.health();
+console.log(health.version);
+```
+
+## API
+
+- `health()`
+- `calculate(engineId, input)`
+- `workflow(workflowId, input)`

--- a/packages/noesis-sdk-ts/package-lock.json
+++ b/packages/noesis-sdk-ts/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "@selemene/sdk",
+  "version": "3.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@selemene/sdk",
+      "version": "3.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/packages/noesis-sdk-ts/package.json
+++ b/packages/noesis-sdk-ts/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@selemene/sdk",
+  "version": "3.0.0",
+  "description": "TypeScript SDK for Selemene Engine",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "selemene",
+    "sdk",
+    "typescript",
+    "astrology",
+    "api"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Sheshiyer/Selemene-engine.git"
+  },
+  "homepage": "https://selemene.tryambakam.space",
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/noesis-sdk-ts/src/index.ts
+++ b/packages/noesis-sdk-ts/src/index.ts
@@ -1,0 +1,95 @@
+export interface BirthData {
+  date: string;
+  time: string;
+  latitude: number;
+  longitude: number;
+  timezone: string;
+}
+
+export interface EngineInput {
+  birth_data: BirthData;
+  [key: string]: unknown;
+}
+
+export interface EngineOutput {
+  engine_id: string;
+  result: Record<string, unknown>;
+  witness_prompts?: string[];
+}
+
+export interface WorkflowResult {
+  workflow_id: string;
+  engine_results: EngineOutput[];
+  synthesis?: string;
+}
+
+export interface HealthResponse {
+  status: string;
+  version: string;
+  uptime_seconds: number;
+  engines_loaded: number;
+  workflows_loaded: number;
+}
+
+export class SelemeneError extends Error {
+  readonly status: number;
+  readonly details?: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.name = "SelemeneError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+export class NoesisClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly authToken?: string,
+  ) {}
+
+  async health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>("/health/live", { method: "GET" });
+  }
+
+  async calculate(engineId: string, input: EngineInput): Promise<EngineOutput> {
+    return this.request<EngineOutput>(`/api/v1/engines/${engineId}/calculate`, {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+  }
+
+  async workflow(workflowId: string, input: EngineInput): Promise<WorkflowResult> {
+    return this.request<WorkflowResult>(`/api/v1/workflows/${workflowId}/execute`, {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const headers = new Headers(init.headers ?? {});
+    headers.set("Content-Type", "application/json");
+    if (this.authToken) {
+      headers.set("Authorization", `Bearer ${this.authToken}`);
+    }
+
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      ...init,
+      headers,
+    });
+
+    const text = await response.text();
+    const payload = text ? JSON.parse(text) : {};
+
+    if (!response.ok) {
+      throw new SelemeneError(
+        `Request failed: ${response.status}`,
+        response.status,
+        payload,
+      );
+    }
+
+    return payload as T;
+  }
+}

--- a/packages/noesis-sdk-ts/tsconfig.build.json
+++ b/packages/noesis-sdk-ts/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  }
+}

--- a/packages/noesis-sdk-ts/tsconfig.json
+++ b/packages/noesis-sdk-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -352,3 +352,59 @@
   - `cargo check -p noesis-api` ✅
   - `pytest -q tests/test_biofield_health.py tests/test_mediapipe_health.py` ✅
   - `npm run typecheck` (apps/admin-web) ✅
+
+---
+
+# Task Plan — Merge + Deploy + Release Tag Execution
+
+## Checklist
+- [x] Merge version-alignment PR into `main`.
+- [x] Verify production deploy result and runtime version.
+- [x] Push release tag `v3.0.0`.
+- [x] Verify GitHub release publication.
+- [x] Re-run production admin smoke checks.
+- [x] Update launch issues with current evidence and blockers.
+
+## Notes
+- Kept launch issues open where acceptance criteria still require external registry evidence/sign-offs.
+
+## Review (fill after execution)
+- Merged PR `#488` into `main`.
+- Pushed tag `v3.0.0` and confirmed GitHub release published.
+- Production health now returns `version: 3.0.0` on `/health/live`.
+- Admin smoke checks passed against production URLs.
+- Confirmed unresolved registry blockers:
+  - crates `noesis-core` and `noesis-sdk` not found on crates.io
+  - npm package `@selemene/sdk` not found on npm
+- Posted status/evidence updates to issues `#477`, `#478`, and `#479`.
+
+---
+
+# Task Plan — Crates Publish Commanding + `@selemene/sdk` Package Target
+
+## Checklist
+- [x] Prepare exact command order for crates.io + npm publishing.
+- [x] Update crate metadata needed for crates.io readiness (`noesis-core`, `noesis-sdk`).
+- [x] Add crate README files for publish metadata completeness.
+- [x] Locate/scaffold intended `@selemene/sdk` package target in repo.
+- [x] Verify new package builds/typechecks and validate publish preconditions.
+
+## Notes
+- `noesis-sdk` dry-run requires `noesis-core@3.0.0` to be indexed first; this is now explicitly encoded in command order.
+
+## Review (fill after execution)
+- Added publish command runbook: `docs/launch/v3.0.0-registry-publish-commands.md`
+- Updated workspace/crate metadata for crates publication readiness:
+  - `Cargo.toml` workspace package now includes repository/homepage
+  - `crates/noesis-core/Cargo.toml` includes readme/keywords/categories + workspace metadata
+  - `crates/noesis-sdk/Cargo.toml` includes readme/keywords/categories + `noesis-core` versioned dependency
+- Added crate README files:
+  - `crates/noesis-core/README.md`
+  - `crates/noesis-sdk/README.md`
+- Scaffolded npm package target at:
+  - `packages/noesis-sdk-ts` (published name `@selemene/sdk`)
+  - includes `package.json`, tsconfig, typed `NoesisClient`, README
+- Verification:
+  - `cargo publish --dry-run --allow-dirty -p noesis-core` ✅
+  - `cargo publish --dry-run --allow-dirty -p noesis-sdk` ⛔ (expected until `noesis-core` is actually published/indexed)
+  - `npm run typecheck` + `npm run build` in `packages/noesis-sdk-ts` ✅


### PR DESCRIPTION
## Summary
Prepare final release-publish execution by making crates metadata publish-ready and scaffolding the intended npm SDK package target.

## Changes
- Added exact ordered publish runbook:
  - `docs/launch/v3.0.0-registry-publish-commands.md`
- Updated crate metadata for publish readiness:
  - workspace `repository` / `homepage`
  - `noesis-core` + `noesis-sdk` readme/keywords/categories
  - `noesis-sdk` dependency on `noesis-core` now includes version `3.0.0`
- Added crate READMEs:
  - `crates/noesis-core/README.md`
  - `crates/noesis-sdk/README.md`
- Scaffolded npm package target for `@selemene/sdk`:
  - `packages/noesis-sdk-ts/*`
  - typed `NoesisClient` with `health`, `calculate`, `workflow`

## Verification
- `cargo publish --dry-run --allow-dirty -p noesis-core` ✅
- `cargo publish --dry-run --allow-dirty -p noesis-sdk` ⛔ expected until `noesis-core@3.0.0` is published/indexed on crates.io
- `npm run typecheck` and `npm run build` in `packages/noesis-sdk-ts` ✅

## Notes
This does not publish to crates.io/npm yet; it prepares exact commands + package target for the final publish step.