### PR TITLE
feat(biofield): storage-backed reprocess and baselines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ Thumbs.db
 
 # Local OpenClaw exports
 Openclaw.txt
+.vercel
+
+# Local runtime artifact storage
+/.runtime/

--- a/apps/biofield-web/app/globals.css
+++ b/apps/biofield-web/app/globals.css
@@ -318,6 +318,25 @@ textarea {
   word-break: break-word;
 }
 
+.biofield-textarea {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+.biofield-checkbox-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  padding: 0.65rem 0.95rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.biofield-checkbox {
+  accent-color: var(--accent);
+}
+
 .biofield-mono {
   font-family: "SFMono-Regular", "Menlo", monospace;
   word-break: break-word;

--- a/apps/biofield-web/src/components/biofield-history-page.tsx
+++ b/apps/biofield-web/src/components/biofield-history-page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
-import type { BiofieldReadingSummary } from "@selemene/biofield-domain";
+import { FormEvent, useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import type { BiofieldBaselineSummary, BiofieldReadingSummary } from "@selemene/biofield-domain";
 import { BiofieldClientError } from "@selemene/biofield-api-client";
 import {
   clearStoredAuthSession,
@@ -51,10 +51,16 @@ export function BiofieldHistoryPage() {
     () => null,
   );
   const [readings, setReadings] = useState<BiofieldReadingSummary[]>([]);
+  const [baselines, setBaselines] = useState<BiofieldBaselineSummary[]>([]);
+  const [selectedReadingIds, setSelectedReadingIds] = useState<string[]>([]);
+  const [baselineName, setBaselineName] = useState("");
+  const [baselineNotes, setBaselineNotes] = useState("");
   const [limit, setLimit] = useState(DEFAULT_PAGE_LIMIT);
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [isCreatingBaseline, setIsCreatingBaseline] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
@@ -73,6 +79,7 @@ export function BiofieldHistoryPage() {
   const handleAuthFailure = useCallback(() => {
     clearStoredAuthSession();
     setReadings([]);
+    setBaselines([]);
     router.replace("/login");
   }, [router]);
 
@@ -85,17 +92,22 @@ export function BiofieldHistoryPage() {
     setErrorMessage(null);
 
     try {
-      const response = await client.listReadings({ limit: nextLimit, offset: nextOffset });
-      setReadings(response.items);
-      setLimit(response.limit);
-      setOffset(response.offset);
-      setHasMore(response.items.length === response.limit);
+      const [readingsResponse, baselinesResponse] = await Promise.all([
+        client.listReadings({ limit: nextLimit, offset: nextOffset }),
+        client.listBaselines(),
+      ]);
+
+      setReadings(readingsResponse.items);
+      setLimit(readingsResponse.limit);
+      setOffset(readingsResponse.offset);
+      setHasMore(readingsResponse.items.length === readingsResponse.limit);
+      setBaselines(baselinesResponse.items);
     } catch (error) {
       if (error instanceof BiofieldClientError && error.status === 401) {
         handleAuthFailure();
         return;
       }
-      setErrorMessage(getErrorMessage(error, "Failed to load biofield readings."));
+      setErrorMessage(getErrorMessage(error, "Failed to load biofield history."));
     } finally {
       setIsLoading(false);
     }
@@ -108,6 +120,46 @@ export function BiofieldHistoryPage() {
 
     void loadReadings(0, DEFAULT_PAGE_LIMIT);
   }, [authSession, client, loadReadings]);
+
+  function toggleReadingSelection(readingId: string) {
+    setSelectedReadingIds((current) =>
+      current.includes(readingId)
+        ? current.filter((id) => id !== readingId)
+        : [...current, readingId],
+    );
+  }
+
+  async function handleCreateBaseline(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!client || selectedReadingIds.length === 0) {
+      return;
+    }
+
+    setIsCreatingBaseline(true);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      const baseline = await client.createBaseline({
+        name: baselineName,
+        notes: baselineNotes.trim() || undefined,
+        reading_ids: selectedReadingIds,
+      });
+      setStatusMessage(`Baseline ${baseline.name} created from ${baseline.reading_count} readings.`);
+      setBaselineName("");
+      setBaselineNotes("");
+      setSelectedReadingIds([]);
+      await loadReadings(offset, limit);
+    } catch (error) {
+      if (error instanceof BiofieldClientError && error.status === 401) {
+        handleAuthFailure();
+        return;
+      }
+      setErrorMessage(getErrorMessage(error, "Failed to create biofield baseline."));
+    } finally {
+      setIsCreatingBaseline(false);
+    }
+  }
 
   function handlePreviousPage() {
     const nextOffset = Math.max(0, offset - limit);
@@ -135,12 +187,12 @@ export function BiofieldHistoryPage() {
       <section className="biofield-panel biofield-form-panel">
         <div className="biofield-toolbar">
           <div>
-            <p className="biofield-eyebrow">BF1-07 history</p>
+            <p className="biofield-eyebrow">BF2 history and baselines</p>
             <h2 className="biofield-title" style={{ fontSize: "2rem" }}>
               Persisted readings
             </h2>
             <p className="biofield-copy">
-              Every successful capture now lands as a user-scoped reading with artifact metadata and a stable detail route.
+              Create lightweight baselines from selected readings while keeping the Phase 1 history surface intact.
             </p>
           </div>
           <div className="biofield-actions">
@@ -155,16 +207,20 @@ export function BiofieldHistoryPage() {
 
         <div className="biofield-meta-grid">
           <div className="biofield-list-card">
-            <p className="biofield-kicker">Loaded items</p>
+            <p className="biofield-kicker">Loaded readings</p>
             <p className="biofield-metric">{readings.length}</p>
           </div>
           <div className="biofield-list-card">
-            <p className="biofield-kicker">Page limit</p>
-            <p className="biofield-metric">{limit}</p>
+            <p className="biofield-kicker">Baselines</p>
+            <p className="biofield-metric">{baselines.length}</p>
           </div>
           <div className="biofield-list-card">
-            <p className="biofield-kicker">Offset</p>
-            <p className="biofield-metric">{offset}</p>
+            <p className="biofield-kicker">Selected readings</p>
+            <p className="biofield-metric">{selectedReadingIds.length}</p>
+          </div>
+          <div className="biofield-list-card">
+            <p className="biofield-kicker">Page window</p>
+            <p className="biofield-metric">{offset} -&gt; {offset + readings.length}</p>
           </div>
           <div className="biofield-list-card">
             <p className="biofield-kicker">Page</p>
@@ -191,12 +247,51 @@ export function BiofieldHistoryPage() {
         </div>
       </section>
 
+      {statusMessage ? <p className="biofield-success">{statusMessage}</p> : null}
       {errorMessage ? <p className="biofield-error">{errorMessage}</p> : null}
+
+      {!isLoading && readings.length > 0 ? (
+        <section className="biofield-panel biofield-form-panel">
+          <p className="biofield-eyebrow">Create baseline</p>
+          <form className="biofield-form" onSubmit={handleCreateBaseline}>
+            <label className="biofield-field" htmlFor="biofield-baseline-name">
+              <span className="biofield-kicker">Baseline name</span>
+              <input
+                className="biofield-input"
+                id="biofield-baseline-name"
+                onChange={(event) => setBaselineName(event.target.value)}
+                placeholder="Morning baseline"
+                required
+                value={baselineName}
+              />
+            </label>
+            <label className="biofield-field" htmlFor="biofield-baseline-notes">
+              <span className="biofield-kicker">Notes</span>
+              <textarea
+                className="biofield-input biofield-textarea"
+                id="biofield-baseline-notes"
+                onChange={(event) => setBaselineNotes(event.target.value)}
+                placeholder="Optional reflection about why these readings belong together"
+                value={baselineNotes}
+              />
+            </label>
+            <div className="biofield-actions">
+              <button
+                className="biofield-button"
+                disabled={isCreatingBaseline || selectedReadingIds.length === 0 || baselineName.trim().length === 0}
+                type="submit"
+              >
+                {isCreatingBaseline ? "Creating baseline…" : "Create baseline from selection"}
+              </button>
+            </div>
+          </form>
+        </section>
+      ) : null}
 
       {isLoading ? (
         <section className="biofield-panel">
           <p className="biofield-eyebrow">Loading</p>
-          <p className="biofield-copy">Fetching your persisted biofield readings…</p>
+          <p className="biofield-copy">Fetching your persisted biofield readings and baselines…</p>
         </section>
       ) : null}
 
@@ -217,51 +312,74 @@ export function BiofieldHistoryPage() {
         </section>
       ) : null}
 
+      {!isLoading && baselines.length > 0 ? (
+        <section className="biofield-panel biofield-form-panel">
+          <p className="biofield-eyebrow">Existing baselines</p>
+          <div className="biofield-list-grid">
+            {baselines.map((baseline) => (
+              <div className="biofield-list-card" key={baseline.baseline_id}>
+                <p className="biofield-kicker">{baseline.name}</p>
+                <p className="biofield-copy">{baseline.notes ?? "No notes"}</p>
+                <p className="biofield-copy">{baseline.reading_count} readings</p>
+                <p className="biofield-copy biofield-mono">{baseline.baseline_id}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
       {!isLoading && readings.length > 0 ? (
         <section className="biofield-panel biofield-form-panel">
           <ul className="biofield-list">
-            {readings.map((reading) => (
-              <li key={reading.reading_id}>
-                <div className="biofield-toolbar">
-                  <div>
-                    <p className="biofield-kicker">{formatTimestamp(reading.created_at)}</p>
-                    <p className="biofield-metric">
-                      {reading.quality.sufficient_quality ? "Accepted capture" : "Rejected capture"}
-                    </p>
-                    <p className="biofield-copy">
-                      Reading <span className="biofield-mono">{reading.reading_id}</span>
-                    </p>
+            {readings.map((reading) => {
+              const selected = selectedReadingIds.includes(reading.reading_id);
+              return (
+                <li key={reading.reading_id}>
+                  <div className="biofield-toolbar">
+                    <div>
+                      <p className="biofield-kicker">{formatTimestamp(reading.created_at)}</p>
+                      <p className="biofield-metric">
+                        {reading.quality.sufficient_quality ? "Accepted capture" : "Rejected capture"}
+                      </p>
+                      <p className="biofield-copy">
+                        Reading <span className="biofield-mono">{reading.reading_id}</span>
+                      </p>
+                    </div>
+                    <div className="biofield-actions">
+                      <label className="biofield-checkbox-row">
+                        <input
+                          checked={selected}
+                          className="biofield-checkbox"
+                          onChange={() => toggleReadingSelection(reading.reading_id)}
+                          type="checkbox"
+                        />
+                        <span>{selected ? "Selected" : "Select for baseline"}</span>
+                      </label>
+                      <Link className="biofield-link" href={`/readings/${reading.reading_id}`}>
+                        Open detail
+                      </Link>
+                    </div>
                   </div>
-                  <div className="biofield-actions">
-                    <span
-                      className={`biofield-status-pill${reading.quality.sufficient_quality ? " biofield-status-pill-good" : " biofield-status-pill-warn"}`}
-                    >
-                      {reading.quality.sufficient_quality ? "quality ok" : "quality failed"}
-                    </span>
-                    <Link className="biofield-link" href={`/readings/${reading.reading_id}`}>
-                      Open detail
-                    </Link>
-                  </div>
-                </div>
 
-                <div className="biofield-meta-grid">
-                  <div className="biofield-list-card">
-                    <p className="biofield-kicker">Session</p>
-                    <p className="biofield-copy biofield-mono">{reading.session_id}</p>
+                  <div className="biofield-meta-grid">
+                    <div className="biofield-list-card">
+                      <p className="biofield-kicker">Session</p>
+                      <p className="biofield-copy biofield-mono">{reading.session_id}</p>
+                    </div>
+                    <div className="biofield-list-card">
+                      <p className="biofield-kicker">Artifact</p>
+                      <p className="biofield-copy">{reading.artifact.mime_type}</p>
+                    </div>
+                    <div className="biofield-list-card">
+                      <p className="biofield-kicker">Storage path</p>
+                      <p className="biofield-copy biofield-mono">
+                        {reading.artifact.storage_path ?? "Not yet linked"}
+                      </p>
+                    </div>
                   </div>
-                  <div className="biofield-list-card">
-                    <p className="biofield-kicker">Artifact</p>
-                    <p className="biofield-copy">{reading.artifact.mime_type}</p>
-                  </div>
-                  <div className="biofield-list-card">
-                    <p className="biofield-kicker">Storage path</p>
-                    <p className="biofield-copy biofield-mono">
-                      {reading.artifact.storage_path ?? "Not yet linked"}
-                    </p>
-                  </div>
-                </div>
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         </section>
       ) : null}

--- a/apps/biofield-web/src/components/biofield-reading-detail-page.tsx
+++ b/apps/biofield-web/src/components/biofield-reading-detail-page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
-import type { BiofieldReadingDetail } from "@selemene/biofield-domain";
+import type { BiofieldReadingDetail, BiofieldReprocessResult } from "@selemene/biofield-domain";
 import { BiofieldClientError } from "@selemene/biofield-api-client";
 import {
   clearStoredAuthSession,
@@ -67,7 +67,10 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
     () => null,
   );
   const [reading, setReading] = useState<BiofieldReadingDetail | null>(null);
+  const [reprocessResult, setReprocessResult] = useState<BiofieldReprocessResult | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isReprocessing, setIsReprocessing] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
@@ -119,6 +122,30 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
     void loadReading();
   }, [authSession, client, loadReading]);
 
+  async function handleReprocess() {
+    if (!client) {
+      return;
+    }
+
+    setIsReprocessing(true);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      const response = await client.reprocessReading(readingId);
+      setReprocessResult(response);
+      setStatusMessage(`Reprocessed into reading ${response.reading_id}.`);
+    } catch (error) {
+      if (error instanceof BiofieldClientError && error.status === 401) {
+        handleAuthFailure();
+        return;
+      }
+      setErrorMessage(getErrorMessage(error, "Failed to reprocess biofield reading."));
+    } finally {
+      setIsReprocessing(false);
+    }
+  }
+
   const metrics = useMemo(() => {
     if (!reading || !isRecord(reading.result)) {
       return [] as Array<{ key: string; value: unknown }>;
@@ -158,7 +185,7 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
       <section className="biofield-panel biofield-form-panel">
         <div className="biofield-toolbar">
           <div>
-            <p className="biofield-eyebrow">BF1-07 detail</p>
+            <p className="biofield-eyebrow">BF2 detail and reprocess</p>
             <h2 className="biofield-title" style={{ fontSize: "2rem" }}>
               {analysisVersion ?? "Biofield reading detail"}
             </h2>
@@ -170,6 +197,9 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
             <button className="biofield-link" onClick={() => void loadReading()} type="button">
               Refresh
             </button>
+            <button className="biofield-button" disabled={isReprocessing} onClick={handleReprocess} type="button">
+              {isReprocessing ? "Reprocessing…" : "Reprocess reading"}
+            </button>
             <Link className="biofield-link" href="/history">
               Back to history
             </Link>
@@ -177,7 +207,19 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
         </div>
       </section>
 
+      {statusMessage ? <p className="biofield-success">{statusMessage}</p> : null}
       {errorMessage ? <p className="biofield-error">{errorMessage}</p> : null}
+
+      {reprocessResult ? (
+        <section className="biofield-panel biofield-form-panel">
+          <p className="biofield-eyebrow">Latest reprocess</p>
+          <div className="biofield-actions">
+            <Link className="biofield-link" href={`/readings/${reprocessResult.reading_id}`}>
+              Open reprocessed reading
+            </Link>
+          </div>
+        </section>
+      ) : null}
 
       {isLoading ? (
         <section className="biofield-panel">

--- a/crates/noesis-api/src/config.rs
+++ b/crates/noesis-api/src/config.rs
@@ -8,6 +8,7 @@ use std::env;
 
 pub const DEFAULT_PYTHON_BIOFIELD_URL: &str = "http://localhost:8002";
 pub const DEFAULT_PYTHON_BIOFIELD_TIMEOUT_MS: u64 = 10_000;
+pub const DEFAULT_BIOFIELD_ARTIFACTS_DIR: &str = ".runtime/biofield-artifacts";
 
 /// API server configuration loaded from environment variables
 #[derive(Debug, Clone)]

--- a/crates/noesis-api/src/handlers/biofield.rs
+++ b/crates/noesis-api/src/handlers/biofield.rs
@@ -11,9 +11,9 @@ use noesis_bridge::BridgeError;
 use noesis_data::{
     models::{
         biofield::{
-            BiofieldCaptureArtifact, BiofieldSession, NewBiofieldCaptureArtifact,
-            NewBiofieldSession, BIOFIELD_CAPTURE_ARTIFACT_SOURCE_IMAGE,
-            BIOFIELD_SESSION_STATUS_ACTIVE,
+            BiofieldBaselineSummaryRecord, BiofieldCaptureArtifact, BiofieldSession,
+            NewBiofieldBaseline, NewBiofieldCaptureArtifact, NewBiofieldSession,
+            BIOFIELD_CAPTURE_ARTIFACT_SOURCE_IMAGE, BIOFIELD_SESSION_STATUS_ACTIVE,
         },
         reading::{NewReading, Reading},
     },
@@ -24,7 +24,8 @@ use noesis_data::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
+use tokio::fs as tokio_fs;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -48,6 +49,20 @@ pub struct CloseBiofieldSessionRequest {
 pub struct ListBiofieldReadingsQuery {
     pub limit: Option<u32>,
     pub offset: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, Default, ToSchema)]
+pub struct ReprocessBiofieldReadingRequest {
+    pub algorithms: Option<Vec<String>>,
+    #[schema(value_type = Object)]
+    pub options: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateBiofieldBaselineRequest {
+    pub name: String,
+    pub notes: Option<String>,
+    pub reading_ids: Vec<String>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -87,6 +102,19 @@ pub struct BiofieldCaptureResponse {
 }
 
 #[derive(Debug, Serialize, ToSchema)]
+pub struct BiofieldReprocessResponse {
+    pub source_reading_id: String,
+    pub reading_id: String,
+    pub session_id: String,
+    pub analysis_version: String,
+    #[schema(value_type = Object)]
+    pub metrics: serde_json::Value,
+    #[schema(value_type = Object)]
+    pub quality_assessment: serde_json::Value,
+    pub artifacts: Vec<BiofieldArtifactSummary>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
 pub struct BiofieldReadingSummary {
     pub reading_id: String,
     pub session_id: String,
@@ -101,6 +129,21 @@ pub struct ListBiofieldReadingsResponse {
     pub items: Vec<BiofieldReadingSummary>,
     pub limit: u32,
     pub offset: u32,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BiofieldBaselineSummary {
+    pub baseline_id: String,
+    pub name: String,
+    pub notes: Option<String>,
+    pub reading_count: u32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListBiofieldBaselinesResponse {
+    pub items: Vec<BiofieldBaselineSummary>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -231,6 +274,44 @@ fn missing_reading_session_link_response(reading_id: Uuid) -> Response {
         "Biofield reading is missing session linkage",
         "BIOFIELD_DB_ERROR",
         Some(serde_json::json!({ "reading_id": reading_id })),
+    )
+}
+
+fn artifact_not_found_response(reading_id: &str) -> Response {
+    json_error_response(
+        StatusCode::NOT_FOUND,
+        "Biofield source artifact not found",
+        "BIOFIELD_ARTIFACT_NOT_FOUND",
+        Some(serde_json::json!({ "reading_id": reading_id })),
+    )
+}
+
+fn baseline_invalid_response(message: impl Into<String>, details: Option<Value>) -> Response {
+    json_error_response(
+        StatusCode::UNPROCESSABLE_ENTITY,
+        message,
+        "BIOFIELD_BASELINE_INVALID",
+        details,
+    )
+}
+
+fn biofield_storage_error_response(
+    action: &str,
+    storage_path: &str,
+    error: &std::io::Error,
+) -> Response {
+    tracing::error!(
+        storage_path = storage_path,
+        "biofield storage error during {action}: {error}"
+    );
+    json_error_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        format!("Failed to {action}"),
+        "BIOFIELD_STORAGE_ERROR",
+        Some(serde_json::json!({
+            "action": action,
+            "storage_path": storage_path,
+        })),
     )
 }
 
@@ -666,6 +747,28 @@ fn build_source_artifact_storage_path(
     )
 }
 
+fn build_biofield_artifacts_root() -> PathBuf {
+    std::env::var("BIOFIELD_ARTIFACTS_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(config::DEFAULT_BIOFIELD_ARTIFACTS_DIR))
+}
+
+fn resolve_artifact_file_path(storage_path: &str) -> PathBuf {
+    build_biofield_artifacts_root().join(storage_path)
+}
+
+async fn persist_artifact_bytes(storage_path: &str, bytes: &[u8]) -> Result<(), std::io::Error> {
+    let absolute_path = resolve_artifact_file_path(storage_path);
+    if let Some(parent) = absolute_path.parent() {
+        tokio_fs::create_dir_all(parent).await?;
+    }
+    tokio_fs::write(absolute_path, bytes).await
+}
+
+async fn load_artifact_bytes(storage_path: &str) -> Result<Vec<u8>, std::io::Error> {
+    tokio_fs::read(resolve_artifact_file_path(storage_path)).await
+}
+
 fn build_artifact_capture_metadata(
     parsed_capture: &ParsedBiofieldCapture,
     content_type: &str,
@@ -685,22 +788,42 @@ async fn create_source_artifact(
     parsed_capture: &ParsedBiofieldCapture,
     content_type: &str,
     image_bytes: &[u8],
-) -> Result<BiofieldCaptureArtifact, sqlx::Error> {
-    biofield_repository
+) -> Result<BiofieldCaptureArtifact, Response> {
+    let storage_path = build_source_artifact_storage_path(
+        session.id,
+        parsed_capture.image_file_name.as_deref(),
+        content_type,
+    );
+
+    if let Err(error) = persist_artifact_bytes(&storage_path, image_bytes).await {
+        return Err(biofield_storage_error_response(
+            "persist biofield source artifact bytes",
+            &storage_path,
+            &error,
+        ));
+    }
+
+    match biofield_repository
         .create_artifact(&NewBiofieldCaptureArtifact {
             session_id: session.id,
             reading_id: None,
             artifact_kind: BIOFIELD_CAPTURE_ARTIFACT_SOURCE_IMAGE.to_string(),
-            storage_path: build_source_artifact_storage_path(
-                session.id,
-                parsed_capture.image_file_name.as_deref(),
-                content_type,
-            ),
+            storage_path: storage_path.clone(),
             mime_type: content_type.to_string(),
             byte_size: image_bytes.len() as i64,
             capture_metadata: build_artifact_capture_metadata(parsed_capture, content_type),
         })
         .await
+    {
+        Ok(artifact) => Ok(artifact),
+        Err(error) => {
+            let _ = tokio_fs::remove_file(resolve_artifact_file_path(&storage_path)).await;
+            Err(biofield_db_error_response(
+                "persist biofield capture artifact",
+                &error,
+            ))
+        }
+    }
 }
 
 async fn link_source_artifact_to_reading(
@@ -745,6 +868,267 @@ fn build_capture_response(
         metrics,
         quality_assessment,
         artifacts,
+    }
+}
+
+fn build_reprocess_response(
+    source_reading_id: Uuid,
+    reading_id: Uuid,
+    session_id: Uuid,
+    analysis_version: &str,
+    metrics: Value,
+    quality_assessment: Value,
+    artifacts: Vec<BiofieldArtifactSummary>,
+) -> BiofieldReprocessResponse {
+    BiofieldReprocessResponse {
+        source_reading_id: source_reading_id.to_string(),
+        reading_id: reading_id.to_string(),
+        session_id: session_id.to_string(),
+        analysis_version: analysis_version.to_string(),
+        metrics,
+        quality_assessment,
+        artifacts,
+    }
+}
+
+fn extract_analysis_payload(sidecar_response: &Value) -> Result<(String, Value, Value), Response> {
+    let analysis_version = match sidecar_response
+        .get("analysis_version")
+        .and_then(|value| value.as_str())
+    {
+        Some(analysis_version) => analysis_version.to_string(),
+        None => {
+            return Err(biofield_analysis_unavailable_response(Some(
+                serde_json::json!({
+                    "reason": "missing analysis_version in sidecar response",
+                }),
+            )))
+        }
+    };
+
+    let metrics = match sidecar_response.get("metrics").cloned() {
+        Some(metrics) => metrics,
+        None => {
+            return Err(biofield_analysis_unavailable_response(Some(
+                serde_json::json!({
+                    "reason": "missing metrics in sidecar response",
+                }),
+            )))
+        }
+    };
+
+    let quality_assessment = match sidecar_response.get("quality_assessment").cloned() {
+        Some(quality_assessment) => quality_assessment,
+        None => {
+            return Err(biofield_analysis_unavailable_response(Some(
+                serde_json::json!({
+                    "reason": "missing quality_assessment in sidecar response",
+                }),
+            )))
+        }
+    };
+
+    let sufficient_quality = match quality_assessment
+        .get("sufficient_quality")
+        .and_then(|value| value.as_bool())
+    {
+        Some(sufficient_quality) => sufficient_quality,
+        None => {
+            return Err(biofield_analysis_unavailable_response(Some(
+                serde_json::json!({
+                    "reason": "missing sufficient_quality in sidecar response",
+                }),
+            )))
+        }
+    };
+
+    if !sufficient_quality {
+        return Err(capture_rejected_quality_response(
+            "Biofield capture rejected for insufficient quality",
+            quality_assessment,
+            Some(&analysis_version),
+        ));
+    }
+
+    Ok((analysis_version, metrics, quality_assessment))
+}
+
+fn reading_algorithms(reading: &Reading) -> Option<Vec<String>> {
+    reading
+        .input_data
+        .get("algorithms")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .filter(|items| !items.is_empty())
+}
+
+fn reading_options(reading: &Reading) -> Option<Value> {
+    reading
+        .input_data
+        .get("options")
+        .filter(|value| value.is_object())
+        .cloned()
+}
+
+fn source_artifact_for_reading<'a>(
+    artifacts: &'a [BiofieldCaptureArtifact],
+) -> Option<&'a BiofieldCaptureArtifact> {
+    artifacts
+        .iter()
+        .find(|artifact| artifact.artifact_kind == BIOFIELD_CAPTURE_ARTIFACT_SOURCE_IMAGE)
+        .or_else(|| artifacts.first())
+}
+
+fn parsed_capture_from_artifact(
+    source_artifact: &BiofieldCaptureArtifact,
+    source_reading: &Reading,
+) -> ParsedBiofieldCapture {
+    let file_name = source_artifact
+        .capture_metadata
+        .get("file_name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            source_reading
+                .input_data
+                .get("file_name")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        });
+
+    let capture_metadata = source_artifact
+        .capture_metadata
+        .get("capture_metadata")
+        .filter(|value| value.is_object())
+        .cloned();
+
+    ParsedBiofieldCapture {
+        image_bytes: None,
+        image_content_type: Some(source_artifact.mime_type.clone()),
+        image_file_name: file_name,
+        algorithms: reading_algorithms(source_reading),
+        options: reading_options(source_reading),
+        capture_metadata,
+    }
+}
+
+fn build_reprocess_input_data(
+    source_reading_id: Uuid,
+    session_id: Uuid,
+    source_artifact: &BiofieldCaptureArtifact,
+    parsed_capture: &ParsedBiofieldCapture,
+) -> Value {
+    serde_json::json!({
+        "session_id": session_id,
+        "file_name": parsed_capture.image_file_name,
+        "content_type": source_artifact.mime_type,
+        "algorithms": parsed_capture.algorithms,
+        "options": parsed_capture.options,
+        "capture_metadata": parsed_capture.capture_metadata,
+        "reprocessed_from_reading_id": source_reading_id,
+        "source_storage_path": source_artifact.storage_path,
+    })
+}
+
+async fn save_reprocessed_reading(
+    readings_repository: &ReadingsRepository,
+    auth_user: &AuthUser,
+    user_id: Uuid,
+    session: &BiofieldSession,
+    parsed_capture: &ParsedBiofieldCapture,
+    source_reading_id: Uuid,
+    source_artifact: &BiofieldCaptureArtifact,
+    sidecar_response: &Value,
+    image_bytes: &[u8],
+) -> Result<Uuid, sqlx::Error> {
+    let input_hash = create_input_hash(
+        session.id,
+        image_bytes,
+        &source_artifact.mime_type,
+        parsed_capture.algorithms.as_ref(),
+        parsed_capture.options.as_ref(),
+        parsed_capture.capture_metadata.as_ref(),
+    );
+
+    let processing_time_ms = sidecar_response
+        .get("processing_time_ms")
+        .and_then(|value| value.as_f64());
+
+    let device_platform = parsed_capture
+        .capture_metadata
+        .as_ref()
+        .and_then(|value| value.get("platform"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+
+    readings_repository
+        .save_reading(&NewReading {
+            user_id,
+            engine_id: BIOFIELD_ENGINE_ID.to_string(),
+            workflow_id: None,
+            input_hash,
+            input_data: build_reprocess_input_data(
+                source_reading_id,
+                session.id,
+                source_artifact,
+                parsed_capture,
+            ),
+            result_data: sidecar_response.clone(),
+            witness_prompt: None,
+            consciousness_level: auth_user.consciousness_level as i16,
+            calculation_time_ms: processing_time_ms,
+            client_event_id: None,
+            client_device_id: session.client_device_id.clone(),
+            device_platform,
+            device_app_version: session.viewer_version.clone(),
+        })
+        .await
+}
+
+fn normalize_baseline_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn normalize_baseline_notes(raw: Option<&str>) -> Option<String> {
+    raw.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn dedupe_preserve_order(items: &[String]) -> Vec<String> {
+    let mut values: Vec<String> = Vec::new();
+    for item in items {
+        if !values.iter().any(|existing| existing == item) {
+            values.push(item.clone());
+        }
+    }
+    values
+}
+
+fn baseline_summary_from_record(record: &BiofieldBaselineSummaryRecord) -> BiofieldBaselineSummary {
+    BiofieldBaselineSummary {
+        baseline_id: record.id.to_string(),
+        name: record.name.clone(),
+        notes: record.notes.clone(),
+        reading_count: record.reading_count.max(0) as u32,
+        created_at: record.created_at,
+        updated_at: record.updated_at,
     }
 }
 
@@ -1050,9 +1434,7 @@ pub async fn create_capture(
     .await
     {
         Ok(artifact) => artifact,
-        Err(error) => {
-            return biofield_db_error_response("persist biofield capture artifact", &error)
-        }
+        Err(response) => return response,
     };
 
     let sidecar_client = build_biofield_client_from_env();
@@ -1069,55 +1451,11 @@ pub async fn create_capture(
         Err(error) => return map_bridge_error(error),
     };
 
-    let analysis_version = match sidecar_response
-        .get("analysis_version")
-        .and_then(|value| value.as_str())
-    {
-        Some(analysis_version) => analysis_version,
-        None => {
-            return biofield_analysis_unavailable_response(Some(serde_json::json!({
-                "reason": "missing analysis_version in sidecar response",
-            })))
-        }
-    };
-
-    let metrics = match sidecar_response.get("metrics").cloned() {
-        Some(metrics) => metrics,
-        None => {
-            return biofield_analysis_unavailable_response(Some(serde_json::json!({
-                "reason": "missing metrics in sidecar response",
-            })))
-        }
-    };
-
-    let quality_assessment = match sidecar_response.get("quality_assessment").cloned() {
-        Some(quality_assessment) => quality_assessment,
-        None => {
-            return biofield_analysis_unavailable_response(Some(serde_json::json!({
-                "reason": "missing quality_assessment in sidecar response",
-            })))
-        }
-    };
-
-    let sufficient_quality = match quality_assessment
-        .get("sufficient_quality")
-        .and_then(|value| value.as_bool())
-    {
-        Some(sufficient_quality) => sufficient_quality,
-        None => {
-            return biofield_analysis_unavailable_response(Some(serde_json::json!({
-                "reason": "missing sufficient_quality in sidecar response",
-            })))
-        }
-    };
-
-    if !sufficient_quality {
-        return capture_rejected_quality_response(
-            "Biofield capture rejected for insufficient quality",
-            quality_assessment,
-            Some(analysis_version),
-        );
-    }
+    let (analysis_version, metrics, quality_assessment) =
+        match extract_analysis_payload(&sidecar_response) {
+            Ok(payload) => payload,
+            Err(response) => return response,
+        };
 
     let reading_id = match save_capture_reading(
         readings_repository,
@@ -1152,7 +1490,7 @@ pub async fn create_capture(
     let response = build_capture_response(
         reading_id,
         session.id,
-        analysis_version,
+        &analysis_version,
         metrics,
         quality_assessment,
         vec![artifact_to_summary(&linked_artifact)],
@@ -1307,4 +1645,317 @@ pub async fn get_reading(
     };
 
     (StatusCode::OK, Json(response)).into_response()
+}
+
+/// POST /api/v1/biofield/readings/:reading_id/reprocess
+#[utoipa::path(
+    post,
+    path = "/api/v1/biofield/readings/{reading_id}/reprocess",
+    tag = "biofield",
+    params(
+        ("reading_id" = String, Path, description = "Biofield reading identifier")
+    ),
+    request_body = ReprocessBiofieldReadingRequest,
+    responses(
+        (status = 201, description = "Biofield reading reprocessed", body = BiofieldReprocessResponse),
+        (status = 401, description = "Unauthorized", body = crate::ErrorResponse),
+        (status = 404, description = "Reading or source artifact not found", body = crate::ErrorResponse),
+        (status = 422, description = "Invalid reading identifier or rejected reprocess", body = crate::ErrorResponse),
+        (status = 503, description = "Biofield dependencies unavailable", body = crate::ErrorResponse),
+        (status = 500, description = "Internal biofield persistence or storage error", body = crate::ErrorResponse),
+    ),
+    security(
+        ("bearer_auth" = []),
+        ("api_key" = [])
+    )
+)]
+pub async fn reprocess_reading(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Path(reading_id): Path<String>,
+    Json(request): Json<ReprocessBiofieldReadingRequest>,
+) -> Response {
+    let Some(readings_repository) = state.readings_repository.as_ref() else {
+        return biofield_db_unavailable_response();
+    };
+    let Some(biofield_repository) = state.biofield_repository.as_ref() else {
+        return biofield_db_unavailable_response();
+    };
+
+    let user_id = match parse_auth_user_uuid(&auth_user) {
+        Ok(user_id) => user_id,
+        Err(response) => return response,
+    };
+
+    let reading_uuid = match parse_uuid_or_422(&reading_id, "reading_id") {
+        Ok(reading_uuid) => reading_uuid,
+        Err(response) => return response,
+    };
+
+    let source_reading = match readings_repository.get_reading(reading_uuid, user_id).await {
+        Ok(Some(reading)) if reading.engine_id == BIOFIELD_ENGINE_ID => reading,
+        Ok(Some(_)) | Ok(None) => return reading_not_found_response(&reading_id),
+        Err(error) => return biofield_db_error_response("fetch biofield reading", &error),
+    };
+
+    let artifacts = match biofield_repository
+        .list_reading_artifacts(reading_uuid, user_id)
+        .await
+    {
+        Ok(artifacts) => artifacts,
+        Err(error) => {
+            return biofield_db_error_response("fetch biofield reading artifacts", &error)
+        }
+    };
+
+    let Some(source_artifact) = source_artifact_for_reading(&artifacts) else {
+        return artifact_not_found_response(&reading_id);
+    };
+
+    let image_bytes = match load_artifact_bytes(&source_artifact.storage_path).await {
+        Ok(image_bytes) => image_bytes,
+        Err(error) => {
+            return biofield_storage_error_response(
+                "load biofield source artifact bytes",
+                &source_artifact.storage_path,
+                &error,
+            )
+        }
+    };
+
+    let session = match biofield_repository
+        .get_session(source_artifact.session_id, user_id)
+        .await
+    {
+        Ok(Some(session)) => session,
+        Ok(None) => return missing_reading_session_link_response(reading_uuid),
+        Err(error) => return biofield_db_error_response("fetch biofield session", &error),
+    };
+
+    let mut parsed_capture = parsed_capture_from_artifact(source_artifact, &source_reading);
+    if request.algorithms.is_some() {
+        parsed_capture.algorithms = request.algorithms.clone();
+    }
+    if request.options.is_some() {
+        parsed_capture.options = request.options.clone();
+    }
+
+    let sidecar_client = build_biofield_client_from_env();
+    let sidecar_response = match sidecar_client
+        .analyze_capture(BiofieldAnalyzeRequest {
+            image_data: image_bytes.clone(),
+            content_type: source_artifact.mime_type.clone(),
+            algorithms: parsed_capture.algorithms.clone(),
+            options: parsed_capture.options.clone(),
+        })
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => return map_bridge_error(error),
+    };
+
+    let (analysis_version, metrics, quality_assessment) =
+        match extract_analysis_payload(&sidecar_response) {
+            Ok(payload) => payload,
+            Err(response) => return response,
+        };
+
+    let reprocessed_reading_id = match save_reprocessed_reading(
+        readings_repository,
+        &auth_user,
+        user_id,
+        &session,
+        &parsed_capture,
+        reading_uuid,
+        source_artifact,
+        &sidecar_response,
+        &image_bytes,
+    )
+    .await
+    {
+        Ok(reading_id) => reading_id,
+        Err(error) => {
+            return biofield_db_error_response("persist reprocessed biofield reading", &error)
+        }
+    };
+
+    let reprocessed_artifact = match create_source_artifact(
+        biofield_repository,
+        &session,
+        &parsed_capture,
+        &source_artifact.mime_type,
+        &image_bytes,
+    )
+    .await
+    {
+        Ok(artifact) => artifact,
+        Err(response) => return response,
+    };
+
+    let linked_artifact = match link_source_artifact_to_reading(
+        biofield_repository,
+        &reprocessed_artifact,
+        reprocessed_reading_id,
+        user_id,
+    )
+    .await
+    {
+        Ok(artifact) => artifact,
+        Err(response) => return response,
+    };
+
+    (
+        StatusCode::CREATED,
+        Json(build_reprocess_response(
+            reading_uuid,
+            reprocessed_reading_id,
+            session.id,
+            &analysis_version,
+            metrics,
+            quality_assessment,
+            vec![artifact_to_summary(&linked_artifact)],
+        )),
+    )
+        .into_response()
+}
+
+/// GET /api/v1/biofield/baselines
+#[utoipa::path(
+    get,
+    path = "/api/v1/biofield/baselines",
+    tag = "biofield",
+    responses(
+        (status = 200, description = "Biofield baselines listed", body = ListBiofieldBaselinesResponse),
+        (status = 401, description = "Unauthorized", body = crate::ErrorResponse),
+        (status = 503, description = "Biofield DB unavailable", body = crate::ErrorResponse),
+        (status = 500, description = "Internal biofield persistence error", body = crate::ErrorResponse),
+    ),
+    security(
+        ("bearer_auth" = []),
+        ("api_key" = [])
+    )
+)]
+pub async fn list_baselines(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+) -> Response {
+    let Some(biofield_repository) = state.biofield_repository.as_ref() else {
+        return biofield_db_unavailable_response();
+    };
+
+    let user_id = match parse_auth_user_uuid(&auth_user) {
+        Ok(user_id) => user_id,
+        Err(response) => return response,
+    };
+
+    let records = match biofield_repository.list_baselines(user_id).await {
+        Ok(records) => records,
+        Err(error) => return biofield_db_error_response("list biofield baselines", &error),
+    };
+
+    (
+        StatusCode::OK,
+        Json(ListBiofieldBaselinesResponse {
+            items: records
+                .iter()
+                .map(baseline_summary_from_record)
+                .collect::<Vec<_>>(),
+        }),
+    )
+        .into_response()
+}
+
+/// POST /api/v1/biofield/baselines
+#[utoipa::path(
+    post,
+    path = "/api/v1/biofield/baselines",
+    tag = "biofield",
+    request_body = CreateBiofieldBaselineRequest,
+    responses(
+        (status = 201, description = "Biofield baseline created", body = BiofieldBaselineSummary),
+        (status = 401, description = "Unauthorized", body = crate::ErrorResponse),
+        (status = 404, description = "Reading not found", body = crate::ErrorResponse),
+        (status = 422, description = "Invalid baseline request", body = crate::ErrorResponse),
+        (status = 503, description = "Biofield DB unavailable", body = crate::ErrorResponse),
+        (status = 500, description = "Internal biofield persistence error", body = crate::ErrorResponse),
+    ),
+    security(
+        ("bearer_auth" = []),
+        ("api_key" = [])
+    )
+)]
+pub async fn create_baseline(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Json(request): Json<CreateBiofieldBaselineRequest>,
+) -> Response {
+    let Some(readings_repository) = state.readings_repository.as_ref() else {
+        return biofield_db_unavailable_response();
+    };
+    let Some(biofield_repository) = state.biofield_repository.as_ref() else {
+        return biofield_db_unavailable_response();
+    };
+
+    let user_id = match parse_auth_user_uuid(&auth_user) {
+        Ok(user_id) => user_id,
+        Err(response) => return response,
+    };
+
+    let Some(name) = normalize_baseline_name(&request.name) else {
+        return baseline_invalid_response("Baseline name is required", None);
+    };
+
+    let reading_id_values = dedupe_preserve_order(&request.reading_ids);
+    if reading_id_values.is_empty() {
+        return baseline_invalid_response(
+            "Baseline must include at least one biofield reading",
+            None,
+        );
+    }
+
+    let mut reading_uuids = Vec::with_capacity(reading_id_values.len());
+    for reading_id in &reading_id_values {
+        let reading_uuid = match parse_uuid_or_422(reading_id, "reading_ids") {
+            Ok(reading_uuid) => reading_uuid,
+            Err(response) => return response,
+        };
+
+        let reading = match readings_repository.get_reading(reading_uuid, user_id).await {
+            Ok(Some(reading)) if reading.engine_id == BIOFIELD_ENGINE_ID => reading,
+            Ok(Some(_)) | Ok(None) => return reading_not_found_response(reading_id),
+            Err(error) => return biofield_db_error_response("fetch baseline reading", &error),
+        };
+        if reading.engine_id != BIOFIELD_ENGINE_ID {
+            return reading_not_found_response(reading_id);
+        }
+        reading_uuids.push(reading_uuid);
+    }
+
+    let baseline = match biofield_repository
+        .create_baseline(
+            &NewBiofieldBaseline {
+                user_id,
+                name,
+                notes: normalize_baseline_notes(request.notes.as_deref()),
+            },
+            &reading_uuids,
+        )
+        .await
+    {
+        Ok(baseline) => baseline,
+        Err(error) => return biofield_db_error_response("create biofield baseline", &error),
+    };
+
+    (
+        StatusCode::CREATED,
+        Json(BiofieldBaselineSummary {
+            baseline_id: baseline.id.to_string(),
+            name: baseline.name,
+            notes: baseline.notes,
+            reading_count: reading_uuids.len() as u32,
+            created_at: baseline.created_at,
+            updated_at: baseline.updated_at,
+        }),
+    )
+        .into_response()
 }

--- a/crates/noesis-api/src/lib.rs
+++ b/crates/noesis-api/src/lib.rs
@@ -4,8 +4,8 @@
 //! All engine calculations and workflow executions are exposed through versioned
 //! JSON endpoints under `/api/v1/`.
 
-mod biofield_client;
 mod billing;
+mod biofield_client;
 mod config;
 pub mod error;
 pub mod error_mapper;
@@ -33,8 +33,11 @@ use axum::{
     routing::{delete, get, patch, post, put},
     Extension, Router,
 };
-use chrono::{Datelike, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike};
+use chrono::{
+    Datelike, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike,
+};
 use chrono_tz::Tz;
+use engine_human_design::ephemeris::{EphemerisCalculator, HDPlanet};
 use noesis_auth::{AuthService, AuthUser};
 use noesis_cache::CacheManager;
 use noesis_core::{
@@ -53,7 +56,6 @@ use noesis_data::repositories::usage_repository::UsageRepository;
 use noesis_data::repositories::user_repository::UserRepository;
 use noesis_metrics::NoesisMetrics;
 use noesis_orchestrator::WorkflowOrchestrator;
-use engine_human_design::ephemeris::{EphemerisCalculator, HDPlanet};
 use sentry_tower::{NewSentryLayer, SentryHttpLayer};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -132,6 +134,9 @@ use workflow_parity::log_workflow_registry_parity;
         handlers::biofield::create_capture,
         handlers::biofield::list_readings,
         handlers::biofield::get_reading,
+        handlers::biofield::reprocess_reading,
+        handlers::biofield::list_baselines,
+        handlers::biofield::create_baseline,
     ),
     components(
         schemas(
@@ -248,8 +253,13 @@ use workflow_parity::log_workflow_registry_parity;
             handlers::biofield::BiofieldQualitySummary,
             handlers::biofield::BiofieldArtifactSummary,
             handlers::biofield::BiofieldCaptureResponse,
+            handlers::biofield::BiofieldReprocessResponse,
             handlers::biofield::BiofieldReadingSummary,
             handlers::biofield::ListBiofieldReadingsResponse,
+            handlers::biofield::CreateBiofieldBaselineRequest,
+            handlers::biofield::BiofieldBaselineSummary,
+            handlers::biofield::ListBiofieldBaselinesResponse,
+            handlers::biofield::ReprocessBiofieldReadingRequest,
             handlers::biofield::BiofieldReadingDetail,
         )
     ),
@@ -679,6 +689,14 @@ pub fn create_router(state: AppState, config: &ApiConfig) -> Router {
         .route(
             "/biofield/readings/:reading_id",
             get(handlers::biofield::get_reading),
+        )
+        .route(
+            "/biofield/readings/:reading_id/reprocess",
+            post(handlers::biofield::reprocess_reading),
+        )
+        .route(
+            "/biofield/baselines",
+            get(handlers::biofield::list_baselines).post(handlers::biofield::create_baseline),
         )
         .route("/admin/session", get(handlers::admin::get_session))
         .route("/admin/users", get(handlers::admin::list_users))
@@ -1371,32 +1389,64 @@ async fn status_handler(State(state): State<AppState>) -> Json<StatusResponse> {
 // ---------------------------------------------------------------------------
 
 const NAKSHATRA_NAMES: [&str; 27] = [
-    "Ashwini", "Bharani", "Krittika", "Rohini", "Mrigashira", "Ardra", "Punarvasu",
-    "Pushya", "Ashlesha", "Magha", "Purva Phalguni", "Uttara Phalguni", "Hasta",
-    "Chitra", "Swati", "Vishakha", "Anuradha", "Jyeshtha", "Mula", "Purva Ashadha",
-    "Uttara Ashadha", "Shravana", "Dhanishtha", "Shatabhisha", "Purva Bhadrapada",
-    "Uttara Bhadrapada", "Revati",
+    "Ashwini",
+    "Bharani",
+    "Krittika",
+    "Rohini",
+    "Mrigashira",
+    "Ardra",
+    "Punarvasu",
+    "Pushya",
+    "Ashlesha",
+    "Magha",
+    "Purva Phalguni",
+    "Uttara Phalguni",
+    "Hasta",
+    "Chitra",
+    "Swati",
+    "Vishakha",
+    "Anuradha",
+    "Jyeshtha",
+    "Mula",
+    "Purva Ashadha",
+    "Uttara Ashadha",
+    "Shravana",
+    "Dhanishtha",
+    "Shatabhisha",
+    "Purva Bhadrapada",
+    "Uttara Bhadrapada",
+    "Revati",
 ];
 
 const VEDIC_SIGN_NAMES: [&str; 12] = [
-    "aries", "taurus", "gemini", "cancer", "leo", "virgo",
-    "libra", "scorpio", "sagittarius", "capricorn", "aquarius", "pisces",
+    "aries",
+    "taurus",
+    "gemini",
+    "cancer",
+    "leo",
+    "virgo",
+    "libra",
+    "scorpio",
+    "sagittarius",
+    "capricorn",
+    "aquarius",
+    "pisces",
 ];
 
 const VEDIC_SIGN_LORDS: [&str; 12] = [
-    "Mars", "Venus", "Mercury", "Moon", "Sun", "Mercury",
-    "Venus", "Mars", "Jupiter", "Saturn", "Saturn", "Jupiter",
+    "Mars", "Venus", "Mercury", "Moon", "Sun", "Mercury", "Venus", "Mars", "Jupiter", "Saturn",
+    "Saturn", "Jupiter",
 ];
 
 /// 9 classical Vedic planets mapped to their familiar names.
 const VEDIC_PLANETS: &[(HDPlanet, &str)] = &[
-    (HDPlanet::Sun,       "Sun"),
-    (HDPlanet::Moon,      "Moon"),
-    (HDPlanet::Mars,      "Mars"),
-    (HDPlanet::Mercury,   "Mercury"),
-    (HDPlanet::Jupiter,   "Jupiter"),
-    (HDPlanet::Venus,     "Venus"),
-    (HDPlanet::Saturn,    "Saturn"),
+    (HDPlanet::Sun, "Sun"),
+    (HDPlanet::Moon, "Moon"),
+    (HDPlanet::Mars, "Mars"),
+    (HDPlanet::Mercury, "Mercury"),
+    (HDPlanet::Jupiter, "Jupiter"),
+    (HDPlanet::Venus, "Venus"),
+    (HDPlanet::Saturn, "Saturn"),
     (HDPlanet::NorthNode, "Rahu"),
     (HDPlanet::SouthNode, "Ketu"),
 ];
@@ -1417,9 +1467,7 @@ fn jd_from_utc(dt: &chrono::DateTime<chrono::Utc>) -> f64 {
 fn tropical_ascendant(jd: f64, lat: f64, lng: f64) -> f64 {
     let t = (jd - 2451545.0) / 36525.0;
     // GMST in degrees
-    let gmst = (280.460_618_37
-        + 360.985_647_366_29 * (jd - 2451545.0)
-        + 0.000_387_933 * t * t
+    let gmst = (280.460_618_37 + 360.985_647_366_29 * (jd - 2451545.0) + 0.000_387_933 * t * t
         - t * t * t / 38_710_000.0)
         .rem_euclid(360.0);
     let lst = (gmst + lng).rem_euclid(360.0);
@@ -1470,7 +1518,12 @@ fn build_d1_chart(
     let mut moon_sid = 0.0_f64;
 
     for (hd_planet, vedic_name) in VEDIC_PLANETS {
-        let Some((_, pp)) = planet_positions.iter().find(|(p, _)| *p as i32 == *hd_planet as i32) else { continue };
+        let Some((_, pp)) = planet_positions
+            .iter()
+            .find(|(p, _)| *p as i32 == *hd_planet as i32)
+        else {
+            continue;
+        };
         let sid_lon = (pp.longitude - ayanamsa).rem_euclid(360.0);
         let sign_idx = (sid_lon / 30.0) as usize % 12;
         let degree = sid_lon % 30.0;
@@ -1546,7 +1599,10 @@ fn build_d1_chart(
 /// Build a JSON D9 (Navamsa) chart from the D1 chart JSON.
 fn build_d9_chart(birth: &ResolvedBirthDetails, d1: &serde_json::Value) -> serde_json::Value {
     let asc_sign_name = d1["ascendant"]["sign"].as_str().unwrap_or("aries");
-    let asc_sign_idx = VEDIC_SIGN_NAMES.iter().position(|&s| s == asc_sign_name).unwrap_or(0);
+    let asc_sign_idx = VEDIC_SIGN_NAMES
+        .iter()
+        .position(|&s| s == asc_sign_name)
+        .unwrap_or(0);
     let asc_degree = d1["ascendant"]["degree"].as_f64().unwrap_or(0.0);
     let d9_lagna_idx = navamsa_sign_idx(asc_sign_idx, asc_degree);
 
@@ -1558,12 +1614,17 @@ fn build_d9_chart(birth: &ResolvedBirthDetails, d1: &serde_json::Value) -> serde
 
     for planet in planets {
         let name = planet["name"].as_str().unwrap_or("");
-        let d1_sign = VEDIC_SIGN_NAMES.iter().position(|&s| s == planet["sign"].as_str().unwrap_or("")).unwrap_or(0);
+        let d1_sign = VEDIC_SIGN_NAMES
+            .iter()
+            .position(|&s| s == planet["sign"].as_str().unwrap_or(""))
+            .unwrap_or(0);
         let degree = planet["degree"].as_f64().unwrap_or(0.0);
         let d9_sign = navamsa_sign_idx(d1_sign, degree);
         let nav_deg = (degree % (30.0 / 9.0)) * 9.0;
         let is_varg = d1_sign == d9_sign;
-        if is_varg { vargottama.push(name); }
+        if is_varg {
+            vargottama.push(name);
+        }
         navamsa_positions.push(serde_json::json!({
             "planet": name,
             "sign": VEDIC_SIGN_NAMES[d9_sign],
@@ -1608,8 +1669,14 @@ async fn vedic_chart_handler(
     let birth = match resolve_birth_details(&input) {
         Ok(v) => v,
         Err(e) => {
-            state.metrics.record_engine_calculation_with_status(metric_label, "failure", start.elapsed().as_secs_f64());
-            state.metrics.record_engine_calculation_error(metric_label, "validation_error");
+            state.metrics.record_engine_calculation_with_status(
+                metric_label,
+                "failure",
+                start.elapsed().as_secs_f64(),
+            );
+            state
+                .metrics
+                .record_engine_calculation_error(metric_label, "validation_error");
             return Err(e);
         }
     };
@@ -1626,9 +1693,14 @@ async fn vedic_chart_handler(
 
     // Ephemeris calls are synchronous (C library with global mutex); run off the async thread.
     let birth_for_task = ResolvedBirthDetails {
-        year: birth.year, month: birth.month, day: birth.day,
-        hour: birth.hour, minute: birth.minute, second: birth.second,
-        latitude: birth.latitude, longitude: birth.longitude,
+        year: birth.year,
+        month: birth.month,
+        day: birth.day,
+        hour: birth.hour,
+        minute: birth.minute,
+        second: birth.second,
+        latitude: birth.latitude,
+        longitude: birth.longitude,
         timezone_offset_hours: birth.timezone_offset_hours,
     };
 
@@ -1637,7 +1709,8 @@ async fn vedic_chart_handler(
         let jd = jd_from_utc(&utc_dt);
         let ayanamsa = lahiri_ayanamsa(jd);
 
-        let mut positions: Vec<(HDPlanet, engine_human_design::ephemeris::PlanetPosition)> = Vec::new();
+        let mut positions: Vec<(HDPlanet, engine_human_design::ephemeris::PlanetPosition)> =
+            Vec::new();
         for (planet, _) in VEDIC_PLANETS {
             match ephe.get_planet_position(*planet, &utc_dt) {
                 Ok(pos) => positions.push((*planet, pos)),
@@ -1651,18 +1724,47 @@ async fn vedic_chart_handler(
     })
     .await
     .map_err(|_| {
-        state.metrics.record_engine_calculation_with_status(metric_label, "failure", start.elapsed().as_secs_f64());
-        state.metrics.record_engine_calculation_error(metric_label, "task_panic");
-        ErrorMapper::response(StatusCode::INTERNAL_SERVER_ERROR, "CALCULATION_ERROR", "Vedic chart task panicked", None)
+        state.metrics.record_engine_calculation_with_status(
+            metric_label,
+            "failure",
+            start.elapsed().as_secs_f64(),
+        );
+        state
+            .metrics
+            .record_engine_calculation_error(metric_label, "task_panic");
+        ErrorMapper::response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "CALCULATION_ERROR",
+            "Vedic chart task panicked",
+            None,
+        )
     })?
     .map_err(|e| {
-        state.metrics.record_engine_calculation_with_status(metric_label, "failure", start.elapsed().as_secs_f64());
-        state.metrics.record_engine_calculation_error(metric_label, "ephemeris_error");
-        ErrorMapper::response(StatusCode::INTERNAL_SERVER_ERROR, "CALCULATION_ERROR", e, None)
+        state.metrics.record_engine_calculation_with_status(
+            metric_label,
+            "failure",
+            start.elapsed().as_secs_f64(),
+        );
+        state
+            .metrics
+            .record_engine_calculation_error(metric_label, "ephemeris_error");
+        ErrorMapper::response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "CALCULATION_ERROR",
+            e,
+            None,
+        )
     })?;
 
-    state.metrics.record_engine_calculation_with_status(metric_label, "success", start.elapsed().as_secs_f64());
-    Ok(Json(VedicChartBundleResponse { d1: chart_result.0, d9: chart_result.1 }))
+    state.metrics.record_engine_calculation_with_status(
+        metric_label,
+        "success",
+        start.elapsed().as_secs_f64(),
+    );
+    Ok(Json(VedicChartBundleResponse {
+        d1: chart_result.0,
+        d9: chart_result.1,
+    }))
 }
 
 /// POST /api/v1/engines/:engine_id/calculate -- execute a single engine

--- a/crates/noesis-api/tests/biofield_capture_proxy.rs
+++ b/crates/noesis-api/tests/biofield_capture_proxy.rs
@@ -57,6 +57,14 @@ async fn ensure_biofield_schema(pool: &PgPool) {
             SELECT 1
             FROM information_schema.tables
             WHERE table_name = 'biofield_capture_artifacts'
+        ) AND EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_name = 'biofield_baselines'
+        ) AND EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_name = 'biofield_baseline_readings'
         )
         "#,
     )
@@ -74,9 +82,12 @@ async fn ensure_biofield_schema(pool: &PgPool) {
         .await
         .expect("schema lock should succeed");
 
-    let migration_sql =
+    let migration_017 =
         fs::read_to_string(repo_root().join("migrations/017_biofield_sessions.sql"))
             .expect("root migration 017");
+    let migration_018 =
+        fs::read_to_string(repo_root().join("migrations/018_biofield_baselines.sql"))
+            .expect("root migration 018");
 
     let apply_result = async {
         let schema_exists_after_lock: bool = sqlx::query_scalar(
@@ -89,6 +100,14 @@ async fn ensure_biofield_schema(pool: &PgPool) {
                 SELECT 1
                 FROM information_schema.tables
                 WHERE table_name = 'biofield_capture_artifacts'
+            ) AND EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_name = 'biofield_baselines'
+            ) AND EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_name = 'biofield_baseline_readings'
             )
             "#,
         )
@@ -100,10 +119,14 @@ async fn ensure_biofield_schema(pool: &PgPool) {
             return;
         }
 
-        sqlx::raw_sql(&migration_sql)
+        sqlx::raw_sql(&migration_017)
             .execute(pool)
             .await
-            .expect("biofield migration should apply to test database");
+            .expect("biofield migration 017 should apply to test database");
+        sqlx::raw_sql(&migration_018)
+            .execute(pool)
+            .await
+            .expect("biofield migration 018 should apply to test database");
     }
     .await;
 
@@ -211,6 +234,14 @@ fn build_multipart_body(fields: Vec<MultipartField<'_>>) -> (Vec<u8>, String) {
 
     body.extend(format!("--{}--\r\n", boundary).as_bytes());
     (body, boundary)
+}
+
+fn json_body(value: Value) -> Body {
+    Body::from(serde_json::to_vec(&value).expect("json body should serialize"))
+}
+
+fn artifact_dir(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("biofield-artifacts-{label}-{}", Uuid::new_v4()))
 }
 
 struct BiofieldCaptureHarness {
@@ -356,6 +387,24 @@ impl BiofieldCaptureHarness {
             .uri(uri)
             .header(header::AUTHORIZATION, format!("Bearer {token}"))
             .body(Body::empty())
+            .expect("request should build");
+
+        self.send_request(request).await
+    }
+
+    async fn send_authenticated_json(
+        &self,
+        method: &str,
+        uri: &str,
+        token: &str,
+        payload: Value,
+    ) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(json_body(payload))
             .expect("request should build");
 
         self.send_request(request).await
@@ -525,9 +574,14 @@ async fn biofield_capture_proxies_to_sidecar_and_persists_reading() {
         .mount(&sidecar)
         .await;
 
+    let artifacts_dir = artifact_dir("success");
     let _env = EnvGuard::set(&[
         ("PYTHON_BIOFIELD_URL", sidecar.uri()),
         ("PYTHON_BIOFIELD_TIMEOUT_MS", "1000".to_string()),
+        (
+            "BIOFIELD_ARTIFACTS_DIR",
+            artifacts_dir.display().to_string(),
+        ),
     ]);
 
     let (body, boundary) = build_multipart_body(vec![
@@ -653,9 +707,14 @@ async fn biofield_capture_normalizes_quality_rejection() {
         .mount(&sidecar)
         .await;
 
+    let artifacts_dir = artifact_dir("quality");
     let _env = EnvGuard::set(&[
         ("PYTHON_BIOFIELD_URL", sidecar.uri()),
         ("PYTHON_BIOFIELD_TIMEOUT_MS", "1000".to_string()),
+        (
+            "BIOFIELD_ARTIFACTS_DIR",
+            artifacts_dir.display().to_string(),
+        ),
     ]);
 
     let (body, boundary) = build_multipart_body(vec![MultipartField {
@@ -744,9 +803,14 @@ async fn biofield_readings_history_and_detail_are_user_scoped() {
         .mount(&sidecar)
         .await;
 
+    let artifacts_dir = artifact_dir("history");
     let _env = EnvGuard::set(&[
         ("PYTHON_BIOFIELD_URL", sidecar.uri()),
         ("PYTHON_BIOFIELD_TIMEOUT_MS", "1000".to_string()),
+        (
+            "BIOFIELD_ARTIFACTS_DIR",
+            artifacts_dir.display().to_string(),
+        ),
     ]);
 
     let (body, boundary) = build_multipart_body(vec![MultipartField {
@@ -839,4 +903,292 @@ async fn biofield_readings_history_and_detail_are_user_scoped() {
 
     harness.delete_user(other_user_id).await;
     harness.delete_user(user_id).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn biofield_reprocess_uses_stored_source_artifact_and_creates_new_reading() {
+    let Some(harness) = BiofieldCaptureHarness::new().await else {
+        return;
+    };
+
+    let user_id = harness.create_user_id("reprocess").await;
+    let session_id = harness.create_session_for_user(user_id).await;
+    let token = harness.token_for_user(user_id);
+
+    let sidecar = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/analyze"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contract_version": "biofield-cv/v1",
+            "analysis_version": "stub-metrics/v1",
+            "metrics": {
+                "light_quanta_density": 51.5,
+                "normalized_area": 0.74,
+                "average_intensity": 0.62,
+                "inner_noise": 0.07,
+                "energy_analysis": {
+                    "low": 0.2,
+                    "medium": 0.5,
+                    "high": 0.3,
+                    "total": 1.0
+                },
+                "entropy_form_coefficient": 2.7,
+                "fractal_dimension": 1.42,
+                "correlation_dimension": 1.95,
+                "body_symmetry": 0.33,
+                "contour_complexity": 1.8,
+                "pattern_regularity": 0.76
+            },
+            "quality_assessment": {
+                "sharpness": 0.88,
+                "contrast": 0.82,
+                "noise_level": 0.08,
+                "exposure": 0.54,
+                "sufficient_quality": true
+            },
+            "algorithms_run": ["fractal_dimension"],
+            "processing_time_ms": 12.5
+        })))
+        .mount(&sidecar)
+        .await;
+
+    let artifacts_dir = artifact_dir("reprocess");
+    let _env = EnvGuard::set(&[
+        ("PYTHON_BIOFIELD_URL", sidecar.uri()),
+        ("PYTHON_BIOFIELD_TIMEOUT_MS", "1000".to_string()),
+        (
+            "BIOFIELD_ARTIFACTS_DIR",
+            artifacts_dir.display().to_string(),
+        ),
+    ]);
+
+    let (body, boundary) = build_multipart_body(vec![MultipartField {
+        name: "image",
+        body: b"\xff\xd8\xff\xe0reprocess-jpeg".to_vec(),
+        file_name: Some("reprocess.jpg"),
+        content_type: Some("image/jpeg"),
+    }]);
+
+    let (capture_status, capture_payload) = harness
+        .send_authenticated_multipart(
+            &format!("/api/v1/biofield/sessions/{session_id}/captures"),
+            &token,
+            body,
+            &boundary,
+        )
+        .await;
+    assert_eq!(capture_status, StatusCode::CREATED);
+
+    let original_reading_id = capture_payload["reading_id"]
+        .as_str()
+        .expect("original reading id")
+        .to_string();
+    let original_storage_path = capture_payload["artifacts"][0]["storage_path"]
+        .as_str()
+        .expect("original storage path")
+        .to_string();
+    assert!(artifacts_dir.join(&original_storage_path).exists());
+
+    let (reprocess_status, reprocess_payload) = harness
+        .send_authenticated_json(
+            "POST",
+            &format!("/api/v1/biofield/readings/{original_reading_id}/reprocess"),
+            &token,
+            json!({}),
+        )
+        .await;
+    assert_eq!(reprocess_status, StatusCode::CREATED);
+    assert_eq!(reprocess_payload["source_reading_id"], original_reading_id);
+
+    let reprocessed_reading_id = reprocess_payload["reading_id"]
+        .as_str()
+        .expect("reprocessed reading id")
+        .to_string();
+    assert_ne!(reprocessed_reading_id, original_reading_id);
+    let reprocessed_storage_path = reprocess_payload["artifacts"][0]["storage_path"]
+        .as_str()
+        .expect("reprocessed storage path")
+        .to_string();
+    assert!(artifacts_dir.join(&reprocessed_storage_path).exists());
+
+    let reprocessed_reading_uuid = Uuid::parse_str(&reprocessed_reading_id).expect("uuid");
+    let reprocessed_reading = harness
+        .readings_repository
+        .get_reading(reprocessed_reading_uuid, user_id)
+        .await
+        .expect("reading fetch should succeed")
+        .expect("reprocessed reading should exist");
+    assert_eq!(
+        reprocessed_reading.input_data["reprocessed_from_reading_id"],
+        original_reading_id
+    );
+
+    let artifacts = harness
+        .biofield_repository
+        .list_reading_artifacts(reprocessed_reading_uuid, user_id)
+        .await
+        .expect("reprocessed artifacts should load");
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].session_id, session_id);
+    assert_eq!(artifacts[0].reading_id, Some(reprocessed_reading_uuid));
+
+    harness.delete_user(user_id).await;
+    let _ = fs::remove_dir_all(artifacts_dir);
+}
+
+#[tokio::test]
+#[serial]
+async fn biofield_baselines_create_and_list_are_user_scoped() {
+    let Some(harness) = BiofieldCaptureHarness::new().await else {
+        return;
+    };
+
+    let user_id = harness.create_user_id("baseline-owner").await;
+    let other_user_id = harness.create_user_id("baseline-other").await;
+    let session_id = harness.create_session_for_user(user_id).await;
+    let other_session_id = harness.create_session_for_user(other_user_id).await;
+    let token = harness.token_for_user(user_id);
+    let other_token = harness.token_for_user(other_user_id);
+
+    let sidecar = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/analyze"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "contract_version": "biofield-cv/v1",
+            "analysis_version": "stub-metrics/v1",
+            "metrics": {
+                "light_quanta_density": 42.5,
+                "normalized_area": 0.67,
+                "average_intensity": 0.51,
+                "inner_noise": 0.11,
+                "energy_analysis": {
+                    "low": 0.2,
+                    "medium": 0.5,
+                    "high": 0.3,
+                    "total": 1.0
+                },
+                "entropy_form_coefficient": 2.7,
+                "fractal_dimension": 1.42,
+                "correlation_dimension": 1.95,
+                "body_symmetry": 0.33,
+                "contour_complexity": 1.8,
+                "pattern_regularity": 0.76
+            },
+            "quality_assessment": {
+                "sharpness": 0.88,
+                "contrast": 0.82,
+                "noise_level": 0.08,
+                "exposure": 0.54,
+                "sufficient_quality": true
+            },
+            "algorithms_run": ["fractal_dimension"],
+            "processing_time_ms": 12.5
+        })))
+        .mount(&sidecar)
+        .await;
+
+    let artifacts_dir = artifact_dir("baseline");
+    let _env = EnvGuard::set(&[
+        ("PYTHON_BIOFIELD_URL", sidecar.uri()),
+        ("PYTHON_BIOFIELD_TIMEOUT_MS", "1000".to_string()),
+        (
+            "BIOFIELD_ARTIFACTS_DIR",
+            artifacts_dir.display().to_string(),
+        ),
+    ]);
+
+    let (body, boundary) = build_multipart_body(vec![MultipartField {
+        name: "image",
+        body: b"\xff\xd8\xff\xe0baseline-jpeg".to_vec(),
+        file_name: Some("baseline.jpg"),
+        content_type: Some("image/jpeg"),
+    }]);
+
+    let mut owner_reading_ids = Vec::new();
+    for _ in 0..2 {
+        let (status, payload) = harness
+            .send_authenticated_multipart(
+                &format!("/api/v1/biofield/sessions/{session_id}/captures"),
+                &token,
+                body.clone(),
+                &boundary,
+            )
+            .await;
+        assert_eq!(status, StatusCode::CREATED);
+        owner_reading_ids.push(
+            payload["reading_id"]
+                .as_str()
+                .expect("owner reading id")
+                .to_string(),
+        );
+    }
+
+    let (other_status, other_payload) = harness
+        .send_authenticated_multipart(
+            &format!("/api/v1/biofield/sessions/{other_session_id}/captures"),
+            &other_token,
+            body,
+            &boundary,
+        )
+        .await;
+    assert_eq!(other_status, StatusCode::CREATED);
+    let other_reading_id = other_payload["reading_id"]
+        .as_str()
+        .expect("other reading id")
+        .to_string();
+
+    let (create_status, create_payload) = harness
+        .send_authenticated_json(
+            "POST",
+            "/api/v1/biofield/baselines",
+            &token,
+            json!({
+                "name": "Morning baseline",
+                "notes": "Two accepted captures",
+                "reading_ids": owner_reading_ids,
+            }),
+        )
+        .await;
+    assert_eq!(create_status, StatusCode::CREATED);
+    assert_eq!(create_payload["name"], "Morning baseline");
+    assert_eq!(create_payload["reading_count"], 2);
+
+    let (list_status, list_payload) = harness
+        .send_authenticated_request("GET", "/api/v1/biofield/baselines", &token)
+        .await;
+    assert_eq!(list_status, StatusCode::OK);
+    assert_eq!(list_payload["items"].as_array().expect("items").len(), 1);
+    assert_eq!(list_payload["items"][0]["name"], "Morning baseline");
+    assert_eq!(list_payload["items"][0]["reading_count"], 2);
+
+    let (other_list_status, other_list_payload) = harness
+        .send_authenticated_request("GET", "/api/v1/biofield/baselines", &other_token)
+        .await;
+    assert_eq!(other_list_status, StatusCode::OK);
+    assert_eq!(
+        other_list_payload["items"].as_array().expect("items").len(),
+        0
+    );
+
+    let (cross_user_status, cross_user_payload) = harness
+        .send_authenticated_json(
+            "POST",
+            "/api/v1/biofield/baselines",
+            &token,
+            json!({
+                "name": "Bad baseline",
+                "reading_ids": [other_reading_id],
+            }),
+        )
+        .await;
+    assert_eq!(cross_user_status, StatusCode::NOT_FOUND);
+    assert_eq!(
+        cross_user_payload["error_code"],
+        "BIOFIELD_READING_NOT_FOUND"
+    );
+
+    harness.delete_user(other_user_id).await;
+    harness.delete_user(user_id).await;
+    let _ = fs::remove_dir_all(artifacts_dir);
 }

--- a/crates/noesis-api/tests/biofield_handler_smoke.rs
+++ b/crates/noesis-api/tests/biofield_handler_smoke.rs
@@ -31,11 +31,22 @@ async fn biofield_handler_smoke_routes_exist_under_api_v1() {
             "/api/v1/biofield/readings/00000000-0000-0000-0000-000000000002",
             None,
         ),
+        (
+            "POST",
+            "/api/v1/biofield/readings/00000000-0000-0000-0000-000000000002/reprocess",
+            Some(json!({})),
+        ),
+        ("GET", "/api/v1/biofield/baselines", None),
+        ("POST", "/api/v1/biofield/baselines", Some(json!({}))),
     ];
 
     for (method, uri, body) in unauthorized_cases {
         let (status, _) = common::make_unauthenticated_request(method, uri, body).await;
-        assert_eq!(status, StatusCode::UNAUTHORIZED, "route should exist: {uri}");
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "route should exist: {uri}"
+        );
     }
 }
 
@@ -69,9 +80,14 @@ async fn biofield_handler_smoke_openapi_contains_biofield_paths() {
         "/api/v1/biofield/sessions/{session_id}/captures",
         "/api/v1/biofield/readings",
         "/api/v1/biofield/readings/{reading_id}",
+        "/api/v1/biofield/readings/{reading_id}/reprocess",
+        "/api/v1/biofield/baselines",
     ];
 
     for path in expected {
-        assert!(paths.contains_key(path), "missing biofield path in openapi: {path}");
+        assert!(
+            paths.contains_key(path),
+            "missing biofield path in openapi: {path}"
+        );
     }
 }

--- a/crates/noesis-data/src/models/biofield.rs
+++ b/crates/noesis-data/src/models/biofield.rs
@@ -90,16 +90,41 @@ pub struct NewBiofieldCaptureArtifact {
     pub capture_metadata: serde_json::Value,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct BiofieldBaseline {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub name: String,
+    pub notes: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct BiofieldBaselineSummaryRecord {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub name: String,
+    pub notes: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub reading_count: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewBiofieldBaseline {
+    pub user_id: Uuid,
+    pub name: String,
+    pub notes: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn biofield_models_session_status_values_are_stable() {
-        assert_eq!(
-            BIOFIELD_SESSION_STATUSES,
-            ["active", "closed", "abandoned"]
-        );
+        assert_eq!(BIOFIELD_SESSION_STATUSES, ["active", "closed", "abandoned"]);
         assert!(is_valid_biofield_session_status("active"));
         assert!(is_valid_biofield_session_status("closed"));
         assert!(is_valid_biofield_session_status("abandoned"));

--- a/crates/noesis-data/src/repositories/biofield_repository.rs
+++ b/crates/noesis-data/src/repositories/biofield_repository.rs
@@ -1,5 +1,6 @@
 use crate::models::biofield::{
-    BiofieldCaptureArtifact, BiofieldSession, NewBiofieldCaptureArtifact, NewBiofieldSession,
+    BiofieldBaseline, BiofieldBaselineSummaryRecord, BiofieldCaptureArtifact, BiofieldSession,
+    NewBiofieldBaseline, NewBiofieldCaptureArtifact, NewBiofieldSession,
     BIOFIELD_SESSION_STATUS_ACTIVE, BIOFIELD_SESSION_STATUS_CLOSED,
 };
 use sqlx::{Error, PgPool};
@@ -172,6 +173,72 @@ impl BiofieldRepository {
         .fetch_all(&self.pool)
         .await
     }
+
+    pub async fn create_baseline(
+        &self,
+        baseline: &NewBiofieldBaseline,
+        reading_ids: &[Uuid],
+    ) -> Result<BiofieldBaseline, Error> {
+        let mut tx = self.pool.begin().await?;
+
+        let baseline_record = sqlx::query_as::<_, BiofieldBaseline>(
+            r#"
+            INSERT INTO biofield_baselines (user_id, name, notes)
+            VALUES ($1, $2, $3)
+            RETURNING *
+            "#,
+        )
+        .bind(baseline.user_id)
+        .bind(&baseline.name)
+        .bind(baseline.notes.as_deref())
+        .fetch_one(&mut *tx)
+        .await?;
+
+        for (index, reading_id) in reading_ids.iter().enumerate() {
+            sqlx::query(
+                r#"
+                INSERT INTO biofield_baseline_readings (baseline_id, reading_id, sort_order)
+                VALUES ($1, $2, $3)
+                "#,
+            )
+            .bind(baseline_record.id)
+            .bind(reading_id)
+            .bind(index as i32)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+
+        Ok(baseline_record)
+    }
+
+    pub async fn list_baselines(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Vec<BiofieldBaselineSummaryRecord>, Error> {
+        sqlx::query_as::<_, BiofieldBaselineSummaryRecord>(
+            r#"
+            SELECT
+                baseline.id,
+                baseline.user_id,
+                baseline.name,
+                baseline.notes,
+                baseline.created_at,
+                baseline.updated_at,
+                COUNT(link.reading_id)::BIGINT AS reading_count
+            FROM biofield_baselines AS baseline
+            LEFT JOIN biofield_baseline_readings AS link
+                ON link.baseline_id = baseline.id
+            WHERE baseline.user_id = $1
+            GROUP BY baseline.id
+            ORDER BY baseline.updated_at DESC, baseline.created_at DESC
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await
+    }
 }
 
 #[cfg(test)]
@@ -208,6 +275,14 @@ mod tests {
                 SELECT 1
                 FROM information_schema.tables
                 WHERE table_name = 'biofield_capture_artifacts'
+            ) AND EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_name = 'biofield_baselines'
+            ) AND EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_name = 'biofield_baseline_readings'
             )
             "#,
         )
@@ -225,9 +300,12 @@ mod tests {
             .await
             .expect("schema lock should succeed");
 
-        let migration_sql =
+        let migration_017 =
             fs::read_to_string(repo_root().join("migrations/017_biofield_sessions.sql"))
                 .expect("root migration 017");
+        let migration_018 =
+            fs::read_to_string(repo_root().join("migrations/018_biofield_baselines.sql"))
+                .expect("root migration 018");
 
         let apply_result = async {
             let schema_exists_after_lock: bool = sqlx::query_scalar(
@@ -240,6 +318,14 @@ mod tests {
                     SELECT 1
                     FROM information_schema.tables
                     WHERE table_name = 'biofield_capture_artifacts'
+                ) AND EXISTS (
+                    SELECT 1
+                    FROM information_schema.tables
+                    WHERE table_name = 'biofield_baselines'
+                ) AND EXISTS (
+                    SELECT 1
+                    FROM information_schema.tables
+                    WHERE table_name = 'biofield_baseline_readings'
                 )
                 "#,
             )
@@ -251,10 +337,14 @@ mod tests {
                 return;
             }
 
-            sqlx::raw_sql(&migration_sql)
+            sqlx::raw_sql(&migration_017)
                 .execute(pool)
                 .await
-                .expect("biofield migration should apply to test database");
+                .expect("biofield migration 017 should apply to test database");
+            sqlx::raw_sql(&migration_018)
+                .execute(pool)
+                .await
+                .expect("biofield migration 018 should apply to test database");
         }
         .await;
 

--- a/docs/runbooks/biofield-capture-analysis.md
+++ b/docs/runbooks/biofield-capture-analysis.md
@@ -1,11 +1,11 @@
 # Biofield Capture Analysis Runbook
 
 Date: 2026-04-09
-Status: Phase 1 complete local verification path
+Status: BF2 local verification path
 
 ## Purpose
 
-This runbook covers the local verification path for the finished Phase 1 biofield web slice.
+This runbook covers the local verification path for the post-BF1 biofield slice.
 
 It proves that:
 
@@ -17,6 +17,8 @@ It proves that:
 - a capture can be uploaded through Noesis to the Python sidecar
 - a persisted reading appears in history
 - the reading detail route returns the persisted analysis payload and artifact metadata
+- a stored source artifact can be reprocessed into a new reading
+- a baseline can be created from selected readings and listed back to the user
 
 ## Expected Local Ports
 
@@ -53,6 +55,8 @@ PGPASSWORD=noesis_password psql 'postgresql://noesis_user@localhost:5432/noesis'
   - default: `http://localhost:8002`
 - `PYTHON_BIOFIELD_TIMEOUT_MS`
   - default: `10000`
+- optional `BIOFIELD_ARTIFACTS_DIR`
+  - default: `./.runtime/biofield-artifacts`
 
 ### Biofield Web
 
@@ -86,6 +90,8 @@ export JWT_SECRET="dev-secret-at-least-32-characters"
 export DATABASE_URL="postgresql://noesis_user:noesis_password@localhost:5432/noesis"
 export PYTHON_BIOFIELD_URL="http://127.0.0.1:8002"
 export PYTHON_BIOFIELD_TIMEOUT_MS="10000"
+# optional override if you want artifact files elsewhere
+# export BIOFIELD_ARTIFACTS_DIR="/absolute/path/to/biofield-artifacts"
 cargo run --bin noesis-server
 ```
 
@@ -110,7 +116,7 @@ bash /Volumes/madara/2026/witnessos/Selemene-engine/scripts/smoke_biofield_web.s
 
 ### Optional Overrides
 
-The smoke script can self-provision a user and generate a tiny PNG automatically.
+The smoke script can self-provision a user and generate a capture automatically.
 
 Override only if you need fixed values:
 
@@ -127,7 +133,7 @@ bash /Volumes/madara/2026/witnessos/Selemene-engine/scripts/smoke_biofield_web.s
 
 ## Expected Results
 
-The smoke path should prove all of the following:
+The BF2 smoke path should prove all of the following:
 
 - `/login`, `/viewer`, and `/history` return `200`
 - `/health/live` returns `200`
@@ -137,17 +143,24 @@ The smoke path should prove all of the following:
 - `POST /api/v1/biofield/sessions/:session_id/captures` returns `201`
 - `GET /api/v1/biofield/readings` returns the new reading
 - `GET /api/v1/biofield/readings/:reading_id` returns detail for the new reading
+- `POST /api/v1/biofield/readings/:reading_id/reprocess` returns a new reading
+- `GET /api/v1/biofield/readings/:reprocessed_reading_id` resolves
+- `POST /api/v1/biofield/baselines` creates a baseline from the original and reprocessed readings
+- `GET /api/v1/biofield/baselines` returns the created baseline
 - `POST /api/v1/biofield/sessions/:session_id/close` returns `closed`
 
 ## What This Runbook Proves
 
-This Phase 1 runbook proves the end-to-end browser-visible biofield slice:
+This BF2 runbook proves the next storage-backed slice beyond BF1:
 
 - authenticated session lifecycle
 - capture ingestion through Noesis
 - Python-backed analysis response
 - reading persistence
 - artifact metadata linkage
+- real source-artifact file persistence
+- reprocess from stored source artifact
+- baseline creation and list
 - history list
 - reading detail
 
@@ -155,7 +168,7 @@ This Phase 1 runbook proves the end-to-end browser-visible biofield slice:
 
 This runbook does not yet prove later-phase scope such as:
 
-- reading reprocess flow
-- baselines
+- baseline comparison deltas/visualization
 - exports
 - downstream synthesis into non-biofield product surfaces
+- real computer-vision upgrade beyond the current Python stub

--- a/migrations/018_biofield_baselines.sql
+++ b/migrations/018_biofield_baselines.sql
@@ -1,0 +1,41 @@
+-- Migration: 018_biofield_baselines
+-- Description: Add biofield baseline persistence surfaces.
+
+CREATE TABLE IF NOT EXISTS biofield_baselines (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(128) NOT NULL,
+    notes TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT biofield_baselines_name_nonempty CHECK (
+        btrim(name) <> ''
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_biofield_baselines_user_id
+    ON biofield_baselines(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_biofield_baselines_user_updated_at
+    ON biofield_baselines(user_id, updated_at DESC);
+
+DROP TRIGGER IF EXISTS update_biofield_baselines_updated_at ON biofield_baselines;
+CREATE TRIGGER update_biofield_baselines_updated_at
+    BEFORE UPDATE ON biofield_baselines
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE IF NOT EXISTS biofield_baseline_readings (
+    baseline_id UUID NOT NULL REFERENCES biofield_baselines(id) ON DELETE CASCADE,
+    reading_id UUID NOT NULL REFERENCES readings(id) ON DELETE CASCADE,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (baseline_id, reading_id),
+    CONSTRAINT biofield_baseline_readings_sort_order_nonnegative CHECK (
+        sort_order >= 0
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_biofield_baseline_readings_baseline_id
+    ON biofield_baseline_readings(baseline_id, sort_order ASC, created_at ASC);
+CREATE INDEX IF NOT EXISTS idx_biofield_baseline_readings_reading_id
+    ON biofield_baseline_readings(reading_id, created_at DESC);

--- a/packages/biofield-api-client/src/biofield-client.test.ts
+++ b/packages/biofield-api-client/src/biofield-client.test.ts
@@ -43,6 +43,33 @@ describe("BiofieldClient", () => {
     );
   });
 
+  it("posts reprocess and baseline routes against the frozen namespace", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ reading_id: "reading-2" }), { status: 200 }),
+    );
+
+    const client = new BiofieldClient("https://example.com", { fetchImpl: fetchMock as typeof fetch });
+    await client.reprocessReading("reading-1");
+    await client.listBaselines();
+    await client.createBaseline({ name: "Morning", reading_ids: ["reading-1"] });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://example.com/api/v1/biofield/readings/reading-1/reprocess",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://example.com/api/v1/biofield/baselines",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://example.com/api/v1/biofield/baselines",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it("raises a typed error on failed requests", async () => {
     const fetchMock = vi.fn(async () =>
       new Response(JSON.stringify({ error: "nope" }), { status: 503 }),

--- a/packages/biofield-api-client/src/biofield-client.ts
+++ b/packages/biofield-api-client/src/biofield-client.ts
@@ -1,10 +1,14 @@
 import type {
   BiofieldCaptureResult,
   BiofieldReadingDetail,
+  BiofieldReprocessResult,
   BiofieldSession,
   CloseBiofieldSessionRequest,
+  CreateBiofieldBaselineRequest,
   CreateBiofieldSessionRequest,
+  ListBiofieldBaselinesResponse,
   ListBiofieldReadingsResponse,
+  ReprocessBiofieldReadingRequest,
 } from "@selemene/biofield-domain";
 
 export interface BiofieldClientOptions {
@@ -95,6 +99,37 @@ export class BiofieldClient {
     return this.request<BiofieldReadingDetail>(`/api/v1/biofield/readings/${readingId}`, {
       method: "GET",
     });
+  }
+
+  async reprocessReading(
+    readingId: string,
+    input: ReprocessBiofieldReadingRequest = {},
+  ): Promise<BiofieldReprocessResult> {
+    return this.request<BiofieldReprocessResult>(
+      `/api/v1/biofield/readings/${readingId}/reprocess`,
+      {
+        method: "POST",
+        body: JSON.stringify(input),
+      },
+    );
+  }
+
+  async listBaselines(): Promise<ListBiofieldBaselinesResponse> {
+    return this.request<ListBiofieldBaselinesResponse>("/api/v1/biofield/baselines", {
+      method: "GET",
+    });
+  }
+
+  async createBaseline(
+    input: CreateBiofieldBaselineRequest,
+  ): Promise<ListBiofieldBaselinesResponse["items"][number]> {
+    return this.request<ListBiofieldBaselinesResponse["items"][number]>(
+      "/api/v1/biofield/baselines",
+      {
+        method: "POST",
+        body: JSON.stringify(input),
+      },
+    );
   }
 
   async uploadCapture(

--- a/packages/biofield-domain/src/index.test.ts
+++ b/packages/biofield-domain/src/index.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  BIOFIELD_CAPTURE_STATES,
+  BIOFIELD_ENGINE_ID,
+  BIOFIELD_SESSION_STATUSES,
+  type BiofieldBaselineSummary,
+  type BiofieldReadingSummary,
+} from "./index.js";
+
+describe("biofield-domain", () => {
+  it("freezes the native reading engine id", () => {
+    expect(BIOFIELD_ENGINE_ID).toBe("biofield-capture");
+  });
+
+  it("defines the expected session and capture states", () => {
+    expect(BIOFIELD_SESSION_STATUSES).toEqual(["active", "closed", "abandoned"]);
+    expect(BIOFIELD_CAPTURE_STATES).toContain("persisted");
+    expect(BIOFIELD_CAPTURE_STATES).toContain("rejected");
+  });
+
+  it("keeps reading summaries aligned to the frozen contract shape", () => {
+    const summary: BiofieldReadingSummary = {
+      reading_id: "reading-1",
+      session_id: "session-1",
+      engine_id: BIOFIELD_ENGINE_ID,
+      created_at: "2026-04-05T12:05:00Z",
+      quality: {
+        sufficient_quality: true,
+      },
+      artifact: {
+        kind: "source-image",
+        mime_type: "image/jpeg",
+      },
+    };
+
+    expect(summary.engine_id).toBe(BIOFIELD_ENGINE_ID);
+    expect(summary.quality.sufficient_quality).toBe(true);
+  });
+
+  it("defines a minimal baseline summary shape", () => {
+    const baseline: BiofieldBaselineSummary = {
+      baseline_id: "baseline-1",
+      name: "Morning baseline",
+      notes: "Created from two accepted captures",
+      reading_count: 2,
+      created_at: "2026-04-09T12:05:00Z",
+      updated_at: "2026-04-09T12:06:00Z",
+    };
+
+    expect(baseline.reading_count).toBe(2);
+    expect(baseline.name).toContain("Morning");
+  });
+});

--- a/packages/biofield-domain/src/index.ts
+++ b/packages/biofield-domain/src/index.ts
@@ -116,3 +116,32 @@ export interface BiofieldCaptureResult {
   quality_assessment: QualityAssessment;
   artifacts: BiofieldArtifactSummary[];
 }
+
+
+export interface ReprocessBiofieldReadingRequest {
+  algorithms?: string[];
+  options?: Record<string, unknown>;
+}
+
+export interface BiofieldReprocessResult extends BiofieldCaptureResult {
+  source_reading_id: string;
+}
+
+export interface CreateBiofieldBaselineRequest {
+  name: string;
+  notes?: string;
+  reading_ids: string[];
+}
+
+export interface BiofieldBaselineSummary {
+  baseline_id: string;
+  name: string;
+  notes?: string | null;
+  reading_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ListBiofieldBaselinesResponse {
+  items: BiofieldBaselineSummary[];
+}

--- a/scripts/smoke_biofield_web.sh
+++ b/scripts/smoke_biofield_web.sh
@@ -17,6 +17,10 @@ SESSION_BODY="$TMP_DIR/session.json"
 CAPTURE_BODY="$TMP_DIR/capture.json"
 HISTORY_BODY="$TMP_DIR/history.json"
 DETAIL_BODY="$TMP_DIR/detail.json"
+REPROCESS_BODY="$TMP_DIR/reprocess.json"
+REPROCESS_DETAIL_BODY="$TMP_DIR/reprocess-detail.json"
+BASELINE_CREATE_BODY="$TMP_DIR/baseline-create.json"
+BASELINE_LIST_BODY="$TMP_DIR/baseline-list.json"
 CLOSE_BODY="$TMP_DIR/close.json"
 GENERATED_IMAGE="$TMP_DIR/smoke.png"
 
@@ -143,13 +147,14 @@ fi
 if [[ -z "$BIOFIELD_CAPTURE_IMAGE" ]]; then
   write_default_capture
   BIOFIELD_CAPTURE_IMAGE="$GENERATED_IMAGE"
+  export BIOFIELD_CAPTURE_IMAGE
 fi
 
 if [[ ! -f "$BIOFIELD_CAPTURE_IMAGE" ]]; then
   fail "BIOFIELD_CAPTURE_IMAGE does not exist: $BIOFIELD_CAPTURE_IMAGE"
 fi
 
-echo "Running biofield-web Phase 1 smoke checks"
+echo "Running biofield-web BF2 smoke checks"
 echo "BIOFIELD_WEB_URL=$BIOFIELD_WEB_URL"
 echo "API_BASE_URL=$API_BASE_URL"
 echo "PYTHON_BIOFIELD_URL=$PYTHON_BIOFIELD_URL"
@@ -230,7 +235,6 @@ FIRST_HISTORY_ID="$(json_field "$HISTORY_BODY" items.0.reading_id)"
 if [[ "$FIRST_HISTORY_ID" != "$READING_ID" ]]; then
   fail "History response top reading_id $FIRST_HISTORY_ID did not match capture reading_id $READING_ID"
 fi
-
 echo "✅ History route returns the new reading"
 
 get_json "$API_BASE_URL/api/v1/biofield/readings/$READING_ID" "200" "$DETAIL_BODY" "$AUTH_HEADER"
@@ -240,15 +244,54 @@ DETAIL_QUALITY_OK="$(json_field "$DETAIL_BODY" quality.sufficient_quality)"
 if [[ "$DETAIL_READING_ID" != "$READING_ID" || "$DETAIL_SESSION_ID" != "$SESSION_ID" || "$DETAIL_QUALITY_OK" != "true" ]]; then
   fail "Reading detail response did not match the created session/reading"
 fi
-
 echo "✅ Reading detail route returns the new reading"
+
+post_json "$API_BASE_URL/api/v1/biofield/readings/$READING_ID/reprocess" "201" '{}' "$REPROCESS_BODY" "$AUTH_HEADER"
+REPROCESSED_READING_ID="$(json_field "$REPROCESS_BODY" reading_id)"
+SOURCE_READING_ID="$(json_field "$REPROCESS_BODY" source_reading_id)"
+if [[ -z "$REPROCESSED_READING_ID" || "$SOURCE_READING_ID" != "$READING_ID" ]]; then
+  fail "Reprocess response did not return a new reading linked to the original reading"
+fi
+echo "✅ Reprocess created reading $REPROCESSED_READING_ID from $READING_ID"
+
+get_json "$API_BASE_URL/api/v1/biofield/readings/$REPROCESSED_READING_ID" "200" "$REPROCESS_DETAIL_BODY" "$AUTH_HEADER"
+REPROCESS_DETAIL_ID="$(json_field "$REPROCESS_DETAIL_BODY" reading_id)"
+if [[ "$REPROCESS_DETAIL_ID" != "$REPROCESSED_READING_ID" ]]; then
+  fail "Reprocessed reading detail did not match the reprocess response"
+fi
+echo "✅ Reprocessed reading detail resolves"
+
+export READING_ID REPROCESSED_READING_ID
+BASELINE_PAYLOAD="$(python3 - <<'PY'
+import json
+import os
+print(json.dumps({
+    'name': 'Smoke baseline',
+    'notes': 'Generated during BF2 smoke verification',
+    'reading_ids': [os.environ['READING_ID'], os.environ['REPROCESSED_READING_ID']],
+}))
+PY
+)"
+post_json "$API_BASE_URL/api/v1/biofield/baselines" "201" "$BASELINE_PAYLOAD" "$BASELINE_CREATE_BODY" "$AUTH_HEADER"
+BASELINE_ID="$(json_field "$BASELINE_CREATE_BODY" baseline_id)"
+BASELINE_COUNT="$(json_field "$BASELINE_CREATE_BODY" reading_count)"
+if [[ -z "$BASELINE_ID" || "$BASELINE_COUNT" != "2" ]]; then
+  fail "Baseline creation did not return the expected id and reading count"
+fi
+echo "✅ Baseline created with 2 readings"
+
+get_json "$API_BASE_URL/api/v1/biofield/baselines" "200" "$BASELINE_LIST_BODY" "$AUTH_HEADER"
+LIST_BASELINE_ID="$(json_field "$BASELINE_LIST_BODY" items.0.baseline_id)"
+if [[ "$LIST_BASELINE_ID" != "$BASELINE_ID" ]]; then
+  fail "Baseline list did not return the created baseline"
+fi
+echo "✅ Baseline list returns the created baseline"
 
 close_payload='{"reason":"smoke-complete"}'
 post_json "$API_BASE_URL/api/v1/biofield/sessions/$SESSION_ID/close" "200" "$close_payload" "$CLOSE_BODY" "$AUTH_HEADER"
-
 CLOSED_STATUS="$(json_field "$CLOSE_BODY" status)"
 if [[ "$CLOSED_STATUS" != "closed" ]]; then
   fail "Session close did not return closed status"
 fi
 
-echo "🎉 Biofield Phase 1 smoke checks passed"
+echo "🎉 Biofield BF2 smoke checks passed"

--- a/supabase/migrations/20260409000018_018_biofield_baselines.sql
+++ b/supabase/migrations/20260409000018_018_biofield_baselines.sql
@@ -1,0 +1,41 @@
+-- Migration: 018_biofield_baselines
+-- Description: Add biofield baseline persistence surfaces.
+
+CREATE TABLE IF NOT EXISTS biofield_baselines (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(128) NOT NULL,
+    notes TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT biofield_baselines_name_nonempty CHECK (
+        btrim(name) <> ''
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_biofield_baselines_user_id
+    ON biofield_baselines(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_biofield_baselines_user_updated_at
+    ON biofield_baselines(user_id, updated_at DESC);
+
+DROP TRIGGER IF EXISTS update_biofield_baselines_updated_at ON biofield_baselines;
+CREATE TRIGGER update_biofield_baselines_updated_at
+    BEFORE UPDATE ON biofield_baselines
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE IF NOT EXISTS biofield_baseline_readings (
+    baseline_id UUID NOT NULL REFERENCES biofield_baselines(id) ON DELETE CASCADE,
+    reading_id UUID NOT NULL REFERENCES readings(id) ON DELETE CASCADE,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (baseline_id, reading_id),
+    CONSTRAINT biofield_baseline_readings_sort_order_nonnegative CHECK (
+        sort_order >= 0
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_biofield_baseline_readings_baseline_id
+    ON biofield_baseline_readings(baseline_id, sort_order ASC, created_at ASC);
+CREATE INDEX IF NOT EXISTS idx_biofield_baseline_readings_reading_id
+    ON biofield_baseline_readings(reading_id, created_at DESC);


### PR DESCRIPTION
## Summary
- replays BF2 tranche on top of bf1-web-first-clean without old branch contamination
- adds storage-backed source artifact persistence plus reading reprocess endpoint
- adds baseline persistence and API endpoints, then wires baseline/reprocess flows into web history UI
- syncs migration files, shared domain types, and typed API client contracts

## Verification
- cargo test -p noesis-api --test biofield_capture_proxy
- cargo test -p noesis-api --test biofield_handler_smoke
- cargo test -p noesis-data biofield
- git diff --cached --check

## Notes
- full cargo test -p noesis-api <filter> run is currently blocked by pre-existing duplicate definitions in crates/noesis-api/tests/chart_endpoint_tests.rs
- intentionally dropped stale tasks/todo.md conflict payload from old branch history

Refs #556
