### PR TITLE
feat(admin): enhance API key display with copy buttons

### DIFF
--- a/apps/admin-web/app/(protected)/api-keys/page.tsx
+++ b/apps/admin-web/app/(protected)/api-keys/page.tsx
@@ -423,7 +423,7 @@ export default function ApiKeysPage() {
             <thead>
               <tr>
                 <th>Name</th>
-                <th>Prefix</th>
+                <th>API Key</th>
                 <th>User</th>
                 <th>Tier</th>
                 <th>Permissions</th>
@@ -439,18 +439,49 @@ export default function ApiKeysPage() {
                   <td>
                     <div className="table-primary">{k.name || "Unnamed"}</div>
                     <div className="helper">{formatDateTime(k.created_at)}</div>
-                    <button
-                      type="button"
-                      className="link-btn"
-                      onClick={() => void handleCopyValue(k.id, "Key ID")}
-                    >
-                      {k.id}
-                    </button>
+                    <div style={{ display: "inline-flex", alignItems: "center", gap: "0.3rem" }}>
+                      <span className="helper" style={{ fontSize: "0.75rem", fontFamily: "var(--font-mono), monospace" }}>
+                        {k.id.slice(0, 8)}...
+                      </span>
+                      <button
+                        type="button"
+                        className="copy-icon-btn"
+                        title="Copy full key ID"
+                        onClick={() => void handleCopyValue(k.id, "Key ID")}
+                      >
+                        ⧉
+                      </button>
+                    </div>
                   </td>
                   <td>
-                    <span className="key-prefix">
-                      {k.key_prefix || k.id.slice(0, 8) + "..."}
-                    </span>
+                    <div className="key-display">
+                      <code>
+                        {k.key_prefix ? (
+                          <>
+                            {k.key_prefix}
+                            <span className="masked">••••</span>
+                          </>
+                        ) : (
+                          <>
+                            {k.id.slice(0, 8)}...
+                            <span className="legacy-tag">(legacy)</span>
+                          </>
+                        )}
+                      </code>
+                      <button
+                        type="button"
+                        className="copy-icon-btn"
+                        title="Copy key prefix"
+                        onClick={() =>
+                          void handleCopyValue(
+                            k.key_prefix || k.id.slice(0, 8),
+                            "Key prefix"
+                          )
+                        }
+                      >
+                        ⧉
+                      </button>
+                    </div>
                   </td>
                   <td>
                     <div className="table-primary">{k.user_email}</div>

--- a/apps/admin-web/app/globals.css
+++ b/apps/admin-web/app/globals.css
@@ -548,7 +548,62 @@ tbody tr:hover {
   color: #9ff0e5;
 }
 
-/* ---- Key prefix ---- */
+/* ---- Key display ---- */
+.key-display {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(25, 48, 51, 0.6);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.3rem 0.5rem;
+  max-width: 100%;
+}
+
+.key-display code {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.84rem;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.key-display .masked {
+  color: var(--text-muted);
+  opacity: 0.5;
+}
+
+.key-display .legacy-tag {
+  font-family: inherit;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  opacity: 0.6;
+  margin-left: 0.2rem;
+}
+
+.copy-icon-btn {
+  border: 0;
+  padding: 0.15rem 0.25rem;
+  margin: 0;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.78rem;
+  line-height: 1;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+
+.copy-icon-btn:hover {
+  color: var(--accent);
+  background: rgba(86, 211, 194, 0.12);
+}
+
+.copy-icon-btn.copied {
+  color: #56d3c2;
+}
+
 .key-prefix {
   font-family: var(--font-mono), monospace;
   font-size: 0.82rem;


### PR DESCRIPTION
## Summary
- Rename "Prefix" column to "API Key" with styled monospace code block
- Show `key_prefix` + masked suffix (`••••`) for clear visual identification
- Add copy-to-clipboard icon buttons for key prefix and key ID
- Legacy keys (null prefix) show graceful fallback with "(legacy)" tag

## Test plan
- [ ] Verify API Keys page renders keys with new styled `.key-display` blocks
- [ ] Click copy button → key prefix copied to clipboard with success toast
- [ ] Legacy keys without `key_prefix` show truncated ID with "(legacy)" label
- [ ] Create/revoke/rotate flows still work correctly
- [ ] Next.js build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)