### PR TITLE
feat(openapi): add workflow-specific execute schemas with typed synthesis

### DIFF
--- a/crates/noesis-api/src/lib.rs
+++ b/crates/noesis-api/src/lib.rs
@@ -73,6 +73,12 @@ use utoipa_swagger_ui::SwaggerUi;
         engine_info_handler,
         list_workflows_handler,
         workflow_execute_handler,
+        birth_blueprint_execute_doc,
+        daily_practice_execute_doc,
+        decision_support_execute_doc,
+        self_inquiry_execute_doc,
+        creative_expression_execute_doc,
+        full_spectrum_execute_doc,
         workflow_info_handler,
         handlers::users::get_me,
         handlers::users::get_my_usage,
@@ -138,6 +144,18 @@ use utoipa_swagger_ui::SwaggerUi;
             EngineListResponse,
             WorkflowListResponse,
             WorkflowInfoResponse,
+            BirthBlueprintSynthesisSchema,
+            DailyPracticeSynthesisSchema,
+            DecisionSupportSynthesisSchema,
+            SelfInquirySynthesisSchema,
+            CreativeExpressionSynthesisSchema,
+            FullSpectrumSynthesisSchema,
+            BirthBlueprintWorkflowResultSchema,
+            DailyPracticeWorkflowResultSchema,
+            DecisionSupportWorkflowResultSchema,
+            SelfInquiryWorkflowResultSchema,
+            CreativeExpressionWorkflowResultSchema,
+            FullSpectrumWorkflowResultSchema,
             ErrorResponse,
             handlers::users::UserResponse,
             handlers::users::LocationResponse,
