### PR TITLE
feat(admin-web): add usage analytics dashboard with usage-summary integration

### DIFF
--- a/apps/admin-web/app/(protected)/analytics/page.tsx
+++ b/apps/admin-web/app/(protected)/analytics/page.tsx
@@ -6,9 +6,10 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
+  Cell,
   Legend,
-  Line,
-  LineChart,
+  Pie,
+  PieChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -16,30 +17,13 @@ import {
 } from "recharts";
 import { PageShell } from "@/components/page-shell";
 import { getAuthToken } from "@/lib/auth";
-import {
-  ApiClientError,
-  getAnalyticsBreakdown,
-  getAnalyticsSummary,
-  getAnalyticsTimeseries,
-  getAnalyticsTopConsumers
-} from "@/lib/api";
+import { ApiClientError, getAdminUsageSummary } from "@/lib/api";
 import { buildQueryString, getNumberParam } from "@/lib/url-query";
-import type {
-  AdminAnalyticsBreakdownEntry,
-  AdminAnalyticsSummaryResponse,
-  AdminAnalyticsTimeseriesPoint,
-  AdminAnalyticsTopConsumerItem
-} from "@/types/admin";
+import type { AdminUsageSummaryResponse } from "@/types/admin";
 
 const REFRESH_OPTIONS = [0, 15, 30, 60] as const;
-
-function formatBucket(bucket: string): string {
-  const date = new Date(bucket);
-  if (Number.isNaN(date.getTime())) {
-    return bucket;
-  }
-  return `${date.getMonth() + 1}/${date.getDate()} ${date.getHours()}:00`;
-}
+const RANGE_DAY_OPTIONS = [7, 14, 30, 60, 90] as const;
+const CHART_COLORS = ["#56d3c2", "#8ac926", "#f9c74f", "#f9844a", "#ef6b73", "#90be6d"];
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat().format(value);
@@ -49,12 +33,10 @@ function formatDateTime(value: string | null): string {
   if (!value) {
     return "--";
   }
-
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
     return "--";
   }
-
   return date.toLocaleString();
 }
 
@@ -63,8 +45,8 @@ export default function AnalyticsPage() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const [windowHours, setWindowHours] = useState(() =>
-    getNumberParam(searchParams, "window_hours", 24, 1, 24 * 30)
+  const [rangeDays, setRangeDays] = useState(() =>
+    getNumberParam(searchParams, "range_days", 30, 7, 90)
   );
   const [autoRefreshSec, setAutoRefreshSec] = useState(() =>
     getNumberParam(searchParams, "refresh", 0, 0, 60)
@@ -73,33 +55,22 @@ export default function AnalyticsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null);
-
-  const [summary, setSummary] = useState<AdminAnalyticsSummaryResponse | null>(null);
-  const [timeseries, setTimeseries] = useState<AdminAnalyticsTimeseriesPoint[]>([]);
-  const [engineBreakdown, setEngineBreakdown] = useState<AdminAnalyticsBreakdownEntry[]>([]);
-  const [topConsumers, setTopConsumers] = useState<AdminAnalyticsTopConsumerItem[]>([]);
-
-  const successRate = useMemo(() => {
-    if (!summary || summary.requests_total === 0) {
-      return 0;
-    }
-    return ((summary.success_total / summary.requests_total) * 100).toFixed(2);
-  }, [summary]);
+  const [usage, setUsage] = useState<AdminUsageSummaryResponse | null>(null);
 
   useEffect(() => {
-    setWindowHours(getNumberParam(searchParams, "window_hours", 24, 1, 24 * 30));
+    setRangeDays(getNumberParam(searchParams, "range_days", 30, 7, 90));
     setAutoRefreshSec(getNumberParam(searchParams, "refresh", 0, 0, 60));
   }, [searchParams]);
 
   useEffect(() => {
     const nextQuery = buildQueryString(searchParams, {
-      window_hours: windowHours,
+      range_days: rangeDays,
       refresh: autoRefreshSec > 0 ? autoRefreshSec : undefined
     });
     router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
-  }, [autoRefreshSec, pathname, router, searchParams, windowHours]);
+  }, [autoRefreshSec, pathname, rangeDays, router, searchParams]);
 
