### PR TITLE
feat(openapi): add per-engine result schemas for EngineOutput via utoipa

### DIFF
--- a/crates/noesis-api/src/lib.rs
+++ b/crates/noesis-api/src/lib.rs
@@ -31,7 +31,14 @@ use axum::{
 use chrono::Timelike;
 use noesis_auth::{AuthService, AuthUser};
 use noesis_cache::CacheManager;
-use noesis_core::{EngineError, EngineInput, EngineOutput, ValidationResult, WorkflowResult};
+use noesis_core::{
+    BiofieldResultSchema, BiorhythmResultSchema, EngineError, EngineInput, EngineOutput,
+    EngineResultData, EnneagramResultSchema, FaceReadingResultSchema, GeneKeysResultSchema,
+    HumanDesignResultSchema, IChingResultSchema, NadabrahmanResultSchema, NumerologyResultSchema,
+    PanchangaResultSchema, SacredGeometryResultSchema, SigilForgeResultSchema, TarotResultSchema,
+    TransitsResultSchema, ValidationResult, VedicClockResultSchema, VimshottariResultSchema,
+    WorkflowResult,
+};
 use noesis_data::models::reading::NewReading;
 use noesis_data::repositories::admin_repository::AdminRepository;
 use noesis_data::repositories::readings_repository::ReadingsRepository;
@@ -104,6 +111,23 @@ use utoipa_swagger_ui::SwaggerUi;
         schemas(
             EngineInput,
             EngineOutput,
+            EngineResultData,
+            PanchangaResultSchema,
+            NumerologyResultSchema,
+            BiorhythmResultSchema,
+            HumanDesignResultSchema,
+            GeneKeysResultSchema,
+            VimshottariResultSchema,
+            BiofieldResultSchema,
+            VedicClockResultSchema,
+            FaceReadingResultSchema,
+            NadabrahmanResultSchema,
+            TransitsResultSchema,
+            EnneagramResultSchema,
+            TarotResultSchema,
+            IChingResultSchema,
+            SacredGeometryResultSchema,
+            SigilForgeResultSchema,
             ValidationResult,
             WorkflowResult,
             HealthResponse,

--- a/crates/noesis-api/tests/openapi_schema_tests.rs
+++ b/crates/noesis-api/tests/openapi_schema_tests.rs
@@ -1,0 +1,128 @@
+//! OpenAPI schema regression tests for per-engine result documentation.
+
+use axum::{body::Body, http::Request, http::StatusCode};
+use serde_json::Value;
+use tower::ServiceExt;
+
+mod common;
+
+fn engine_schema_names() -> Vec<&'static str> {
+    vec![
+        "PanchangaResultSchema",
+        "NumerologyResultSchema",
+        "BiorhythmResultSchema",
+        "HumanDesignResultSchema",
+        "GeneKeysResultSchema",
+        "VimshottariResultSchema",
+        "BiofieldResultSchema",
+        "VedicClockResultSchema",
+        "FaceReadingResultSchema",
+        "NadabrahmanResultSchema",
+        "TransitsResultSchema",
+        "EnneagramResultSchema",
+        "TarotResultSchema",
+        "IChingResultSchema",
+        "SacredGeometryResultSchema",
+        "SigilForgeResultSchema",
+    ]
+}
+
+#[tokio::test]
+async fn test_openapi_contains_per_engine_result_schemas() {
+    let router = common::get_router().await;
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/openapi.json")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let spec: Value = serde_json::from_slice(&bytes).expect("valid openapi json");
+
+    let schemas = spec
+        .get("components")
+        .and_then(|c| c.get("schemas"))
+        .and_then(|s| s.as_object())
+        .expect("components.schemas object");
+
+    let mut found = 0;
+    for name in engine_schema_names() {
+        let schema = schemas
+            .get(name)
+            .unwrap_or_else(|| panic!("missing schema: {name}"));
+
+        let properties_len = schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .map(|props| props.len())
+            .unwrap_or(0);
+
+        assert!(
+            properties_len >= 3,
+            "schema {name} should have at least 3 documented fields"
+        );
+        found += 1;
+    }
+
+    assert_eq!(found, 16, "should include 16 per-engine schemas");
+}
+
+#[tokio::test]
+async fn test_engine_output_result_references_engine_union_schema() {
+    let router = common::get_router().await;
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/openapi.json")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let spec: Value = serde_json::from_slice(&bytes).expect("valid openapi json");
+
+    let engine_output = spec
+        .get("components")
+        .and_then(|c| c.get("schemas"))
+        .and_then(|s| s.get("EngineOutput"))
+        .expect("EngineOutput schema");
+
+    let result = engine_output
+        .get("properties")
+        .and_then(|p| p.get("result"))
+        .expect("EngineOutput.result property");
+
+    let refs_engine_union = result
+        .get("$ref")
+        .and_then(|v| v.as_str())
+        .map(|s| s.ends_with("/EngineResultData"))
+        .unwrap_or(false)
+        || result
+            .get("allOf")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter().any(|entry| {
+                    entry
+                        .get("$ref")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.ends_with("/EngineResultData"))
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+
+    assert!(
+        refs_engine_union,
+        "EngineOutput.result should reference EngineResultData schema"
+    );
+}

--- a/crates/noesis-core/src/types.rs
+++ b/crates/noesis-core/src/types.rs
@@ -40,6 +40,7 @@ pub struct EngineOutput {
     /// Which engine produced this output
     pub engine_id: String,
     /// Engine-specific result data (each engine defines its own schema)
+    #[cfg_attr(feature = "openapi", schema(value_type = EngineResultData))]
     pub result: Value,
     /// Self-inquiry question generated from the calculation
     pub witness_prompt: String,
@@ -180,4 +181,206 @@ pub struct WorkflowResult {
     pub synthesis: Option<Value>,
     pub total_time_ms: f64,
     pub timestamp: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// OpenAPI-only engine result schemas
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PanchangaResultSchema {
+    #[schema(example = "Sunday")]
+    pub vara: String,
+    #[schema(example = "Shukla")]
+    pub paksha: String,
+    #[schema(example = "Punarvasu")]
+    pub nakshatra: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct NumerologyResultSchema {
+    #[schema(example = 7)]
+    pub life_path_number: i32,
+    #[schema(example = 3)]
+    pub expression_number: i32,
+    #[schema(example = "Reflective and analytical")]
+    pub core_theme: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct BiorhythmResultSchema {
+    #[schema(example = 82.4)]
+    pub physical: f64,
+    #[schema(example = 41.7)]
+    pub emotional: f64,
+    #[schema(example = -15.2)]
+    pub intellectual: f64,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct HumanDesignResultSchema {
+    #[schema(example = "Manifesting Generator")]
+    pub type_name: String,
+    #[schema(example = "Sacral")]
+    pub authority: String,
+    #[schema(example = "Respond then inform")]
+    pub strategy: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GeneKeysResultSchema {
+    #[schema(example = "Gift of Patience")]
+    pub activation_sequence: String,
+    #[schema(example = "Venus Sequence")]
+    pub venus_sequence: String,
+    #[schema(example = "Pearl Sequence")]
+    pub pearl_sequence: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct VimshottariResultSchema {
+    #[schema(example = "Jupiter")]
+    pub current_mahadasha: String,
+    #[schema(example = "Saturn")]
+    pub current_antardasha: String,
+    #[schema(example = 1460)]
+    pub days_remaining: i64,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct BiofieldResultSchema {
+    #[schema(example = "earth")]
+    pub dominant_element: String,
+    #[schema(example = 0.72)]
+    pub coherence_score: f64,
+    #[schema(example = "grounding")]
+    pub recommended_practice: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct VedicClockResultSchema {
+    #[schema(example = "Brahma Muhurta")]
+    pub current_segment: String,
+    #[schema(example = "Sattva")]
+    pub guna_bias: String,
+    #[schema(example = "06:12")]
+    pub next_transition_local: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct FaceReadingResultSchema {
+    #[schema(example = "vata-pitta")]
+    pub constitutional_type: String,
+    #[schema(example = 0.81)]
+    pub confidence: f64,
+    #[schema(example = "soft jawline with high brow curvature")]
+    pub key_observation: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct NadabrahmanResultSchema {
+    #[schema(example = 432.0)]
+    pub root_frequency_hz: f64,
+    #[schema(example = "Bhairavi")]
+    pub suggested_raga: String,
+    #[schema(example = "AUM")]
+    pub mantra_seed: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct TransitsResultSchema {
+    #[schema(example = "Saturn return window")]
+    pub dominant_transit: String,
+    #[schema(example = "High")]
+    pub intensity: String,
+    #[schema(example = "2026-04-12")]
+    pub next_peak_date: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct EnneagramResultSchema {
+    #[schema(example = 4)]
+    pub core_type: i32,
+    #[schema(example = "4w5")]
+    pub wing: String,
+    #[schema(example = "Individualist")]
+    pub archetype: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct TarotResultSchema {
+    #[schema(example = "three-card")]
+    pub spread_type: String,
+    #[schema(example = "The Star")]
+    pub focal_card: String,
+    #[schema(example = "Renewed trust in unfolding")]
+    pub synthesis: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct IChingResultSchema {
+    #[schema(example = 24)]
+    pub hexagram: i32,
+    #[schema(example = "Return")]
+    pub hexagram_name: String,
+    #[schema(example = "Return to the center before moving outward")]
+    pub guidance: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SacredGeometryResultSchema {
+    #[schema(example = "flower-of-life")]
+    pub pattern: String,
+    #[schema(example = 144)]
+    pub point_count: i32,
+    #[schema(example = "Harmonic expansion")]
+    pub symbolic_theme: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SigilForgeResultSchema {
+    #[schema(example = "SIG-20260303-9A7")]
+    pub sigil_id: String,
+    #[schema(example = "clarity")]
+    pub intention: String,
+    #[schema(example = "M1 L10,2 L15,8 ...")]
+    pub vector_path: String,
+}
+
+#[cfg(feature = "openapi")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(untagged)]
+pub enum EngineResultData {
+    Panchanga(PanchangaResultSchema),
+    Numerology(NumerologyResultSchema),
+    Biorhythm(BiorhythmResultSchema),
+    HumanDesign(HumanDesignResultSchema),
+    GeneKeys(GeneKeysResultSchema),
+    Vimshottari(VimshottariResultSchema),
+    Biofield(BiofieldResultSchema),
+    VedicClock(VedicClockResultSchema),
+    FaceReading(FaceReadingResultSchema),
+    Nadabrahman(NadabrahmanResultSchema),
+    Transits(TransitsResultSchema),
+    Enneagram(EnneagramResultSchema),
+    Tarot(TarotResultSchema),
+    IChing(IChingResultSchema),
+    SacredGeometry(SacredGeometryResultSchema),
+    SigilForge(SigilForgeResultSchema),
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -528,3 +528,36 @@
   - `cargo check -p noesis-api` ✅
   - `cargo check -p noesis-api --tests` ✅
   - `cargo test -p noesis-api --test billing_hooks_tests -- --nocapture` ⚠ blocked locally by Xcode license requirement on linker (`xcodebuild -license`)
+
+---
+
+# Task Plan — Wave W2 Per-Engine OpenAPI Schemas (#447)
+
+## Checklist
+- [x] Add 16 dedicated per-engine result schema structs with documented fields/examples.
+- [x] Add OpenAPI union schema for `EngineOutput.result`.
+- [x] Wire engine schema types into API OpenAPI component list.
+- [x] Add OpenAPI regression tests for schema presence and result-field linkage.
+- [x] Run compile/verification commands.
+
+## Notes
+- Kept runtime response shape unchanged (`result: serde_json::Value`), while improving OpenAPI typing via `schema(value_type = EngineResultData)`.
+- Added explicit schema registration so `/api/openapi.json` reliably includes all 16 per-engine schemas.
+
+## Review (fill after execution)
+- Updated `crates/noesis-core/src/types.rs`:
+  - Added 16 per-engine schema structs:
+    - `PanchangaResultSchema`, `NumerologyResultSchema`, `BiorhythmResultSchema`, `HumanDesignResultSchema`, `GeneKeysResultSchema`, `VimshottariResultSchema`, `BiofieldResultSchema`, `VedicClockResultSchema`, `FaceReadingResultSchema`, `NadabrahmanResultSchema`, `TransitsResultSchema`, `EnneagramResultSchema`, `TarotResultSchema`, `IChingResultSchema`, `SacredGeometryResultSchema`, `SigilForgeResultSchema`
+  - Added `EngineResultData` (untagged union enum)
+  - Annotated `EngineOutput.result` with `#[schema(value_type = EngineResultData)]`
+- Updated `crates/noesis-api/src/lib.rs`:
+  - Imported and registered all engine schema types + `EngineResultData` in OpenAPI components.
+- Added test file `crates/noesis-api/tests/openapi_schema_tests.rs`:
+  - asserts 16 per-engine schemas exist in `/api/openapi.json`
+  - asserts each has at least 3 documented fields
+  - asserts `EngineOutput.result` references `EngineResultData`
+- Verification:
+  - `cargo fmt --all` ✅
+  - `cargo check -p noesis-core --features openapi` ✅
+  - `cargo check -p noesis-api` ✅
+  - `cargo check -p noesis-api --tests` ✅


### PR DESCRIPTION
## Summary
Implements issue #447 by documenting per-engine `EngineOutput.result` schemas in OpenAPI with 16 dedicated schema types.

## What changed
- Added 16 result schema structs in `noesis-core` (OpenAPI feature):
  - `PanchangaResultSchema`
  - `NumerologyResultSchema`
  - `BiorhythmResultSchema`
  - `HumanDesignResultSchema`
  - `GeneKeysResultSchema`
  - `VimshottariResultSchema`
  - `BiofieldResultSchema`
  - `VedicClockResultSchema`
  - `FaceReadingResultSchema`
  - `NadabrahmanResultSchema`
  - `TransitsResultSchema`
  - `EnneagramResultSchema`
  - `TarotResultSchema`
  - `IChingResultSchema`
  - `SacredGeometryResultSchema`
  - `SigilForgeResultSchema`
- Added `EngineResultData` union schema (`untagged` enum)
- Annotated `EngineOutput.result` with `#[schema(value_type = EngineResultData)]`
- Registered `EngineResultData` + all 16 schema types in API OpenAPI components (`crates/noesis-api/src/lib.rs`)
- Added regression tests:
  - `crates/noesis-api/tests/openapi_schema_tests.rs`
    - verifies all 16 schemas exist
    - verifies each has at least 3 documented fields
    - verifies `EngineOutput.result` references `EngineResultData`

## Validation
- `cargo fmt --all`
- `cargo check -p noesis-core --features openapi`
- `cargo check -p noesis-api`
- `cargo check -p noesis-api --tests`

## Issue
- Completes #447