@@ -546,6 +564,102 @@ struct WorkflowInfoResponse {
     name: String,
     description: String,
     engine_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct BirthBlueprintSynthesisSchema {
+    themes: Vec<String>,
+    alignments: Vec<String>,
+    tensions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct DailyPracticeSynthesisSchema {
+    practices: Vec<String>,
+    timing_notes: Vec<String>,
+    cautions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct DecisionSupportSynthesisSchema {
+    options_summary: Vec<String>,
+    decision_lenses: Vec<String>,
+    risks: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct SelfInquirySynthesisSchema {
+    inquiry_threads: Vec<String>,
+    shadow_themes: Vec<String>,
+    reflection_prompts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct CreativeExpressionSynthesisSchema {
+    creative_seeds: Vec<String>,
+    modality_alignment: Vec<String>,
+    blockers: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct FullSpectrumSynthesisSchema {
+    integrative_themes: Vec<String>,
+    cross_system_alignments: Vec<String>,
+    developmental_edges: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct BirthBlueprintWorkflowResultSchema {
+    workflow_id: String,
+    engine_outputs: std::collections::HashMap<String, EngineOutput>,
+    synthesis: Option<BirthBlueprintSynthesisSchema>,
+    total_time_ms: f64,
+    timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct DailyPracticeWorkflowResultSchema {
+    workflow_id: String,
+    engine_outputs: std::collections::HashMap<String, EngineOutput>,
+    synthesis: Option<DailyPracticeSynthesisSchema>,
+    total_time_ms: f64,
+    timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct DecisionSupportWorkflowResultSchema {
+    workflow_id: String,
+    engine_outputs: std::collections::HashMap<String, EngineOutput>,
+    synthesis: Option<DecisionSupportSynthesisSchema>,
+    total_time_ms: f64,
+    timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct SelfInquiryWorkflowResultSchema {
+    workflow_id: String,
+    engine_outputs: std::collections::HashMap<String, EngineOutput>,
+    synthesis: Option<SelfInquirySynthesisSchema>,
+    total_time_ms: f64,
+    timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct CreativeExpressionWorkflowResultSchema {
+    workflow_id: String,
+    engine_outputs: std::collections::HashMap<String, EngineOutput>,
+    synthesis: Option<CreativeExpressionSynthesisSchema>,
+    total_time_ms: f64,
+    timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct FullSpectrumWorkflowResultSchema {
+    workflow_id: String,
+    engine_outputs: std::collections::HashMap<String, EngineOutput>,
+    synthesis: Option<FullSpectrumSynthesisSchema>,
+    total_time_ms: f64,
+    timestamp: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -1000,6 +1114,15 @@ async fn workflow_execute_handler(
     Path(workflow_id): Path<String>,
     Json(input): Json<EngineInput>,
 ) -> Result<Json<noesis_core::WorkflowResult>, (StatusCode, Json<ErrorResponse>)> {
+    execute_workflow_by_id(state, user, workflow_id, input).await
+}
+
+async fn execute_workflow_by_id(
+    state: AppState,
+    user: AuthUser,
+    workflow_id: String,
+    input: EngineInput,
+) -> Result<Json<noesis_core::WorkflowResult>, (StatusCode, Json<ErrorResponse>)> {
     let start = Instant::now();
 
     // Capture input for persistence before it's moved into the workflow
@@ -1129,6 +1252,156 @@ async fn workflow_execute_handler(
             Err(engine_error_to_response(e))
         }
     }
+}
+
+/// POST /api/v1/workflows/birth-blueprint/execute -- workflow-specific OpenAPI shape
+#[utoipa::path(
+    post,
+    path = "/api/v1/workflows/birth-blueprint/execute",
+    tag = "workflows",
+    request_body = EngineInput,
+    responses(
+        (status = 200, description = "Birth Blueprint workflow result", body = BirthBlueprintWorkflowResultSchema),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Workflow not found", body = ErrorResponse),
+        (status = 422, description = "Validation error", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+    ),
+    security(("bearer_auth" = []), ("api_key" = []))
+)]
+#[allow(dead_code)]
+async fn birth_blueprint_execute_doc(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Json(input): Json<EngineInput>,
+) -> Result<Json<noesis_core::WorkflowResult>, (StatusCode, Json<ErrorResponse>)> {
+    execute_workflow_by_id(state, user, "birth-blueprint".to_string(), input).await
+}
+
+/// POST /api/v1/workflows/daily-practice/execute -- workflow-specific OpenAPI shape
+#[utoipa::path(
+    post,
+    path = "/api/v1/workflows/daily-practice/execute",
+    tag = "workflows",
+    request_body = EngineInput,
+    responses(
+        (status = 200, description = "Daily Practice workflow result", body = DailyPracticeWorkflowResultSchema),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Workflow not found", body = ErrorResponse),
+        (status = 422, description = "Validation error", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+    ),
+    security(("bearer_auth" = []), ("api_key" = []))
+)]
+#[allow(dead_code)]
+async fn daily_practice_execute_doc(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Json(input): Json<EngineInput>,
+) -> Result<Json<noesis_core::WorkflowResult>, (StatusCode, Json<ErrorResponse>)> {
+    execute_workflow_by_id(state, user, "daily-practice".to_string(), input).await
+}
+
+/// POST /api/v1/workflows/decision-support/execute -- workflow-specific OpenAPI shape
+#[utoipa::path(
+    post,
+    path = "/api/v1/workflows/decision-support/execute",
+    tag = "workflows",
+    request_body = EngineInput,
+    responses(
+        (status = 200, description = "Decision Support workflow result", body = DecisionSupportWorkflowResultSchema),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Workflow not found", body = ErrorResponse),
+        (status = 422, description = "Validation error", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+    ),
+    security(("bearer_auth" = []), ("api_key" = []))
+)]
+#[allow(dead_code)]
+async fn decision_support_execute_doc(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Json(input): Json<EngineInput>,
+) -> Result<Json<noesis_core::WorkflowResult>, (StatusCode, Json<ErrorResponse>)> {
+    execute_workflow_by_id(state, user, "decision-support".to_string(), input).await
+}
+
+/// POST /api/v1/workflows/self-inquiry/execute -- workflow-specific OpenAPI shape
+#[utoipa::path(
+    post,
+    path = "/api/v1/workflows/self-inquiry/execute",
+    tag = "workflows",
+    request_body = EngineInput,
+    responses(
+        (status = 200, description = "Self Inquiry workflow result", body = SelfInquiryWorkflowResultSchema),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Workflow not found", body = ErrorResponse),
+        (status = 422, description = "Validation error", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+    ),
+    security(("bearer_auth" = []), ("api_key" = []))
+)]
+#[allow(dead_code)]
+async fn self_inquiry_execute_doc(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Json(input): Json<EngineInput>,
+) -> Result<Json<noesis_core::WorkflowResult>, (StatusCode, Json<ErrorResponse>)> {
+    execute_workflow_by_id(state, user, "self-inquiry".to_string(), input).await
+}
+
+/// POST /api/v1/workflows/creative-expression/execute -- workflow-specific OpenAPI shape
+#[utoipa::path(
+    post,
+    path = "/api/v1/workflows/creative-expression/execute",
+    tag = "workflows",
+    request_body = EngineInput,
+    responses(
+        (status = 200, description = "Creative Expression workflow result", body = CreativeExpressionWorkflowResultSchema),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Workflow not found", body = ErrorResponse),
+        (status = 422, description = "Validation error", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+    ),
+    security(("bearer_auth" = []), ("api_key" = []))
+)]
+#[allow(dead_code)]
+async fn creative_expression_execute_doc(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Json(input): Json<EngineInput>,
+) -> Result<Json<noesis_core::WorkflowResult>, (StatusCode, Json<ErrorResponse>)> {
+    execute_workflow_by_id(state, user, "creative-expression".to_string(), input).await
+}
+
+/// POST /api/v1/workflows/full-spectrum/execute -- workflow-specific OpenAPI shape
+#[utoipa::path(
+    post,
+    path = "/api/v1/workflows/full-spectrum/execute",
+    tag = "workflows",
+    request_body = EngineInput,
+    responses(
+        (status = 200, description = "Full Spectrum workflow result", body = FullSpectrumWorkflowResultSchema),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Workflow not found", body = ErrorResponse),
+        (status = 422, description = "Validation error", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+    ),
+    security(("bearer_auth" = []), ("api_key" = []))
+)]
+#[allow(dead_code)]
+async fn full_spectrum_execute_doc(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Json(input): Json<EngineInput>,
+) -> Result<Json<noesis_core::WorkflowResult>, (StatusCode, Json<ErrorResponse>)> {
+    execute_workflow_by_id(state, user, "full-spectrum".to_string(), input).await
 }
 
 /// GET /api/v1/workflows -- list all workflow IDs

--- a/crates/noesis-api/tests/workflow_openapi_tests.rs
+++ b/crates/noesis-api/tests/workflow_openapi_tests.rs
@@ -1,0 +1,112 @@
+//! OpenAPI workflow schema tests for workflow-specific endpoint definitions.
+
+use axum::{body::Body, http::Request, http::StatusCode};
+use serde_json::Value;
+use tower::ServiceExt;
+
+mod common;
+
+#[tokio::test]
+async fn test_openapi_contains_six_workflow_execute_paths() {
+    let router = common::get_router().await;
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/openapi.json")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let spec: Value = serde_json::from_slice(&bytes).expect("valid openapi json");
+
+    let paths = spec
+        .get("paths")
+        .and_then(|v| v.as_object())
+        .expect("paths object");
+
+    let expected = [
+        "/api/v1/workflows/birth-blueprint/execute",
+        "/api/v1/workflows/daily-practice/execute",
+        "/api/v1/workflows/decision-support/execute",
+        "/api/v1/workflows/self-inquiry/execute",
+        "/api/v1/workflows/creative-expression/execute",
+        "/api/v1/workflows/full-spectrum/execute",
+    ];
+
+    for path in expected {
+        assert!(paths.contains_key(path), "missing workflow path: {path}");
+    }
+}
+
+#[tokio::test]
+async fn test_workflow_synthesis_schemas_are_typed() {
+    let router = common::get_router().await;
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/openapi.json")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let spec: Value = serde_json::from_slice(&bytes).expect("valid openapi json");
+
+    let schemas = spec
+        .get("components")
+        .and_then(|c| c.get("schemas"))
+        .and_then(|s| s.as_object())
+        .expect("components.schemas object");
+
+    let expected_response_schemas = [
+        "BirthBlueprintWorkflowResultSchema",
+        "DailyPracticeWorkflowResultSchema",
+        "DecisionSupportWorkflowResultSchema",
+        "SelfInquiryWorkflowResultSchema",
+        "CreativeExpressionWorkflowResultSchema",
+        "FullSpectrumWorkflowResultSchema",
+    ];
+
+    for schema_name in expected_response_schemas {
+        let schema = schemas
+            .get(schema_name)
+            .unwrap_or_else(|| panic!("missing response schema: {schema_name}"));
+
+        let synthesis = schema
+            .get("properties")
+            .and_then(|p| p.get("synthesis"))
+            .expect("synthesis field in workflow result schema");
+
+        let has_typed_ref = synthesis
+            .get("allOf")
+            .and_then(|v| v.as_array())
+            .map(|items| {
+                items.iter().any(|item| {
+                    item.get("$ref")
+                        .and_then(|r| r.as_str())
+                        .map(|r| r.contains("SynthesisSchema"))
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false)
+            || synthesis
+                .get("$ref")
+                .and_then(|r| r.as_str())
+                .map(|r| r.contains("SynthesisSchema"))
+                .unwrap_or(false);
+
+        assert!(
+            has_typed_ref,
+            "workflow schema {schema_name} should reference a typed synthesis schema"
+        );
+    }
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -561,3 +561,41 @@
   - `cargo check -p noesis-core --features openapi` ✅
   - `cargo check -p noesis-api` ✅
   - `cargo check -p noesis-api --tests` ✅
+
+---
+
+# Task Plan — Wave W2 Workflow-Specific OpenAPI Schemas (#448)
+
+## Checklist
+- [x] Add workflow-specific typed synthesis schema models.
+- [x] Add workflow-specific response schemas for all 6 workflows.
+- [x] Add 6 workflow-specific OpenAPI endpoint definitions for execute routes.
+- [x] Reuse shared execution logic to avoid behavioral drift.
+- [x] Add OpenAPI regression tests for path presence and synthesis typing.
+- [x] Run verification compile checks.
+
+## Notes
+- Runtime API surface unchanged (existing dynamic execute route still handles execution).
+- Added static-path OpenAPI definitions for each workflow to satisfy per-workflow endpoint visibility in docs/Swagger.
+
+## Review (fill after execution)
+- Updated `crates/noesis-api/src/lib.rs`:
+  - Added typed synthesis schemas:
+    - `BirthBlueprintSynthesisSchema`, `DailyPracticeSynthesisSchema`, `DecisionSupportSynthesisSchema`, `SelfInquirySynthesisSchema`, `CreativeExpressionSynthesisSchema`, `FullSpectrumSynthesisSchema`
+  - Added typed workflow result schemas (6):
+    - `BirthBlueprintWorkflowResultSchema`, `DailyPracticeWorkflowResultSchema`, `DecisionSupportWorkflowResultSchema`, `SelfInquiryWorkflowResultSchema`, `CreativeExpressionWorkflowResultSchema`, `FullSpectrumWorkflowResultSchema`
+  - Added 6 workflow-specific OpenAPI execute handlers/definitions:
+    - `/api/v1/workflows/birth-blueprint/execute`
+    - `/api/v1/workflows/daily-practice/execute`
+    - `/api/v1/workflows/decision-support/execute`
+    - `/api/v1/workflows/self-inquiry/execute`
+    - `/api/v1/workflows/creative-expression/execute`
+    - `/api/v1/workflows/full-spectrum/execute`
+  - Refactored shared runtime logic into `execute_workflow_by_id(...)` and reused it.
+- Added tests in `crates/noesis-api/tests/workflow_openapi_tests.rs`:
+  - verifies 6 workflow execute paths exist in OpenAPI
+  - verifies workflow result schemas reference typed synthesis schemas
+- Verification:
+  - `cargo fmt --all` ✅
+  - `cargo check -p noesis-api` ✅
+  - `cargo check -p noesis-api --tests` ✅


### PR DESCRIPTION
## Summary
Implements issue #448 by documenting workflow-specific request/response schemas and typed synthesis models in OpenAPI.

## Included
- Added six workflow-specific execute endpoint definitions in OpenAPI:
  - `/api/v1/workflows/birth-blueprint/execute`
  - `/api/v1/workflows/daily-practice/execute`
  - `/api/v1/workflows/decision-support/execute`
  - `/api/v1/workflows/self-inquiry/execute`
  - `/api/v1/workflows/creative-expression/execute`
  - `/api/v1/workflows/full-spectrum/execute`
- Added typed synthesis schemas:
  - `BirthBlueprintSynthesisSchema`
  - `DailyPracticeSynthesisSchema`
  - `DecisionSupportSynthesisSchema`
  - `SelfInquirySynthesisSchema`
  - `CreativeExpressionSynthesisSchema`
  - `FullSpectrumSynthesisSchema`
- Added typed workflow result schemas (one per workflow)
- Registered all new schemas in OpenAPI components
- Refactored shared runtime execution logic into `execute_workflow_by_id(...)` to avoid behavior duplication

## Tests
Added `crates/noesis-api/tests/workflow_openapi_tests.rs` to validate:
- all 6 workflow execute path definitions exist in `/api/openapi.json`
- workflow result schemas reference typed synthesis schemas

## Validation
- `cargo fmt --all`
- `cargo check -p noesis-api`
- `cargo check -p noesis-api --tests`

## Issue
- Completes #448