-  const loadAnalytics = useCallback(async () => {
+  const loadUsage = useCallback(async () => {
     const token = getAuthToken();
     if (!token) {
       setError("Missing session token. Please sign in again.");
@@ -111,63 +82,58 @@ export default function AnalyticsPage() {
     setError(null);
 
     try {
-      const [summaryResponse, timeseriesResponse, breakdownResponse, topConsumersResponse] =
-        await Promise.all([
-          getAnalyticsSummary(token, { window_hours: windowHours }),
-          getAnalyticsTimeseries(token, {
-            window_hours: windowHours,
-            bucket: windowHours > 72 ? "day" : "hour"
-          }),
-          getAnalyticsBreakdown(token, { window_hours: windowHours, limit: 8 }),
-          getAnalyticsTopConsumers(token, { window_hours: windowHours, limit: 8 })
-        ]);
+      const response = await getAdminUsageSummary(token, {
+        range_days: rangeDays,
+        engine_limit: 10,
+        top_users_limit: 10
+      });
 
-      setSummary(summaryResponse);
-      setTimeseries(timeseriesResponse.points);
-      setEngineBreakdown(breakdownResponse.engines);
-      setTopConsumers(topConsumersResponse.items);
+      setUsage(response);
       setLastUpdatedAt(new Date().toISOString());
     } catch (err) {
       if (err instanceof ApiClientError) {
         setError(err.payload?.error || err.message);
       } else {
-        setError("Failed to load analytics");
+        setError("Failed to load usage analytics");
       }
     } finally {
       setLoading(false);
     }
-  }, [windowHours]);
+  }, [rangeDays]);
 
   useEffect(() => {
-    void loadAnalytics();
-  }, [loadAnalytics]);
+    void loadUsage();
+  }, [loadUsage]);
 
   useEffect(() => {
     if (autoRefreshSec <= 0) {
       return;
     }
     const interval = window.setInterval(() => {
-      void loadAnalytics();
+      void loadUsage();
     }, autoRefreshSec * 1000);
     return () => window.clearInterval(interval);
-  }, [autoRefreshSec, loadAnalytics]);
+  }, [autoRefreshSec, loadUsage]);
+
+  const chartData = useMemo(() => usage?.daily_requests ?? [], [usage]);
 
   return (
     <PageShell
       title="Usage Analytics"
-      summary="Time-windowed usage, engine segmentation, and top-consumer attribution."
+      summary="Daily request activity, engine popularity, tier distribution, and top users."
     >
       <div className="panel-inline">
         <label>
-          Window
+          Date range
           <select
-            value={windowHours}
-            onChange={(event) => setWindowHours(Number.parseInt(event.target.value, 10))}
+            value={rangeDays}
+            onChange={(event) => setRangeDays(Number.parseInt(event.target.value, 10))}
           >
-            <option value={24}>Last 24 hours</option>
-            <option value={72}>Last 72 hours</option>
-            <option value={168}>Last 7 days</option>
-            <option value={336}>Last 14 days</option>
+            {RANGE_DAY_OPTIONS.map((value) => (
+              <option key={value} value={value}>
+                Last {value} days
+              </option>
+            ))}
           </select>
         </label>
         <label>
@@ -183,7 +149,7 @@ export default function AnalyticsPage() {
             ))}
           </select>
         </label>
-        <button type="button" onClick={() => void loadAnalytics()}>
+        <button type="button" onClick={() => void loadUsage()}>
           Refresh
         </button>
       </div>
