### PR TITLE
feat(api): add billing event hooks for Stripe integration readiness

### DIFF
--- a/crates/noesis-api/src/billing.rs
+++ b/crates/noesis-api/src/billing.rs
@@ -1,0 +1,133 @@
+use chrono::Utc;
+use serde_json::Value;
+use std::sync::{Arc, LazyLock, RwLock};
+
+pub trait BillingEventEmitter: Send + Sync {
+    fn emit_usage_event(&self, user_id: &str, engine_id: &str, tier: &str);
+    fn emit_quota_exceeded(&self, user_id: &str, tier: &str);
+}
+
+pub struct NoopBillingEmitter;
+
+impl BillingEventEmitter for NoopBillingEmitter {
+    fn emit_usage_event(&self, user_id: &str, engine_id: &str, tier: &str) {
+        tracing::debug!(
+            user_id = user_id,
+            engine_id = engine_id,
+            tier = tier,
+            "noop billing usage event"
+        );
+    }
+
+    fn emit_quota_exceeded(&self, user_id: &str, tier: &str) {
+        tracing::debug!(
+            user_id = user_id,
+            tier = tier,
+            "noop billing quota exceeded event"
+        );
+    }
+}
+
+pub struct StripeWebhookEmitter {
+    webhook_url: String,
+}
+
+impl StripeWebhookEmitter {
+    pub fn new(webhook_url: impl Into<String>) -> Self {
+        Self {
+            webhook_url: webhook_url.into(),
+        }
+    }
+
+    pub fn format_usage_payload(&self, user_id: &str, engine_id: &str, tier: &str) -> Value {
+        serde_json::json!({
+            "event_type": "usage_event",
+            "provider": "stripe",
+            "webhook_url": self.webhook_url,
+            "user_id": user_id,
+            "engine_id": engine_id,
+            "tier": tier,
+            "timestamp": Utc::now().to_rfc3339(),
+        })
+    }
+
+    pub fn format_quota_exceeded_payload(&self, user_id: &str, tier: &str) -> Value {
+        serde_json::json!({
+            "event_type": "quota_exceeded",
+            "provider": "stripe",
+            "webhook_url": self.webhook_url,
+            "user_id": user_id,
+            "tier": tier,
+            "timestamp": Utc::now().to_rfc3339(),
+        })
+    }
+}
+
+impl BillingEventEmitter for StripeWebhookEmitter {
+    fn emit_usage_event(&self, user_id: &str, engine_id: &str, tier: &str) {
+        let payload = self.format_usage_payload(user_id, engine_id, tier);
+        tracing::debug!(payload = %payload, "stripe webhook usage payload formatted");
+    }
+
+    fn emit_quota_exceeded(&self, user_id: &str, tier: &str) {
+        let payload = self.format_quota_exceeded_payload(user_id, tier);
+        tracing::debug!(payload = %payload, "stripe webhook quota payload formatted");
+    }
+}
+
+static BILLING_EMITTER: LazyLock<RwLock<Arc<dyn BillingEventEmitter>>> =
+    LazyLock::new(|| RwLock::new(Arc::new(NoopBillingEmitter)));
+
+pub fn set_billing_emitter(emitter: Arc<dyn BillingEventEmitter>) {
+    if let Ok(mut guard) = BILLING_EMITTER.write() {
+        *guard = emitter;
+    }
+}
+
+pub fn reset_billing_emitter() {
+    set_billing_emitter(Arc::new(NoopBillingEmitter));
+}
+
+pub fn emit_usage_event(user_id: &str, engine_id: &str, tier: &str) {
+    if let Ok(guard) = BILLING_EMITTER.read() {
+        guard.emit_usage_event(user_id, engine_id, tier);
+    }
+}
+
+pub fn emit_quota_exceeded(user_id: &str, tier: &str) {
+    if let Ok(guard) = BILLING_EMITTER.read() {
+        guard.emit_quota_exceeded(user_id, tier);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stripe_usage_payload_shape() {
+        let emitter = StripeWebhookEmitter::new("https://stripe.example/webhook");
+        let payload = emitter.format_usage_payload("user-1", "panchanga", "pro");
+
+        assert_eq!(payload["event_type"], "usage_event");
+        assert_eq!(payload["provider"], "stripe");
+        assert_eq!(payload["webhook_url"], "https://stripe.example/webhook");
+        assert_eq!(payload["user_id"], "user-1");
+        assert_eq!(payload["engine_id"], "panchanga");
+        assert_eq!(payload["tier"], "pro");
+        assert!(payload["timestamp"].as_str().is_some());
+    }
+
+    #[test]
+    fn stripe_quota_payload_shape() {
+        let emitter = StripeWebhookEmitter::new("https://stripe.example/webhook");
+        let payload = emitter.format_quota_exceeded_payload("user-1", "free");
+
+        assert_eq!(payload["event_type"], "quota_exceeded");
+        assert_eq!(payload["provider"], "stripe");
+        assert_eq!(payload["webhook_url"], "https://stripe.example/webhook");
+        assert_eq!(payload["user_id"], "user-1");
+        assert_eq!(payload["tier"], "free");
+        assert!(payload["timestamp"].as_str().is_some());
+    }
+}

--- a/crates/noesis-api/src/lib.rs
+++ b/crates/noesis-api/src/lib.rs
@@ -4,11 +4,17 @@
 //! All engine calculations and workflow executions are exposed through versioned
 //! JSON endpoints under `/api/v1/`.
 
+mod billing;
 mod config;
 pub mod error;
 mod handlers;
 mod logging;
 mod middleware;
+
+pub use billing::{
+    reset_billing_emitter, set_billing_emitter, BillingEventEmitter, NoopBillingEmitter,
+    StripeWebhookEmitter,
+};
 
 // Re-export configuration and logging for main.rs
 pub use config::ApiConfig;
@@ -723,6 +729,8 @@ async fn calculate_handler(
     let duration_ms = duration_secs * 1000.0;
     let user_id_str = user.user_id.clone();
 
+    billing::emit_usage_event(&user_id_str, &engine_id, &user.tier);
+
     match result {
         Ok(output) => {
             state.metrics.record_engine_calculation_with_status(
@@ -986,6 +994,8 @@ async fn workflow_execute_handler(
 
     // Use workflow_id prefixed to distinguish from engine calculations
     let workflow_label = format!("workflow:{}", workflow_id);
+
+    billing::emit_usage_event(&user_id_str, &workflow_label, &user.tier);
 
     match result {
         Ok(workflow_result) => {

--- a/crates/noesis-api/src/middleware.rs
+++ b/crates/noesis-api/src/middleware.rs
@@ -1,5 +1,6 @@
 //! Middleware components for request logging, tracing, and response standardization
 
+use crate::billing;
 use axum::{
     extract::{Request, State},
     http::{header::AUTHORIZATION, StatusCode},
@@ -503,7 +504,7 @@ pub async fn rate_limit_middleware(
     // Determine rate limit key and limits based on authentication status
     let user = req.extensions().get::<AuthUser>().cloned();
 
-    let (key, per_minute_limit, daily_limit, auth_user_id) = match user {
+    let (key, per_minute_limit, daily_limit, auth_user_id, auth_tier) = match user {
         Some(auth_user) => {
             let tier_limits = limiter.limits_for_tier(&auth_user.tier);
             // Backward compatibility: explicit per-key rate_limit still overrides if set
@@ -518,12 +519,13 @@ pub async fn rate_limit_middleware(
                 per_minute_limit,
                 tier_limits.per_day,
                 Some(auth_user.user_id),
+                Some(auth_user.tier),
             )
         }
         None => {
             // Unauthenticated: rate limit by IP
             let ip = extract_client_ip(&req);
-            (format!("ip:{}", ip), limiter.anonymous_limit, 0, None)
+            (format!("ip:{}", ip), limiter.anonymous_limit, 0, None, None)
         }
     };
 
@@ -587,6 +589,10 @@ pub async fn rate_limit_middleware(
             );
         }
 
+        if let (Some(user_id), Some(tier)) = (&auth_user_id, &auth_tier) {
+            billing::emit_quota_exceeded(user_id, tier);
+        }
+
         return Ok(response);
     }
 
@@ -636,6 +642,10 @@ pub async fn rate_limit_middleware(
                 "X-RateLimit-Daily-Reset",
                 reset_daily.to_string().parse().unwrap(),
             );
+
+            if let Some(tier) = &auth_tier {
+                billing::emit_quota_exceeded(user_id, tier);
+            }
 
             return Ok(response);
         }

--- a/crates/noesis-api/tests/billing_hooks_tests.rs
+++ b/crates/noesis-api/tests/billing_hooks_tests.rs
@@ -1,0 +1,212 @@
+//! Integration tests for billing hook emission.
+
+use axum::{
+    body::Body,
+    http::{header, Request, StatusCode},
+};
+use chrono::{Duration as ChronoDuration, Utc};
+use noesis_api::{
+    create_router, reset_billing_emitter, set_billing_emitter, ApiConfig, AppState,
+    BillingEventEmitter, StripeWebhookEmitter,
+};
+use noesis_auth::{ApiKey, AuthService};
+use noesis_cache::CacheManager;
+use noesis_data::repositories::user_repository::UserRepository;
+use noesis_orchestrator::WorkflowOrchestrator;
+use sqlx::postgres::PgPoolOptions;
+use std::sync::{Arc, Mutex, Once};
+use std::time::{Duration, Instant};
+use tower::ServiceExt;
+
+mod common;
+
+#[derive(Clone, Default)]
+struct RecordingEmitter {
+    usage_events: Arc<Mutex<Vec<(String, String, String)>>>,
+    quota_events: Arc<Mutex<Vec<(String, String)>>>,
+}
+
+impl BillingEventEmitter for RecordingEmitter {
+    fn emit_usage_event(&self, user_id: &str, engine_id: &str, tier: &str) {
+        self.usage_events.lock().unwrap().push((
+            user_id.to_string(),
+            engine_id.to_string(),
+            tier.to_string(),
+        ));
+    }
+
+    fn emit_quota_exceeded(&self, user_id: &str, tier: &str) {
+        self.quota_events
+            .lock()
+            .unwrap()
+            .push((user_id.to_string(), tier.to_string()));
+    }
+}
+
+static INIT_METRICS: Once = Once::new();
+
+fn build_test_app_state() -> (AppState, ApiConfig) {
+    let mut orchestrator = WorkflowOrchestrator::new();
+    orchestrator.register_engine(Arc::new(engine_panchanga::PanchangaEngine::new()));
+    orchestrator.register_engine(Arc::new(engine_numerology::NumerologyEngine::new()));
+    orchestrator.register_engine(Arc::new(engine_biorhythm::BiorhythmEngine::new()));
+
+    let cache = CacheManager::new(String::new(), 100, Duration::from_secs(3600), false);
+
+    let jwt_secret = common::TEST_JWT_SECRET.to_string();
+    let auth = AuthService::new(jwt_secret);
+
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://localhost/noesis_test".to_string());
+    let config = ApiConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        jwt_secret: common::TEST_JWT_SECRET.to_string(),
+        database_url: Some(database_url.clone()),
+        redis_url: None,
+        allowed_origins: vec![],
+        rate_limit_requests: 100,
+        rate_limit_window_secs: 60,
+        request_timeout_secs: 30,
+        log_level: "info".to_string(),
+        log_format: "pretty".to_string(),
+    };
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect_lazy(&database_url)
+        .expect("Invalid DATABASE_URL");
+    let user_repository = Arc::new(UserRepository::new(pool));
+
+    static mut METRICS: Option<Arc<noesis_metrics::NoesisMetrics>> = None;
+    #[allow(static_mut_refs)]
+    let metrics = unsafe {
+        INIT_METRICS.call_once(|| {
+            let m = noesis_metrics::NoesisMetrics::new().expect("Failed to initialize metrics");
+            METRICS = Some(Arc::new(m));
+        });
+        METRICS.as_ref().unwrap().clone()
+    };
+
+    let state = AppState {
+        orchestrator: Arc::new(orchestrator),
+        cache: Arc::new(cache),
+        auth: Arc::new(auth),
+        metrics,
+        user_repository,
+        admin_repository: None,
+        readings_repository: None,
+        usage_repository: None,
+        startup_time: Instant::now(),
+    };
+
+    (state, config)
+}
+
+async fn create_test_api_key(auth: &Arc<AuthService>, user_id: &str, rate_limit: u32) -> String {
+    let api_key_value = format!("billing-test-key-{}", user_id);
+
+    let api_key = ApiKey {
+        key: api_key_value.clone(),
+        user_id: user_id.to_string(),
+        tier: "free".to_string(),
+        permissions: vec!["basic:access".to_string()],
+        created_at: Utc::now(),
+        expires_at: Some(Utc::now() + ChronoDuration::hours(1)),
+        last_used: None,
+        rate_limit,
+        consciousness_level: 0,
+    };
+
+    auth.add_api_key(api_key)
+        .await
+        .expect("Failed to add API key");
+    api_key_value
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_billing_usage_event_emitted_on_calculation() {
+    let emitter = RecordingEmitter::default();
+    set_billing_emitter(Arc::new(emitter.clone()));
+
+    let router = common::get_router().await;
+    let token = common::generate_test_token(5);
+    let input = common::create_test_birth_input();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/engines/numerology/calculate")
+        .header(header::AUTHORIZATION, format!("Bearer {}", token))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&input).unwrap()))
+        .unwrap();
+
+    let response = router.clone().oneshot(request).await.unwrap();
+    assert!(
+        response.status() == StatusCode::OK
+            || response.status() == StatusCode::UNPROCESSABLE_ENTITY,
+        "Unexpected status: {}",
+        response.status()
+    );
+
+    let events = emitter.usage_events.lock().unwrap();
+    assert!(!events.is_empty(), "Expected usage billing event emission");
+
+    reset_billing_emitter();
+}
+
+#[test]
+fn test_stripe_webhook_emitter_formats_payload_structure() {
+    let emitter = StripeWebhookEmitter::new("https://stripe.example/webhook");
+
+    let usage = emitter.format_usage_payload("user-1", "numerology", "pro");
+    assert_eq!(usage["event_type"], "usage_event");
+    assert_eq!(usage["provider"], "stripe");
+    assert_eq!(usage["user_id"], "user-1");
+    assert_eq!(usage["engine_id"], "numerology");
+    assert_eq!(usage["tier"], "pro");
+    assert!(usage["timestamp"].as_str().is_some());
+
+    let quota = emitter.format_quota_exceeded_payload("user-1", "free");
+    assert_eq!(quota["event_type"], "quota_exceeded");
+    assert_eq!(quota["provider"], "stripe");
+    assert_eq!(quota["user_id"], "user-1");
+    assert_eq!(quota["tier"], "free");
+    assert!(quota["timestamp"].as_str().is_some());
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_billing_quota_event_emitted_on_rate_limit() {
+    let emitter = RecordingEmitter::default();
+    set_billing_emitter(Arc::new(emitter.clone()));
+
+    let (state, config) = build_test_app_state();
+    let api_key = create_test_api_key(&state.auth, "quota-user", 1).await;
+    let app = create_router(state, &config);
+
+    let first = Request::builder()
+        .uri("/api/v1/status")
+        .header("X-API-Key", &api_key)
+        .body(Body::empty())
+        .unwrap();
+    let first_resp = app.clone().oneshot(first).await.unwrap();
+    assert_eq!(first_resp.status(), StatusCode::OK);
+
+    let second = Request::builder()
+        .uri("/api/v1/status")
+        .header("X-API-Key", &api_key)
+        .body(Body::empty())
+        .unwrap();
+    let second_resp = app.clone().oneshot(second).await.unwrap();
+    assert_eq!(second_resp.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    let quota_events = emitter.quota_events.lock().unwrap();
+    assert!(
+        !quota_events.is_empty(),
+        "Expected quota exceeded billing event emission"
+    );
+
+    reset_billing_emitter();
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -488,3 +488,43 @@
   - `npm --prefix apps/admin-web run typecheck` ✅
   - `npm --prefix apps/admin-web run lint` ✅
   - `npm --prefix apps/admin-web run build` ✅
+
+---
+
+# Task Plan — Wave W2 Billing Event Hooks (#457)
+
+## Checklist
+- [x] Add `BillingEventEmitter` trait with required methods.
+- [x] Add `NoopBillingEmitter` default that logs events at debug level.
+- [x] Add `StripeWebhookEmitter` stub with JSON payload formatting helpers.
+- [x] Emit usage billing events on each engine/workflow calculation attempt.
+- [x] Emit quota-exceeded billing events on authenticated 429 rate-limit responses.
+- [x] Add tests for Stripe payload format and billing hook emission wiring.
+- [x] Run verification commands.
+
+## Notes
+- Billing hooks are non-blocking instrumentation only (no payment side effects).
+- Existing API behavior remains unchanged; events are emitted in parallel to normal flow.
+
+## Review (fill after execution)
+- Added new module `crates/noesis-api/src/billing.rs`:
+  - `BillingEventEmitter`
+  - `NoopBillingEmitter`
+  - `StripeWebhookEmitter`
+  - global emitter setters and emit helpers
+- Integrated usage event calls in:
+  - `calculate_handler`
+  - `workflow_execute_handler`
+- Integrated quota-exceeded event calls in:
+  - minute-limit 429 path in `rate_limit_middleware`
+  - daily-limit 429 path in `rate_limit_middleware`
+- Added integration test file:
+  - `crates/noesis-api/tests/billing_hooks_tests.rs`
+    - usage event emitted on calculation
+    - quota event emitted on rate-limit exceed
+    - Stripe payload format assertions
+- Verification:
+  - `cargo fmt --all` ✅
+  - `cargo check -p noesis-api` ✅
+  - `cargo check -p noesis-api --tests` ✅
+  - `cargo test -p noesis-api --test billing_hooks_tests -- --nocapture` ⚠ blocked locally by Xcode license requirement on linker (`xcodebuild -license`)


### PR DESCRIPTION
## Summary
Implements issue #457 by adding billing event hooks for Stripe integration readiness.

## Included
- Added `BillingEventEmitter` trait with:
  - `emit_usage_event(user_id, engine_id, tier)`
  - `emit_quota_exceeded(user_id, tier)`
- Added `NoopBillingEmitter` default implementation
  - logs events at debug level
- Added `StripeWebhookEmitter` stub
  - formats usage/quota JSON payloads for future webhook integration

## Wiring
- Usage event emission on each calculation attempt:
  - `calculate_handler` (engine calculations)
  - `workflow_execute_handler` (workflow execution as `workflow:<id>`)
- Quota-exceeded emission on authenticated 429 paths in rate limiter:
  - per-minute limit exceeded
  - daily quota exceeded

## Tests
- Added `crates/noesis-api/tests/billing_hooks_tests.rs`
  - validates usage-event emission on calculation call
  - validates quota-exceeded emission on rate-limit 429
  - validates Stripe payload JSON structure

## Validation
- `cargo fmt --all`
- `cargo check -p noesis-api`
- `cargo check -p noesis-api --tests`
- `cargo test -p noesis-api --test billing_hooks_tests -- --nocapture` *(blocked locally by Xcode linker license requirement on this machine; test code compiles via `cargo check --tests`)*

## Issue
- Completes #457