@@ -194,28 +160,20 @@ export default function AnalyticsPage() {
 
       <div className="grid metrics">
         <article className="metric">
-          <div className="label">Requests</div>
-          <div className="value">{summary ? formatNumber(summary.requests_total) : "--"}</div>
+          <div className="label">24h Requests</div>
+          <div className="value">{usage ? formatNumber(usage.daily.total) : "--"}</div>
         </article>
         <article className="metric">
-          <div className="label">Error Rate</div>
-          <div className="value">{summary ? `${summary.error_rate_pct.toFixed(2)}%` : "--"}</div>
+          <div className="label">30d Requests</div>
+          <div className="value">{usage ? formatNumber(usage.monthly.total) : "--"}</div>
         </article>
         <article className="metric">
-          <div className="label">Success Rate</div>
-          <div className="value">{summary ? `${successRate}%` : "--"}</div>
+          <div className="label">24h Active Users</div>
+          <div className="value">{usage ? formatNumber(usage.daily.active_users) : "--"}</div>
         </article>
         <article className="metric">
-          <div className="label">P95 (ms)</div>
-          <div className="value">{summary ? summary.p95_duration_ms.toFixed(0) : "--"}</div>
-        </article>
-        <article className="metric">
-          <div className="label">Active Users</div>
-          <div className="value">{summary ? formatNumber(summary.active_users) : "--"}</div>
-        </article>
-        <article className="metric">
-          <div className="label">Unique Keys</div>
-          <div className="value">{summary ? formatNumber(summary.unique_keys) : "--"}</div>
+          <div className="label">30d Active Users</div>
+          <div className="value">{usage ? formatNumber(usage.monthly.active_users) : "--"}</div>
         </article>
       </div>
 
@@ -224,51 +182,12 @@ export default function AnalyticsPage() {
       ) : (
         <>
           <article className="panel chart-panel">
-            <h3>Traffic Over Time</h3>
+            <h3>Daily Requests</h3>
             <div className="chart-wrap">
               <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={timeseries}>
+                <BarChart data={chartData}>
                   <CartesianGrid strokeDasharray="3 3" stroke="#214247" />
-                  <XAxis
-                    dataKey="bucket_start"
-                    tickFormatter={formatBucket}
-                    stroke="#9cb9b6"
-                    minTickGap={20}
-                  />
-                  <YAxis stroke="#9cb9b6" />
-                  <Tooltip
-                    formatter={(value) => formatNumber(Number(value))}
-                    labelFormatter={(label) => formatBucket(String(label))}
-                  />
-                  <Legend />
-                  <Line
-                    type="monotone"
-                    dataKey="request_count"
-                    name="Requests"
-                    stroke="#56d3c2"
-                    strokeWidth={2}
-                    dot={false}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="failure_count"
-                    name="Failures"
-                    stroke="#ef6b73"
-                    strokeWidth={2}
-                    dot={false}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-          </article>
-
-          <article className="panel chart-panel">
-            <h3>Engine Breakdown</h3>
-            <div className="chart-wrap">
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={engineBreakdown}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#214247" />
-                  <XAxis dataKey="label" stroke="#9cb9b6" />
+                  <XAxis dataKey="day" stroke="#9cb9b6" />
                   <YAxis stroke="#9cb9b6" />
                   <Tooltip formatter={(value) => formatNumber(Number(value))} />
                   <Legend />
@@ -278,34 +197,78 @@ export default function AnalyticsPage() {
             </div>
           </article>
 
+          <div className="grid two-col">
+            <article className="panel chart-panel">
+              <h3>Engine Popularity</h3>
+              <div className="chart-wrap">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie
+                      data={usage?.engine_breakdown ?? []}
+                      dataKey="request_count"
+                      nameKey="engine_id"
+                      outerRadius={110}
+                      label
+                    >
+                      {(usage?.engine_breakdown ?? []).map((entry, index) => (
+                        <Cell key={`${entry.engine_id}-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                      ))}
+                    </Pie>
+                    <Tooltip formatter={(value) => formatNumber(Number(value))} />
+                    <Legend />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+            </article>
+
+            <article className="panel chart-panel">
+              <h3>Tier Distribution</h3>
+              <div className="chart-wrap">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie
+                      data={usage?.tier_distribution ?? []}
+                      dataKey="request_count"
+                      nameKey="tier"
+                      outerRadius={110}
+                      label
+                    >
+                      {(usage?.tier_distribution ?? []).map((entry, index) => (
+                        <Cell key={`${entry.tier}-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                      ))}
+                    </Pie>
+                    <Tooltip formatter={(value) => formatNumber(Number(value))} />
+                    <Legend />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+            </article>
+          </div>
+
           <article className="panel">
-            <h3>Top Consumers</h3>
+            <h3>Top 10 Users</h3>
             <div className="table-wrap compact">
               <table>
                 <thead>
                   <tr>
                     <th>User</th>
                     <th>Requests</th>
-                    <th>Failures</th>
-                    <th>Avg Duration (ms)</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {topConsumers.map((item) => (
+                  {(usage?.top_users ?? []).map((item) => (
                     <tr key={item.user_id}>
                       <td>
                         <div className="table-primary">{item.user_email}</div>
                         <div className="helper">{item.user_id}</div>
                       </td>
                       <td>{formatNumber(item.request_count)}</td>
-                      <td>{formatNumber(item.failure_count)}</td>
-                      <td>{item.avg_duration_ms.toFixed(1)}</td>
                     </tr>
                   ))}
-                  {topConsumers.length === 0 ? (
+                  {(usage?.top_users.length ?? 0) === 0 ? (
                     <tr>
-                      <td colSpan={4}>
-                        <p className="helper">No consumers in this time window.</p>
+                      <td colSpan={2}>
+                        <p className="helper">No usage activity in the selected range.</p>
                       </td>
                     </tr>
                   ) : null}

--- a/apps/admin-web/src/lib/api.ts
+++ b/apps/admin-web/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   AdminSystemHealthResponse,
   AdminSystemServicesResponse,
   AdminSystemWorkflowsResponse,
+  AdminUsageSummaryResponse,
   AdminUsersResponse,
   ApiErrorPayload,
   CreateApiKeyResponse,
@@ -321,6 +322,20 @@ export async function getHistorySyncEvents(
       status: params.status,
       limit: params.limit,
       offset: params.offset
+    })}`,
+    { token }
+  );
+}
+
+export async function getAdminUsageSummary(
+  token: string,
+  params: { engine_limit?: number; top_users_limit?: number; range_days?: number } = {}
+): Promise<AdminUsageSummaryResponse> {
+  return request<AdminUsageSummaryResponse>(
+    `/api/v1/admin/usage/summary${buildQuery({
+      engine_limit: params.engine_limit,
+      top_users_limit: params.top_users_limit,
+      range_days: params.range_days
     })}`,
     { token }
   );

--- a/apps/admin-web/src/types/admin.ts
+++ b/apps/admin-web/src/types/admin.ts
@@ -197,6 +197,43 @@ export interface AdminAnalyticsTopConsumersResponse {
   items: AdminAnalyticsTopConsumerItem[];
 }
 
+export interface AdminUsageWindowSummary {
+  total: number;
+  success: number;
+  failure: number;
+  active_users: number;
+}
+
+export interface AdminUsageDailyPoint {
+  day: string;
+  request_count: number;
+}
+
+export interface AdminUsageEngineEntry {
+  engine_id: string;
+  request_count: number;
+}
+
+export interface AdminUsageTierEntry {
+  tier: string;
+  request_count: number;
+}
+
+export interface AdminUsageTopUserEntry {
+  user_id: string;
+  user_email: string;
+  request_count: number;
+}
+
+export interface AdminUsageSummaryResponse {
+  daily: AdminUsageWindowSummary;
+  monthly: AdminUsageWindowSummary;
+  daily_requests: AdminUsageDailyPoint[];
+  engine_breakdown: AdminUsageEngineEntry[];
+  tier_distribution: AdminUsageTierEntry[];
+  top_users: AdminUsageTopUserEntry[];
+}
+
 export interface AdminSystemSubsystemStatus {
   name: string;
   status: string;

--- a/crates/noesis-api/src/handlers/admin.rs
+++ b/crates/noesis-api/src/handlers/admin.rs
@@ -284,10 +284,24 @@ pub struct AdminUsageTopUserEntry {
 }
 
 #[derive(Serialize, ToSchema)]
+pub struct AdminUsageDailyPoint {
+    pub day: String,
+    pub request_count: i64,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminUsageTierEntry {
+    pub tier: String,
+    pub request_count: i64,
+}
+
+#[derive(Serialize, ToSchema)]
 pub struct AdminUsageSummaryResponse {
     pub daily: AdminUsageWindowSummary,
     pub monthly: AdminUsageWindowSummary,
+    pub daily_requests: Vec<AdminUsageDailyPoint>,
     pub engine_breakdown: Vec<AdminUsageEngineEntry>,
+    pub tier_distribution: Vec<AdminUsageTierEntry>,
     pub top_users: Vec<AdminUsageTopUserEntry>,
 }
 
@@ -435,6 +449,7 @@ pub struct AnalyticsQuery {
 pub struct AdminUsageSummaryQuery {
     pub engine_limit: Option<i64>,
     pub top_users_limit: Option<i64>,
+    pub range_days: Option<i64>,
 }
 
 #[derive(Deserialize, Default)]
@@ -1867,7 +1882,8 @@ pub async fn history_sync_events(
     tag = "admin",
     params(
         ("engine_limit" = Option<i64>, Query, description = "Max engine breakdown rows (default 10, max 50)"),
-        ("top_users_limit" = Option<i64>, Query, description = "Max top users rows (default 10, max 100)")
+        ("top_users_limit" = Option<i64>, Query, description = "Max top users rows (default 10, max 100)"),
+        ("range_days" = Option<i64>, Query, description = "Daily chart range in days (7-90, default 30)")
     ),
     responses(
         (status = 200, description = "Usage summary", body = AdminUsageSummaryResponse),
@@ -1895,6 +1911,7 @@ pub async fn usage_summary(
 
     let engine_limit = query.engine_limit.unwrap_or(10).clamp(1, 50);
     let top_users_limit = query.top_users_limit.unwrap_or(10).clamp(1, 100);
+    let range_days = query.range_days.unwrap_or(30).clamp(7, 90);
 
     let daily = usage_repo.admin_usage_summary(24).await.map_err(|e| {
         EngineError::InternalError(format!("Failed to fetch daily usage summary: {e}"))
@@ -1903,6 +1920,19 @@ pub async fn usage_summary(
     let monthly = usage_repo.admin_usage_summary(24 * 30).await.map_err(|e| {
         EngineError::InternalError(format!("Failed to fetch monthly usage summary: {e}"))
     })?;
+
+    let daily_requests = usage_repo
+        .admin_daily_series(range_days)
+        .await
+        .map_err(|e| {
+            EngineError::InternalError(format!("Failed to fetch daily usage series: {e}"))
+        })?
+        .into_iter()
+        .map(|point| AdminUsageDailyPoint {
+            day: point.day,
+            request_count: point.request_count,
+        })
+        .collect::<Vec<_>>();
 
     let engine_breakdown = usage_repo
         .admin_engine_breakdown(24 * 30, engine_limit)
@@ -1913,6 +1943,17 @@ pub async fn usage_summary(
         .into_iter()
         .map(|row| AdminUsageEngineEntry {
             engine_id: row.engine_id,
+            request_count: row.request_count,
+        })
+        .collect::<Vec<_>>();
+
+    let tier_distribution = usage_repo
+        .admin_tier_distribution(24 * 30)
+        .await
+        .map_err(|e| EngineError::InternalError(format!("Failed to fetch tier distribution: {e}")))?
+        .into_iter()
+        .map(|row| AdminUsageTierEntry {
+            tier: row.tier,
             request_count: row.request_count,
         })
         .collect::<Vec<_>>();
@@ -1944,7 +1985,9 @@ pub async fn usage_summary(
                 failure: monthly.failure,
                 active_users: monthly.active_users,
             },
+            daily_requests,
             engine_breakdown,
+            tier_distribution,
             top_users,
         }),
     )

--- a/crates/noesis-api/src/lib.rs
+++ b/crates/noesis-api/src/lib.rs
@@ -138,6 +138,8 @@ use utoipa_swagger_ui::SwaggerUi;
             handlers::admin::AdminUsageWindowSummary,
             handlers::admin::AdminUsageEngineEntry,
             handlers::admin::AdminUsageTopUserEntry,
+            handlers::admin::AdminUsageDailyPoint,
+            handlers::admin::AdminUsageTierEntry,
             handlers::admin::AdminUsageSummaryResponse,
             handlers::admin::AdminAnalyticsSummaryResponse,
             handlers::admin::AdminAnalyticsTimeseriesResponse,

--- a/crates/noesis-api/tests/usage_analytics_tests.rs
+++ b/crates/noesis-api/tests/usage_analytics_tests.rs
@@ -148,6 +148,8 @@ async fn test_admin_usage_summary_response_shape() {
     assert_eq!(status, StatusCode::OK, "Unexpected response: {:?}", body);
     assert!(body["daily"].is_object());
     assert!(body["monthly"].is_object());
+    assert!(body["daily_requests"].is_array());
     assert!(body["engine_breakdown"].is_array());
+    assert!(body["tier_distribution"].is_array());
     assert!(body["top_users"].is_array());
 }

--- a/crates/noesis-data/src/repositories/usage_repository.rs
+++ b/crates/noesis-data/src/repositories/usage_repository.rs
@@ -32,6 +32,16 @@ pub struct AdminUsageTopUser {
     pub request_count: i64,
 }
 
+pub struct AdminUsageDailyPoint {
+    pub day: String,
+    pub request_count: i64,
+}
+
+pub struct AdminUsageTierDistribution {
+    pub tier: String,
+    pub request_count: i64,
+}
+
 impl UsageRepository {
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
@@ -179,6 +189,62 @@ impl UsageRepository {
             .into_iter()
             .map(|(engine_id, request_count)| UsageEngineBreakdown {
                 engine_id,
+                request_count,
+            })
+            .collect())
+    }
+
+    /// Get daily request counts over the last `range_days` days.
+    pub async fn admin_daily_series(
+        &self,
+        range_days: i64,
+    ) -> Result<Vec<AdminUsageDailyPoint>, Error> {
+        let rows = sqlx::query_as::<_, (String, i64)>(
+            r#"
+            SELECT
+                to_char(date_trunc('day', created_at), 'YYYY-MM-DD') AS day,
+                COUNT(*)::BIGINT AS request_count
+            FROM usage_logs
+            WHERE created_at >= NOW() - make_interval(days => $1)
+            GROUP BY date_trunc('day', created_at)
+            ORDER BY date_trunc('day', created_at) ASC
+            "#,
+        )
+        .bind(range_days)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(day, request_count)| AdminUsageDailyPoint { day, request_count })
+            .collect())
+    }
+
+    /// Get request distribution by user tier over the last `window_hours`.
+    pub async fn admin_tier_distribution(
+        &self,
+        window_hours: i64,
+    ) -> Result<Vec<AdminUsageTierDistribution>, Error> {
+        let rows = sqlx::query_as::<_, (String, i64)>(
+            r#"
+            SELECT
+                COALESCE(NULLIF(lower(u.tier), ''), 'unknown') AS tier,
+                COUNT(*)::BIGINT AS request_count
+            FROM usage_logs l
+            INNER JOIN users u ON u.id = l.user_id
+            WHERE l.created_at >= NOW() - make_interval(hours => $1)
+            GROUP BY COALESCE(NULLIF(lower(u.tier), ''), 'unknown')
+            ORDER BY request_count DESC, tier ASC
+            "#,
+        )
+        .bind(window_hours)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(tier, request_count)| AdminUsageTierDistribution {
+                tier,
                 request_count,
             })
             .collect())

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -444,3 +444,47 @@
   - `cargo fmt --all` ✅
   - `cargo check -p noesis-api` ✅
   - `cargo test -p noesis-api --test usage_analytics_tests -- --nocapture` ✅
+
+---
+
+# Task Plan — Wave W2 Admin Usage Analytics Dashboard (#458)
+
+## Checklist
+- [x] Extend usage summary API payload for dashboard data (`daily_requests`, `tier_distribution`).
+- [x] Add date-range query support (`range_days`) to `/api/v1/admin/usage/summary`.
+- [x] Wire frontend API client/types for new usage summary contract.
+- [x] Update admin analytics page to use `/api/v1/admin/usage/summary`.
+- [x] Add daily request chart, engine popularity pie chart, tier distribution pie chart, top 10 users table.
+- [x] Add date range selector and hover-enabled chart interactions.
+- [x] Run backend and frontend verification gates.
+
+## Notes
+- Kept existing analytics endpoints untouched for backward compatibility.
+- Dashboard now uses usage-summary endpoint as primary source for usage views.
+
+## Review (fill after execution)
+- Backend (`noesis-api` + `noesis-data`):
+  - Extended admin usage response with:
+    - `daily_requests` (time series)
+    - `tier_distribution`
+  - Added `range_days` query support on `/api/v1/admin/usage/summary`
+  - Added repository methods:
+    - `admin_daily_series`
+    - `admin_tier_distribution`
+  - Updated OpenAPI schema registration for new response entities.
+- Frontend (`apps/admin-web`):
+  - Added new API client method: `getAdminUsageSummary`
+  - Added types: `AdminUsageSummaryResponse` and nested usage chart/table types
+  - Reworked `/analytics` page to include:
+    - daily requests bar chart
+    - engine popularity pie chart
+    - tier distribution pie chart
+    - top 10 users table
+    - date range selector + auto-refresh
+- Verification:
+  - `cargo fmt --all` ✅
+  - `cargo check -p noesis-api` ✅
+  - `cargo test -p noesis-api --test usage_analytics_tests -- --nocapture` ✅
+  - `npm --prefix apps/admin-web run typecheck` ✅
+  - `npm --prefix apps/admin-web run lint` ✅
+  - `npm --prefix apps/admin-web run build` ✅


### PR DESCRIPTION
## Summary
Implements issue #458 by shipping a production-ready admin usage analytics dashboard driven by `GET /api/v1/admin/usage/summary`.

## Frontend
- Reworked `/analytics` page to consume usage summary endpoint
- Added date range selector (`range_days`) and auto-refresh controls
- Added daily request chart (bar chart with hover interactions)
- Added engine popularity pie chart
- Added tier distribution pie chart
- Added top 10 users table

## Backend support (for dashboard contract)
- Extended `GET /api/v1/admin/usage/summary` response with:
  - `daily_requests` (daily time series)
  - `tier_distribution`
- Added query parameter: `range_days` (7-90)
- Added repository methods:
  - `admin_daily_series`
  - `admin_tier_distribution`
- Updated OpenAPI schemas for new usage summary response fields

## Validation
- `cargo fmt --all`
- `cargo check -p noesis-api`
- `cargo test -p noesis-api --test usage_analytics_tests -- --nocapture`
- `npm --prefix apps/admin-web run typecheck`
- `npm --prefix apps/admin-web run lint`
- `npm --prefix apps/admin-web run build`

## Issue
- Completes #458