### PR TITLE
feat(biofield): land comparison/export + capture seam on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "engine-biofield-capture"
+version = "3.0.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "noesis-core",
+ "noesis-data",
+ "serde_json",
+ "sha2",
+ "sqlx",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "engine-biorhythm"
 version = "3.0.0"
 dependencies = [
@@ -2657,6 +2672,7 @@ dependencies = [
  "chrono",
  "criterion",
  "engine-biofield",
+ "engine-biofield-capture",
  "engine-biorhythm",
  "engine-face-reading",
  "engine-gene-keys",
@@ -2674,6 +2690,7 @@ dependencies = [
  "noesis-witness",
  "serde",
  "serde_json",
+ "sqlx",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/engine-gene-keys",
     "crates/engine-vedic-clock",
     "crates/engine-biofield",
+    "crates/engine-biofield-capture",
     "crates/engine-face-reading",
     "crates/engine-nadabrahman",
     "crates/engine-transits",

--- a/apps/biofield-web/app/globals.css
+++ b/apps/biofield-web/app/globals.css
@@ -201,9 +201,20 @@ textarea {
   gap: 1rem;
 }
 
+.biofield-form-inline {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+}
+
 .biofield-field {
   display: grid;
   gap: 0.45rem;
+}
+
+.biofield-field-grow {
+  min-width: 0;
 }
 
 .biofield-input {
@@ -345,5 +356,9 @@ textarea {
 @media (max-width: 720px) {
   .biofield-shell {
     padding: 1rem;
+  }
+
+  .biofield-form-inline {
+    grid-template-columns: 1fr;
   }
 }

--- a/apps/biofield-web/src/components/biofield-reading-detail-page.tsx
+++ b/apps/biofield-web/src/components/biofield-reading-detail-page.tsx
@@ -2,7 +2,12 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
-import type { BiofieldReadingDetail, BiofieldReprocessResult } from "@selemene/biofield-domain";
+import type {
+  BiofieldBaselineSummary,
+  BiofieldExportResult,
+  BiofieldReadingDetail,
+  BiofieldReprocessResult,
+} from "@selemene/biofield-domain";
 import { BiofieldClientError } from "@selemene/biofield-api-client";
 import {
   clearStoredAuthSession,
@@ -26,6 +31,10 @@ const detailFormatter = new Intl.DateTimeFormat("en-IN", {
   timeStyle: "short",
 });
 
+const numberFormatter = new Intl.NumberFormat("en-IN", {
+  maximumFractionDigits: 4,
+});
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -36,6 +45,27 @@ function formatTimestamp(value: string): string {
     return value;
   }
   return detailFormatter.format(date);
+}
+
+function formatMetricValue(value: number | null | undefined): string {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "—";
+  }
+  return numberFormatter.format(value);
+}
+
+function formatSignedMetricValue(value: number | null | undefined): string {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "—";
+  }
+  const formatted = numberFormatter.format(Math.abs(value));
+  if (value > 0) {
+    return `+${formatted}`;
+  }
+  if (value < 0) {
+    return `-${formatted}`;
+  }
+  return formatted;
 }
 
 function getErrorMessage(error: unknown, fallback: string): string {
@@ -59,6 +89,20 @@ function prettyJson(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
 
+function downloadExportBundle(result: BiofieldExportResult) {
+  const blob = new Blob([JSON.stringify(result.bundle, null, 2)], {
+    type: result.mime_type,
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = result.file_name;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
 export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) {
   const router = useRouter();
   const authSession = useSyncExternalStore(
@@ -67,9 +111,13 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
     () => null,
   );
   const [reading, setReading] = useState<BiofieldReadingDetail | null>(null);
+  const [baselines, setBaselines] = useState<BiofieldBaselineSummary[]>([]);
+  const [selectedBaselineId, setSelectedBaselineId] = useState("");
   const [reprocessResult, setReprocessResult] = useState<BiofieldReprocessResult | null>(null);
+  const [latestExport, setLatestExport] = useState<BiofieldExportResult | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isReprocessing, setIsReprocessing] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -86,41 +134,76 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
     return createBiofieldClient(authSession.token);
   }, [authSession]);
 
+  const selectedBaseline = useMemo(
+    () => baselines.find((baseline) => baseline.baseline_id === selectedBaselineId) ?? null,
+    [baselines, selectedBaselineId],
+  );
+
   const handleAuthFailure = useCallback(() => {
     clearStoredAuthSession();
     setReading(null);
+    setBaselines([]);
     router.replace("/login");
   }, [router]);
 
-  const loadReading = useCallback(async () => {
-    if (!client) {
-      return;
-    }
-
-    setIsLoading(true);
-    setErrorMessage(null);
-
-    try {
-      const response = await client.getReading(readingId);
-      setReading(response);
-    } catch (error) {
-      if (error instanceof BiofieldClientError && error.status === 401) {
-        handleAuthFailure();
+  const loadPageData = useCallback(
+    async (baselineId?: string) => {
+      if (!client) {
         return;
       }
-      setErrorMessage(getErrorMessage(error, "Failed to load biofield reading detail."));
-    } finally {
-      setIsLoading(false);
-    }
-  }, [client, handleAuthFailure, readingId]);
+
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const [readingResponse, baselinesResponse] = await Promise.all([
+          client.getReading(readingId, { baselineId }),
+          client.listBaselines(),
+        ]);
+        setReading(readingResponse);
+        setBaselines(baselinesResponse.items);
+      } catch (error) {
+        if (error instanceof BiofieldClientError && error.status === 401) {
+          handleAuthFailure();
+          return;
+        }
+        setErrorMessage(getErrorMessage(error, "Failed to load biofield reading detail."));
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [client, handleAuthFailure, readingId],
+  );
 
   useEffect(() => {
     if (!authSession || !client) {
       return;
     }
 
-    void loadReading();
-  }, [authSession, client, loadReading]);
+    void loadPageData();
+  }, [authSession, client, loadPageData]);
+
+  async function handleRefresh() {
+    await loadPageData(selectedBaselineId || undefined);
+  }
+
+  async function handleLoadComparison() {
+    if (!selectedBaselineId) {
+      setStatusMessage("Select a baseline to compare this reading against.");
+      return;
+    }
+
+    setStatusMessage(null);
+    await loadPageData(selectedBaselineId);
+    setStatusMessage("Loaded baseline comparison deltas.");
+  }
+
+  async function handleClearComparison() {
+    setSelectedBaselineId("");
+    setStatusMessage(null);
+    await loadPageData();
+    setStatusMessage("Cleared baseline comparison.");
+  }
 
   async function handleReprocess() {
     if (!client) {
@@ -143,6 +226,35 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
       setErrorMessage(getErrorMessage(error, "Failed to reprocess biofield reading."));
     } finally {
       setIsReprocessing(false);
+    }
+  }
+
+  async function handleExport() {
+    if (!client) {
+      return;
+    }
+
+    setIsExporting(true);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      const response = await client.createExport({
+        reading_id: readingId,
+        baseline_id: selectedBaselineId || undefined,
+        format: "json",
+      });
+      setLatestExport(response);
+      downloadExportBundle(response);
+      setStatusMessage(`Export ${response.file_name} generated and downloaded.`);
+    } catch (error) {
+      if (error instanceof BiofieldClientError && error.status === 401) {
+        handleAuthFailure();
+        return;
+      }
+      setErrorMessage(getErrorMessage(error, "Failed to create biofield export."));
+    } finally {
+      setIsExporting(false);
     }
   }
 
@@ -185,7 +297,7 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
       <section className="biofield-panel biofield-form-panel">
         <div className="biofield-toolbar">
           <div>
-            <p className="biofield-eyebrow">BF2 detail and reprocess</p>
+            <p className="biofield-eyebrow">BF3 detail, comparison, and exports</p>
             <h2 className="biofield-title" style={{ fontSize: "2rem" }}>
               {analysisVersion ?? "Biofield reading detail"}
             </h2>
@@ -194,11 +306,14 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
             </p>
           </div>
           <div className="biofield-actions">
-            <button className="biofield-link" onClick={() => void loadReading()} type="button">
+            <button className="biofield-link" onClick={() => void handleRefresh()} type="button">
               Refresh
             </button>
             <button className="biofield-button" disabled={isReprocessing} onClick={handleReprocess} type="button">
               {isReprocessing ? "Reprocessing…" : "Reprocess reading"}
+            </button>
+            <button className="biofield-button" disabled={isExporting || isLoading} onClick={handleExport} type="button">
+              {isExporting ? "Exporting…" : "Export JSON bundle"}
             </button>
             <Link className="biofield-link" href="/history">
               Back to history
@@ -209,6 +324,71 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
 
       {statusMessage ? <p className="biofield-success">{statusMessage}</p> : null}
       {errorMessage ? <p className="biofield-error">{errorMessage}</p> : null}
+
+      <section className="biofield-panel biofield-form-panel">
+        <p className="biofield-eyebrow">Baseline comparison</p>
+        <div className="biofield-form-inline">
+          <label className="biofield-field biofield-field-grow" htmlFor="biofield-baseline-select">
+            <span className="biofield-kicker">Baseline</span>
+            <select
+              className="biofield-input"
+              id="biofield-baseline-select"
+              onChange={(event) => setSelectedBaselineId(event.target.value)}
+              value={selectedBaselineId}
+            >
+              <option value="">No baseline selected</option>
+              {baselines.map((baseline) => (
+                <option key={baseline.baseline_id} value={baseline.baseline_id}>
+                  {baseline.name} · {baseline.reading_count} readings
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="biofield-actions">
+            <button className="biofield-button" disabled={isLoading || !selectedBaselineId} onClick={handleLoadComparison} type="button">
+              {isLoading ? "Loading…" : "Load comparison"}
+            </button>
+            <button className="biofield-link" disabled={isLoading} onClick={handleClearComparison} type="button">
+              Clear
+            </button>
+          </div>
+        </div>
+        {selectedBaseline ? (
+          <p className="biofield-copy">
+            Selected baseline <span className="biofield-mono">{selectedBaseline.baseline_id}</span>
+            {selectedBaseline.notes ? ` — ${selectedBaseline.notes}` : ""}
+          </p>
+        ) : (
+          <p className="biofield-copy">
+            Choose one of your persisted baselines to compute deterministic deltas against this reading.
+          </p>
+        )}
+      </section>
+
+      {latestExport ? (
+        <section className="biofield-panel biofield-form-panel">
+          <p className="biofield-eyebrow">Latest export</p>
+          <div className="biofield-list-grid">
+            <div className="biofield-list-card">
+              <p className="biofield-kicker">File</p>
+              <p className="biofield-copy biofield-mono">{latestExport.file_name}</p>
+            </div>
+            <div className="biofield-list-card">
+              <p className="biofield-kicker">Bytes</p>
+              <p className="biofield-metric">{latestExport.byte_size}</p>
+            </div>
+            <div className="biofield-list-card">
+              <p className="biofield-kicker">Storage path</p>
+              <p className="biofield-copy biofield-mono">{latestExport.storage_path}</p>
+            </div>
+          </div>
+          <div className="biofield-actions">
+            <button className="biofield-link" onClick={() => downloadExportBundle(latestExport)} type="button">
+              Download again
+            </button>
+          </div>
+        </section>
+      ) : null}
 
       {reprocessResult ? (
         <section className="biofield-panel biofield-form-panel">
@@ -224,7 +404,7 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
       {isLoading ? (
         <section className="biofield-panel">
           <p className="biofield-eyebrow">Loading</p>
-          <p className="biofield-copy">Fetching persisted reading detail…</p>
+          <p className="biofield-copy">Fetching persisted reading detail, baselines, and optional comparison…</p>
         </section>
       ) : null}
 
@@ -244,6 +424,39 @@ export function BiofieldReadingDetailPage({ readingId }: { readingId: string }) 
               <p className="biofield-metric">{reading.artifacts.length}</p>
             </article>
           </section>
+
+          {reading.comparison ? (
+            <section className="biofield-panel biofield-form-panel">
+              <div className="biofield-toolbar">
+                <div>
+                  <p className="biofield-eyebrow">Comparison deltas</p>
+                  <h3 className="biofield-title" style={{ fontSize: "1.6rem" }}>
+                    {reading.comparison.baseline.name}
+                  </h3>
+                  <p className="biofield-copy">
+                    {reading.comparison.baseline.reading_count} readings · version {reading.comparison.comparison_version}
+                  </p>
+                </div>
+              </div>
+              {reading.comparison.deltas.length > 0 ? (
+                <div className="biofield-list-grid">
+                  {reading.comparison.deltas.map((delta) => (
+                    <div className="biofield-list-card" key={delta.key}>
+                      <p className="biofield-kicker">{delta.key}</p>
+                      <p className="biofield-copy">Reading {formatMetricValue(delta.reading_value)}</p>
+                      <p className="biofield-copy">Baseline {formatMetricValue(delta.baseline_value)}</p>
+                      <p className="biofield-metric">Δ {formatSignedMetricValue(delta.absolute_delta)}</p>
+                      <p className="biofield-copy">
+                        Relative {delta.relative_delta == null ? "—" : formatSignedMetricValue(delta.relative_delta)}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="biofield-copy">No comparable numeric metrics were available for this baseline.</p>
+              )}
+            </section>
+          ) : null}
 
           {metrics.length > 0 ? (
             <section className="biofield-panel biofield-form-panel">

--- a/crates/engine-biofield-capture/Cargo.toml
+++ b/crates/engine-biofield-capture/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "engine-biofield-capture"
+version = "3.0.0"
+edition = "2021"
+description = "Capture-derived biofield engine for persisted reading lookup"
+
+[dependencies]
+noesis-core = { path = "../noesis-core" }
+noesis-data = { path = "../noesis-data" }
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+serde_json = "1.0"
+sha2 = "0.10"
+sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-rustls", "uuid", "chrono", "json", "macros"] }
+uuid = { version = "1.7", features = ["serde", "v4"] }
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["full", "test-util"] }

--- a/crates/engine-biofield-capture/src/lib.rs
+++ b/crates/engine-biofield-capture/src/lib.rs
@@ -1,0 +1,471 @@
+//! Biofield Capture Engine
+//!
+//! Resolves a persisted `biofield-capture` reading by `reading_id` and exposes it as a
+//! workflow-consumable `EngineOutput` without changing the existing birth-data `biofield` engine.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use noesis_core::{
+    CalculationMetadata, ConsciousnessEngine, EngineError, EngineInput, EngineOutput,
+    ValidationResult,
+};
+use noesis_data::{
+    models::reading::Reading, repositories::readings_repository::ReadingsRepository,
+};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+pub const BIOFIELD_CAPTURE_ENGINE_ID: &str = "biofield-capture";
+const BIOFIELD_CAPTURE_OPTION_NAMESPACE: &str = "biofield_capture";
+const INTERNAL_AUTH_OPTION_NAMESPACE: &str = "_auth";
+const REQUIRED_PHASE: u8 = 1;
+
+pub struct BiofieldCaptureEngine {
+    pool: PgPool,
+}
+
+impl BiofieldCaptureEngine {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    fn extract_reading_id(input: &EngineInput) -> Result<Uuid, EngineError> {
+        let raw = input
+            .options
+            .get(BIOFIELD_CAPTURE_OPTION_NAMESPACE)
+            .and_then(Value::as_object)
+            .and_then(|value| value.get("reading_id"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                EngineError::ValidationError(
+                    "options.biofield_capture.reading_id is required".to_string(),
+                )
+            })?;
+
+        Uuid::parse_str(raw).map_err(|_| {
+            EngineError::ValidationError(
+                "options.biofield_capture.reading_id must be a valid UUID".to_string(),
+            )
+        })
+    }
+
+    fn extract_user_id(input: &EngineInput) -> Result<Uuid, EngineError> {
+        let raw = input
+            .options
+            .get(INTERNAL_AUTH_OPTION_NAMESPACE)
+            .and_then(Value::as_object)
+            .and_then(|value| value.get("user_id"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                EngineError::AuthError(
+                    "Authenticated user context is required for biofield-capture lookup"
+                        .to_string(),
+                )
+            })?;
+
+        Uuid::parse_str(raw).map_err(|_| {
+            EngineError::AuthError(
+                "Authenticated user context contained an invalid user_id".to_string(),
+            )
+        })
+    }
+
+    fn build_result(reading: &Reading) -> Value {
+        json!({
+            "available": true,
+            "reading_id": reading.id,
+            "engine_id": reading.engine_id,
+            "created_at": reading.created_at,
+            "session_id": reading.input_data.get("session_id").cloned().unwrap_or(Value::Null),
+            "analysis_version": reading.result_data.get("analysis_version").cloned().unwrap_or(Value::Null),
+            "contract_version": reading.result_data.get("contract_version").cloned().unwrap_or(Value::Null),
+            "quality_assessment": reading.result_data.get("quality_assessment").cloned().unwrap_or_else(|| json!({})),
+            "input": reading.input_data,
+            "analysis": reading.result_data,
+        })
+    }
+
+    fn build_witness_prompt(reading: &Reading) -> String {
+        if let Some(prompt) = reading
+            .witness_prompt
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return prompt.to_string();
+        }
+
+        let sufficient_quality = reading
+            .result_data
+            .get("quality_assessment")
+            .and_then(|value| value.get("sufficient_quality"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
+        let analysis_version = reading
+            .result_data
+            .get("analysis_version")
+            .and_then(Value::as_str)
+            .unwrap_or("captured analysis");
+
+        if sufficient_quality {
+            format!(
+                "What stands out as you witness this captured field state from {}?",
+                analysis_version
+            )
+        } else {
+            "What do you notice about the conditions around this capture when you witness them without trying to improve them?".to_string()
+        }
+    }
+}
+
+#[async_trait]
+impl ConsciousnessEngine for BiofieldCaptureEngine {
+    fn engine_id(&self) -> &str {
+        BIOFIELD_CAPTURE_ENGINE_ID
+    }
+
+    fn engine_name(&self) -> &str {
+        "Biofield Capture"
+    }
+
+    fn required_phase(&self) -> u8 {
+        REQUIRED_PHASE
+    }
+
+    async fn calculate(&self, input: EngineInput) -> Result<EngineOutput, EngineError> {
+        let start = std::time::Instant::now();
+        let reading_id = Self::extract_reading_id(&input)?;
+        let user_id = Self::extract_user_id(&input)?;
+        let repository = ReadingsRepository::new(self.pool.clone());
+
+        let reading = repository
+            .get_reading(reading_id, user_id)
+            .await
+            .map_err(|error| {
+                EngineError::ServiceUnavailable(format!(
+                    "Failed to load persisted biofield capture reading: {error}"
+                ))
+            })?
+            .ok_or_else(|| {
+                EngineError::ValidationError(
+                    "Persisted biofield-capture reading not found or not accessible".to_string(),
+                )
+            })?;
+
+        if reading.engine_id != BIOFIELD_CAPTURE_ENGINE_ID {
+            return Err(EngineError::ValidationError(format!(
+                "reading_id does not reference a {} reading",
+                BIOFIELD_CAPTURE_ENGINE_ID
+            )));
+        }
+
+        Ok(EngineOutput {
+            engine_id: BIOFIELD_CAPTURE_ENGINE_ID.to_string(),
+            result: Self::build_result(&reading),
+            witness_prompt: Self::build_witness_prompt(&reading),
+            consciousness_level: reading.consciousness_level.max(0) as u8,
+            metadata: CalculationMetadata {
+                calculation_time_ms: start.elapsed().as_secs_f64() * 1000.0,
+                backend: "persisted-reading".to_string(),
+                precision_achieved: "Persisted".to_string(),
+                cached: false,
+                timestamp: Utc::now(),
+                engine_version: env!("CARGO_PKG_VERSION").to_string(),
+            },
+        })
+    }
+
+    async fn validate(&self, output: &EngineOutput) -> Result<ValidationResult, EngineError> {
+        let has_reading_id = output
+            .result
+            .get("reading_id")
+            .and_then(Value::as_str)
+            .is_some();
+        let has_analysis = output.result.get("analysis").is_some();
+
+        Ok(ValidationResult {
+            valid: output.engine_id == BIOFIELD_CAPTURE_ENGINE_ID && has_reading_id && has_analysis,
+            confidence: if has_reading_id && has_analysis {
+                1.0
+            } else {
+                0.0
+            },
+            messages: if has_reading_id && has_analysis {
+                vec!["biofield-capture output shape is valid".to_string()]
+            } else {
+                vec!["biofield-capture output is missing required fields".to_string()]
+            },
+        })
+    }
+
+    fn cache_key(&self, input: &EngineInput) -> String {
+        let reading_id = input
+            .options
+            .get(BIOFIELD_CAPTURE_OPTION_NAMESPACE)
+            .and_then(Value::as_object)
+            .and_then(|value| value.get("reading_id"))
+            .and_then(Value::as_str)
+            .unwrap_or("missing-reading-id");
+        let user_id = input
+            .options
+            .get(INTERNAL_AUTH_OPTION_NAMESPACE)
+            .and_then(Value::as_object)
+            .and_then(|value| value.get("user_id"))
+            .and_then(Value::as_str)
+            .unwrap_or("missing-user-id");
+
+        let mut hasher = Sha256::new();
+        hasher.update(BIOFIELD_CAPTURE_ENGINE_ID.as_bytes());
+        hasher.update(reading_id.as_bytes());
+        hasher.update(user_id.as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noesis_data::{models::reading::NewReading, repositories::user_repository::UserRepository};
+    use serde_json::json;
+    use sqlx::postgres::PgPoolOptions;
+
+    fn dummy_pool() -> PgPool {
+        PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://localhost/noesis_test")
+            .expect("lazy pool should build")
+    }
+
+    fn capture_input(reading_id: Option<&str>, user_id: Option<&str>) -> EngineInput {
+        let mut options = serde_json::Map::new();
+        if let Some(reading_id) = reading_id {
+            options.insert(
+                BIOFIELD_CAPTURE_OPTION_NAMESPACE.to_string(),
+                json!({ "reading_id": reading_id }),
+            );
+        }
+        if let Some(user_id) = user_id {
+            options.insert(
+                INTERNAL_AUTH_OPTION_NAMESPACE.to_string(),
+                json!({ "user_id": user_id }),
+            );
+        }
+
+        EngineInput {
+            birth_data: None,
+            current_time: Utc::now(),
+            location: None,
+            precision: noesis_core::Precision::Standard,
+            options: options.into_iter().collect(),
+        }
+    }
+
+    async fn connect_test_pool() -> Option<PgPool> {
+        let database_url = match std::env::var("DATABASE_URL") {
+            Ok(url) => url,
+            Err(_) => {
+                eprintln!("Skipping DB integration test: DATABASE_URL not set");
+                return None;
+            }
+        };
+
+        match PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&database_url)
+            .await
+        {
+            Ok(pool) => Some(pool),
+            Err(err) => {
+                eprintln!(
+                    "Skipping DB integration test: failed to connect to test database: {err}"
+                );
+                None
+            }
+        }
+    }
+
+    async fn create_user(pool: &PgPool, label: &str) -> noesis_data::models::user::User {
+        let repo = UserRepository::new(pool.clone());
+        let email = format!(
+            "biofield-capture-engine-{label}-{}@example.com",
+            Uuid::new_v4()
+        );
+        repo.create_user(
+            &email,
+            "test_password_hash",
+            "Biofield Capture Engine Test User",
+        )
+        .await
+        .expect("test user should be created")
+    }
+
+    async fn create_reading(pool: &PgPool, user_id: Uuid, engine_id: &str) -> Uuid {
+        let repo = ReadingsRepository::new(pool.clone());
+        repo.save_reading(&NewReading {
+            user_id,
+            engine_id: engine_id.to_string(),
+            workflow_id: None,
+            input_hash: format!("bfce-{}", Uuid::new_v4().simple()),
+            input_data: json!({
+                "session_id": Uuid::new_v4(),
+                "content_type": "image/jpeg"
+            }),
+            result_data: json!({
+                "contract_version": "biofield-cv/v1",
+                "analysis_version": "stub-metrics/v1",
+                "quality_assessment": { "sufficient_quality": true },
+                "metrics": { "light_quanta_density": 42.0 }
+            }),
+            witness_prompt: Some(
+                "What do you notice as you witness this stored capture?".to_string(),
+            ),
+            consciousness_level: 1,
+            calculation_time_ms: Some(7.5),
+            client_event_id: None,
+            client_device_id: None,
+            device_platform: None,
+            device_app_version: None,
+        })
+        .await
+        .expect("reading should be created")
+    }
+
+    #[tokio::test]
+    async fn missing_reading_id_is_validation_error() {
+        let engine = BiofieldCaptureEngine::new(dummy_pool());
+        let input = capture_input(None, Some(&Uuid::new_v4().to_string()));
+
+        let error = engine
+            .calculate(input)
+            .await
+            .expect_err("missing reading_id should fail");
+        assert!(matches!(error, EngineError::ValidationError(_)));
+        assert!(error
+            .to_string()
+            .contains("options.biofield_capture.reading_id"));
+    }
+
+    #[tokio::test]
+    async fn missing_user_context_is_auth_error() {
+        let engine = BiofieldCaptureEngine::new(dummy_pool());
+        let input = capture_input(Some(&Uuid::new_v4().to_string()), None);
+
+        let error = engine
+            .calculate(input)
+            .await
+            .expect_err("missing auth should fail");
+        assert!(matches!(error, EngineError::AuthError(_)));
+    }
+
+    #[tokio::test]
+    async fn malformed_reading_id_is_validation_error() {
+        let engine = BiofieldCaptureEngine::new(dummy_pool());
+        let input = capture_input(Some("not-a-uuid"), Some(&Uuid::new_v4().to_string()));
+
+        let error = engine
+            .calculate(input)
+            .await
+            .expect_err("bad reading_id should fail");
+        assert!(matches!(error, EngineError::ValidationError(_)));
+    }
+
+    #[tokio::test]
+    async fn resolves_persisted_biofield_capture_reading() {
+        let Some(pool) = connect_test_pool().await else {
+            return;
+        };
+
+        let user = create_user(&pool, "owner").await;
+        let reading_id = create_reading(&pool, user.id, BIOFIELD_CAPTURE_ENGINE_ID).await;
+        let engine = BiofieldCaptureEngine::new(pool.clone());
+        let input = capture_input(Some(&reading_id.to_string()), Some(&user.id.to_string()));
+
+        let output = engine
+            .calculate(input)
+            .await
+            .expect("reading lookup should succeed");
+        assert_eq!(output.engine_id, BIOFIELD_CAPTURE_ENGINE_ID);
+        assert_eq!(output.result["reading_id"], reading_id.to_string());
+        assert_eq!(
+            output.result["analysis"]["analysis_version"],
+            "stub-metrics/v1"
+        );
+        assert!(!output.witness_prompt.trim().is_empty());
+
+        sqlx::query("DELETE FROM readings WHERE id = $1")
+            .bind(reading_id)
+            .execute(&pool)
+            .await
+            .expect("cleanup reading");
+        sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user.id)
+            .execute(&pool)
+            .await
+            .expect("cleanup user");
+    }
+
+    #[tokio::test]
+    async fn rejects_foreign_user_reading_lookup() {
+        let Some(pool) = connect_test_pool().await else {
+            return;
+        };
+
+        let owner = create_user(&pool, "owner-foreign").await;
+        let other = create_user(&pool, "other-foreign").await;
+        let reading_id = create_reading(&pool, owner.id, BIOFIELD_CAPTURE_ENGINE_ID).await;
+        let engine = BiofieldCaptureEngine::new(pool.clone());
+        let input = capture_input(Some(&reading_id.to_string()), Some(&other.id.to_string()));
+
+        let error = engine
+            .calculate(input)
+            .await
+            .expect_err("foreign reading should fail");
+        assert!(matches!(error, EngineError::ValidationError(_)));
+        assert!(error.to_string().contains("not found or not accessible"));
+
+        sqlx::query("DELETE FROM readings WHERE id = $1")
+            .bind(reading_id)
+            .execute(&pool)
+            .await
+            .expect("cleanup reading");
+        sqlx::query("DELETE FROM users WHERE id = $1 OR id = $2")
+            .bind(owner.id)
+            .bind(other.id)
+            .execute(&pool)
+            .await
+            .expect("cleanup users");
+    }
+
+    #[tokio::test]
+    async fn rejects_non_biofield_capture_reading() {
+        let Some(pool) = connect_test_pool().await else {
+            return;
+        };
+
+        let user = create_user(&pool, "wrong-engine").await;
+        let reading_id = create_reading(&pool, user.id, "numerology").await;
+        let engine = BiofieldCaptureEngine::new(pool.clone());
+        let input = capture_input(Some(&reading_id.to_string()), Some(&user.id.to_string()));
+
+        let error = engine
+            .calculate(input)
+            .await
+            .expect_err("wrong engine_id should fail");
+        assert!(matches!(error, EngineError::ValidationError(_)));
+        assert!(error.to_string().contains(BIOFIELD_CAPTURE_ENGINE_ID));
+
+        sqlx::query("DELETE FROM readings WHERE id = $1")
+            .bind(reading_id)
+            .execute(&pool)
+            .await
+            .expect("cleanup reading");
+        sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user.id)
+            .execute(&pool)
+            .await
+            .expect("cleanup user");
+    }
+}

--- a/crates/noesis-api/src/handlers/biofield.rs
+++ b/crates/noesis-api/src/handlers/biofield.rs
@@ -12,8 +12,9 @@ use noesis_data::{
     models::{
         biofield::{
             BiofieldBaselineSummaryRecord, BiofieldCaptureArtifact, BiofieldSession,
-            NewBiofieldBaseline, NewBiofieldCaptureArtifact, NewBiofieldSession,
-            BIOFIELD_CAPTURE_ARTIFACT_SOURCE_IMAGE, BIOFIELD_SESSION_STATUS_ACTIVE,
+            NewBiofieldBaseline, NewBiofieldCaptureArtifact, NewBiofieldExport, NewBiofieldSession,
+            BIOFIELD_CAPTURE_ARTIFACT_SOURCE_IMAGE, BIOFIELD_EXPORT_FORMAT_JSON,
+            BIOFIELD_SESSION_STATUS_ACTIVE,
         },
         reading::{NewReading, Reading},
     },
@@ -24,12 +25,14 @@ use noesis_data::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::{path::PathBuf, time::Duration};
+use std::{collections::BTreeMap, path::PathBuf, time::Duration};
 use tokio::fs as tokio_fs;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 const BIOFIELD_ENGINE_ID: &str = "biofield-capture";
+const BIOFIELD_BASELINE_COMPARISON_VERSION: &str = "biofield-baseline-delta/v1";
+const BIOFIELD_EXPORT_CONTRACT_VERSION: &str = "biofield-export/v1";
 const DEFAULT_BIOFIELD_READINGS_LIMIT: u32 = 20;
 const MAX_BIOFIELD_READINGS_LIMIT: u32 = 100;
 
@@ -52,6 +55,11 @@ pub struct ListBiofieldReadingsQuery {
 }
 
 #[derive(Debug, Deserialize, Default, ToSchema)]
+pub struct GetBiofieldReadingQuery {
+    pub baseline_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default, ToSchema)]
 pub struct ReprocessBiofieldReadingRequest {
     pub algorithms: Option<Vec<String>>,
     #[schema(value_type = Object)]
@@ -65,6 +73,13 @@ pub struct CreateBiofieldBaselineRequest {
     pub reading_ids: Vec<String>,
 }
 
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateBiofieldExportRequest {
+    pub reading_id: String,
+    pub baseline_id: Option<String>,
+    pub format: Option<String>,
+}
+
 #[derive(Debug, Serialize, ToSchema)]
 pub struct BiofieldSessionResource {
     pub id: String,
@@ -75,12 +90,12 @@ pub struct BiofieldSessionResource {
     pub viewer_version: Option<String>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct BiofieldQualitySummary {
     pub sufficient_quality: bool,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct BiofieldArtifactSummary {
     pub id: Option<String>,
     pub kind: String,
@@ -114,7 +129,7 @@ pub struct BiofieldReprocessResponse {
     pub artifacts: Vec<BiofieldArtifactSummary>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct BiofieldReadingSummary {
     pub reading_id: String,
     pub session_id: String,
@@ -131,7 +146,7 @@ pub struct ListBiofieldReadingsResponse {
     pub offset: u32,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct BiofieldBaselineSummary {
     pub baseline_id: String,
     pub name: String,
@@ -146,7 +161,23 @@ pub struct ListBiofieldBaselinesResponse {
     pub items: Vec<BiofieldBaselineSummary>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct BiofieldMetricDelta {
+    pub key: String,
+    pub reading_value: f64,
+    pub baseline_value: f64,
+    pub absolute_delta: f64,
+    pub relative_delta: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct BiofieldBaselineComparison {
+    pub comparison_version: String,
+    pub baseline: BiofieldBaselineSummary,
+    pub deltas: Vec<BiofieldMetricDelta>,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct BiofieldReadingDetail {
     pub reading_id: String,
     pub session_id: String,
@@ -156,6 +187,22 @@ pub struct BiofieldReadingDetail {
     pub result: serde_json::Value,
     pub quality: serde_json::Value,
     pub artifacts: Vec<BiofieldArtifactSummary>,
+    pub comparison: Option<BiofieldBaselineComparison>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BiofieldExportResponse {
+    pub export_id: String,
+    pub reading_id: String,
+    pub baseline_id: Option<String>,
+    pub format: String,
+    pub file_name: String,
+    pub mime_type: String,
+    pub byte_size: u64,
+    pub created_at: DateTime<Utc>,
+    pub storage_path: String,
+    #[schema(value_type = Object)]
+    pub bundle: serde_json::Value,
 }
 
 #[derive(Debug, Default)]
@@ -291,6 +338,24 @@ fn baseline_invalid_response(message: impl Into<String>, details: Option<Value>)
         StatusCode::UNPROCESSABLE_ENTITY,
         message,
         "BIOFIELD_BASELINE_INVALID",
+        details,
+    )
+}
+
+fn baseline_not_found_response(baseline_id: &str) -> Response {
+    json_error_response(
+        StatusCode::NOT_FOUND,
+        "Biofield baseline not found",
+        "BIOFIELD_BASELINE_NOT_FOUND",
+        Some(serde_json::json!({ "baseline_id": baseline_id })),
+    )
+}
+
+fn export_invalid_response(message: impl Into<String>, details: Option<Value>) -> Response {
+    json_error_response(
+        StatusCode::UNPROCESSABLE_ENTITY,
+        message,
+        "BIOFIELD_EXPORT_INVALID",
         details,
     )
 }
@@ -676,6 +741,7 @@ fn build_reading_summary(
 fn build_reading_detail_resource(
     reading: &Reading,
     artifacts: &[BiofieldCaptureArtifact],
+    comparison: Option<BiofieldBaselineComparison>,
 ) -> Result<BiofieldReadingDetail, Response> {
     let session_id = extract_reading_session_id(reading, artifacts)
         .ok_or_else(|| missing_reading_session_link_response(reading.id))?;
@@ -698,7 +764,18 @@ fn build_reading_detail_resource(
             .cloned()
             .unwrap_or_else(|| serde_json::json!({})),
         artifacts: artifact_summaries,
+        comparison,
     })
+}
+
+fn extract_reading_session_uuid(
+    reading: &Reading,
+    artifacts: &[BiofieldCaptureArtifact],
+) -> Result<Uuid, Response> {
+    let session_id = extract_reading_session_id(reading, artifacts)
+        .ok_or_else(|| missing_reading_session_link_response(reading.id))?;
+
+    Uuid::parse_str(&session_id).map_err(|_| missing_reading_session_link_response(reading.id))
 }
 
 fn normalize_readings_page(query: &ListBiofieldReadingsQuery) -> (u32, u32) {
@@ -1130,6 +1207,207 @@ fn baseline_summary_from_record(record: &BiofieldBaselineSummaryRecord) -> Biofi
         created_at: record.created_at,
         updated_at: record.updated_at,
     }
+}
+
+fn collect_numeric_metrics(
+    value: &Value,
+    prefix: Option<&str>,
+    metrics: &mut BTreeMap<String, f64>,
+) {
+    match value {
+        Value::Number(number) => {
+            if let (Some(key), Some(metric_value)) = (prefix, number.as_f64()) {
+                metrics.insert(key.to_string(), metric_value);
+            }
+        }
+        Value::Object(object) => {
+            let mut keys = object.keys().cloned().collect::<Vec<_>>();
+            keys.sort();
+            for key in keys {
+                let child_prefix = prefix
+                    .map(|value| format!("{value}.{key}"))
+                    .unwrap_or(key.clone());
+                if let Some(child) = object.get(&key) {
+                    collect_numeric_metrics(child, Some(&child_prefix), metrics);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn reading_metric_map(reading: &Reading) -> BTreeMap<String, f64> {
+    let mut metrics = BTreeMap::new();
+    if let Some(raw_metrics) = reading.result_data.get("metrics") {
+        collect_numeric_metrics(raw_metrics, None, &mut metrics);
+    }
+    metrics
+}
+
+fn build_baseline_comparison(
+    reading: &Reading,
+    baseline: BiofieldBaselineSummary,
+    baseline_readings: &[Reading],
+) -> BiofieldBaselineComparison {
+    let reading_metrics = reading_metric_map(reading);
+    let mut aggregate: BTreeMap<String, (f64, u32)> = BTreeMap::new();
+
+    for baseline_reading in baseline_readings {
+        for (key, value) in reading_metric_map(baseline_reading) {
+            let entry = aggregate.entry(key).or_insert((0.0, 0));
+            entry.0 += value;
+            entry.1 += 1;
+        }
+    }
+
+    let deltas = reading_metrics
+        .into_iter()
+        .filter_map(|(key, reading_value)| {
+            let (sum, count) = aggregate.get(&key)?;
+            if *count == 0 {
+                return None;
+            }
+
+            let baseline_value = sum / f64::from(*count);
+            let absolute_delta = reading_value - baseline_value;
+            let relative_delta = if baseline_value.abs() < f64::EPSILON {
+                None
+            } else {
+                Some(absolute_delta / baseline_value)
+            };
+
+            Some(BiofieldMetricDelta {
+                key,
+                reading_value,
+                baseline_value,
+                absolute_delta,
+                relative_delta,
+            })
+        })
+        .collect();
+
+    BiofieldBaselineComparison {
+        comparison_version: BIOFIELD_BASELINE_COMPARISON_VERSION.to_string(),
+        baseline,
+        deltas,
+    }
+}
+
+async fn resolve_optional_baseline_comparison(
+    biofield_repository: &BiofieldRepository,
+    reading: &Reading,
+    user_id: Uuid,
+    baseline_id: Option<&str>,
+) -> Result<Option<(Uuid, BiofieldBaselineComparison)>, Response> {
+    let Some(baseline_id) = baseline_id else {
+        return Ok(None);
+    };
+
+    let baseline_uuid = match parse_uuid_or_422(baseline_id, "baseline_id") {
+        Ok(baseline_uuid) => baseline_uuid,
+        Err(response) => return Err(response),
+    };
+
+    let record = match biofield_repository
+        .get_baseline_summary(baseline_uuid, user_id)
+        .await
+    {
+        Ok(Some(record)) => record,
+        Ok(None) => return Err(baseline_not_found_response(baseline_id)),
+        Err(error) => {
+            return Err(biofield_db_error_response(
+                "fetch biofield baseline",
+                &error,
+            ))
+        }
+    };
+
+    let baseline_readings = match biofield_repository
+        .list_baseline_readings(baseline_uuid, user_id)
+        .await
+    {
+        Ok(readings) => readings,
+        Err(error) => {
+            return Err(biofield_db_error_response(
+                "list biofield baseline readings",
+                &error,
+            ))
+        }
+    };
+
+    Ok(Some((
+        baseline_uuid,
+        build_baseline_comparison(
+            reading,
+            baseline_summary_from_record(&record),
+            &baseline_readings,
+        ),
+    )))
+}
+
+fn normalize_export_format(raw: Option<&str>) -> Option<String> {
+    let normalized = raw
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(BIOFIELD_EXPORT_FORMAT_JSON)
+        .to_ascii_lowercase();
+
+    match normalized.as_str() {
+        BIOFIELD_EXPORT_FORMAT_JSON => Some(normalized),
+        _ => None,
+    }
+}
+
+fn build_export_storage_path(session_id: Uuid, format: &str) -> String {
+    format!(
+        "biofield/{session_id}/exports/export-{}.{}",
+        Uuid::new_v4(),
+        format
+    )
+}
+
+fn build_export_file_name(reading_id: Uuid, baseline_id: Option<Uuid>, format: &str) -> String {
+    match baseline_id {
+        Some(baseline_id) => {
+            format!("biofield-reading-{reading_id}-baseline-{baseline_id}.{format}")
+        }
+        None => format!("biofield-reading-{reading_id}.{format}"),
+    }
+}
+
+fn build_export_bundle(reading: &BiofieldReadingDetail, format: &str) -> Value {
+    serde_json::json!({
+        "contract_version": BIOFIELD_EXPORT_CONTRACT_VERSION,
+        "format": format,
+        "exported_at": Utc::now(),
+        "reading": reading,
+    })
+}
+
+async fn save_export_record(
+    biofield_repository: &BiofieldRepository,
+    user_id: Uuid,
+    reading_id: Uuid,
+    baseline_id: Option<Uuid>,
+    format: &str,
+    file_name: &str,
+    storage_path: &str,
+    mime_type: &str,
+    byte_size: u64,
+) -> Result<noesis_data::models::biofield::BiofieldExport, Response> {
+    biofield_repository
+        .create_export(&NewBiofieldExport {
+            user_id,
+            reading_id,
+            baseline_id,
+            export_format: format.to_string(),
+            file_name: file_name.to_string(),
+            storage_path: storage_path.to_string(),
+            mime_type: mime_type.to_string(),
+            byte_size: byte_size as i64,
+        })
+        .await
+        .map_err(|error| biofield_db_error_response("create biofield export", &error))
 }
 
 async fn save_capture_reading(
@@ -1586,7 +1864,8 @@ pub async fn list_readings(
     path = "/api/v1/biofield/readings/{reading_id}",
     tag = "biofield",
     params(
-        ("reading_id" = String, Path, description = "Biofield reading identifier")
+        ("reading_id" = String, Path, description = "Biofield reading identifier"),
+        ("baseline_id" = Option<String>, Query, description = "Optional biofield baseline identifier for comparison deltas")
     ),
     responses(
         (status = 200, description = "Biofield reading detail", body = BiofieldReadingDetail),
@@ -1605,6 +1884,7 @@ pub async fn get_reading(
     State(state): State<AppState>,
     Extension(auth_user): Extension<AuthUser>,
     Path(reading_id): Path<String>,
+    Query(query): Query<GetBiofieldReadingQuery>,
 ) -> Response {
     let Some(readings_repository) = state.readings_repository.as_ref() else {
         return biofield_db_unavailable_response();
@@ -1639,7 +1919,19 @@ pub async fn get_reading(
         }
     };
 
-    let response = match build_reading_detail_resource(&reading, &artifacts) {
+    let comparison = match resolve_optional_baseline_comparison(
+        biofield_repository,
+        &reading,
+        user_id,
+        query.baseline_id.as_deref(),
+    )
+    .await
+    {
+        Ok(comparison) => comparison.map(|(_, comparison)| comparison),
+        Err(response) => return response,
+    };
+
+    let response = match build_reading_detail_resource(&reading, &artifacts, comparison) {
         Ok(response) => response,
         Err(response) => return response,
     };
@@ -1955,6 +2247,154 @@ pub async fn create_baseline(
             reading_count: reading_uuids.len() as u32,
             created_at: baseline.created_at,
             updated_at: baseline.updated_at,
+        }),
+    )
+        .into_response()
+}
+
+/// POST /api/v1/biofield/exports
+#[utoipa::path(
+    post,
+    path = "/api/v1/biofield/exports",
+    tag = "biofield",
+    request_body = CreateBiofieldExportRequest,
+    responses(
+        (status = 201, description = "Biofield export created", body = BiofieldExportResponse),
+        (status = 401, description = "Unauthorized", body = crate::ErrorResponse),
+        (status = 404, description = "Reading or baseline not found", body = crate::ErrorResponse),
+        (status = 422, description = "Invalid export request", body = crate::ErrorResponse),
+        (status = 503, description = "Biofield DB unavailable", body = crate::ErrorResponse),
+        (status = 500, description = "Internal biofield persistence or storage error", body = crate::ErrorResponse),
+    ),
+    security(
+        ("bearer_auth" = []),
+        ("api_key" = [])
+    )
+)]
+pub async fn create_export(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Json(request): Json<CreateBiofieldExportRequest>,
+) -> Response {
+    let Some(readings_repository) = state.readings_repository.as_ref() else {
+        return biofield_db_unavailable_response();
+    };
+    let Some(biofield_repository) = state.biofield_repository.as_ref() else {
+        return biofield_db_unavailable_response();
+    };
+
+    let user_id = match parse_auth_user_uuid(&auth_user) {
+        Ok(user_id) => user_id,
+        Err(response) => return response,
+    };
+
+    let reading_uuid = match parse_uuid_or_422(&request.reading_id, "reading_id") {
+        Ok(reading_uuid) => reading_uuid,
+        Err(response) => return response,
+    };
+
+    let Some(export_format) = normalize_export_format(request.format.as_deref()) else {
+        return export_invalid_response(
+            "Unsupported biofield export format",
+            Some(serde_json::json!({ "format": request.format })),
+        );
+    };
+
+    let reading = match readings_repository.get_reading(reading_uuid, user_id).await {
+        Ok(Some(reading)) if reading.engine_id == BIOFIELD_ENGINE_ID => reading,
+        Ok(Some(_)) | Ok(None) => return reading_not_found_response(&request.reading_id),
+        Err(error) => return biofield_db_error_response("fetch biofield reading", &error),
+    };
+
+    let artifacts = match biofield_repository
+        .list_reading_artifacts(reading_uuid, user_id)
+        .await
+    {
+        Ok(artifacts) => artifacts,
+        Err(error) => {
+            return biofield_db_error_response("fetch biofield reading artifacts", &error)
+        }
+    };
+
+    let baseline_context = match resolve_optional_baseline_comparison(
+        biofield_repository,
+        &reading,
+        user_id,
+        request.baseline_id.as_deref(),
+    )
+    .await
+    {
+        Ok(context) => context,
+        Err(response) => return response,
+    };
+    let baseline_id = baseline_context
+        .as_ref()
+        .map(|(baseline_id, _)| *baseline_id);
+    let comparison = baseline_context.map(|(_, comparison)| comparison);
+
+    let detail = match build_reading_detail_resource(&reading, &artifacts, comparison) {
+        Ok(detail) => detail,
+        Err(response) => return response,
+    };
+
+    let session_id = match extract_reading_session_uuid(&reading, &artifacts) {
+        Ok(session_id) => session_id,
+        Err(response) => return response,
+    };
+
+    let bundle = build_export_bundle(&detail, &export_format);
+    let bundle_bytes = match serde_json::to_vec_pretty(&bundle) {
+        Ok(bundle_bytes) => bundle_bytes,
+        Err(error) => {
+            return json_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to serialize biofield export bundle",
+                "BIOFIELD_EXPORT_SERIALIZATION_FAILED",
+                Some(serde_json::json!({ "error": error.to_string() })),
+            )
+        }
+    };
+
+    let storage_path = build_export_storage_path(session_id, &export_format);
+    if let Err(error) = persist_artifact_bytes(&storage_path, &bundle_bytes).await {
+        return biofield_storage_error_response(
+            "persist biofield export bundle",
+            &storage_path,
+            &error,
+        );
+    }
+
+    let file_name = build_export_file_name(reading_uuid, baseline_id, &export_format);
+    let export_record = match save_export_record(
+        biofield_repository,
+        user_id,
+        reading_uuid,
+        baseline_id,
+        &export_format,
+        &file_name,
+        &storage_path,
+        "application/json",
+        bundle_bytes.len() as u64,
+    )
+    .await
+    {
+        Ok(export_record) => export_record,
+        Err(response) => return response,
+    };
+
+    (
+        StatusCode::CREATED,
+        Json(BiofieldExportResponse {
+            export_id: export_record.id.to_string(),
+            reading_id: export_record.reading_id.to_string(),
+            baseline_id: export_record.baseline_id.map(|value| value.to_string()),
+            format: export_record.export_format,
+            file_name: export_record.file_name,
+            mime_type: export_record.mime_type,
+            byte_size: export_record.byte_size as u64,
+            created_at: export_record.created_at,
+            storage_path: export_record.storage_path,
+            bundle,
         }),
     )
         .into_response()

--- a/crates/noesis-api/src/lib.rs
+++ b/crates/noesis-api/src/lib.rs
@@ -1164,6 +1164,18 @@ fn resolve_timezone_offset(
     }
 }
 
+fn inject_internal_auth_context(mut input: EngineInput, user: &AuthUser) -> EngineInput {
+    input.options.insert(
+        "_auth".to_string(),
+        serde_json::json!({ "user_id": user.user_id.clone() }),
+    );
+    input
+}
+
+fn should_persist_engine_output(engine_id: &str) -> bool {
+    engine_id != "biofield-capture"
+}
+
 fn resolve_birth_details(
     input: &EngineInput,
 ) -> Result<ResolvedBirthDetails, (StatusCode, Json<ErrorResponse>)> {
@@ -1805,9 +1817,11 @@ async fn calculate_handler(
     // Extract birth_data for profile auto-population (before input is moved)
     let birth_data_for_profile = input.birth_data.clone();
 
+    let runtime_input = inject_internal_auth_context(input, &user);
+
     let result = state
         .orchestrator
-        .execute_engine(&engine_id, input, user.consciousness_level)
+        .execute_engine(&engine_id, runtime_input, user.consciousness_level)
         .await;
 
     let duration_secs = start.elapsed().as_secs_f64();
@@ -1824,8 +1838,9 @@ async fn calculate_handler(
                 duration_secs,
             );
 
-            // Fire-and-forget: persist reading, log usage, award XP
+            // Fire-and-forget: persist reading when appropriate, log usage, award XP
             if let Ok(uid) = uuid::Uuid::parse_str(&user_id_str) {
+                let should_persist = should_persist_engine_output(&engine_id);
                 let input_hash = format!("{:x}", Sha256::digest(input_json.to_string().as_bytes()));
                 let reading = NewReading {
                     user_id: uid,
@@ -1848,9 +1863,11 @@ async fn calculate_handler(
                 let eid = engine_id.clone();
                 let bd = birth_data_for_profile.clone();
                 tokio::spawn(async move {
-                    if let Some(repo) = readings_repo {
-                        if let Err(e) = repo.save_reading(&reading).await {
-                            tracing::warn!("Failed to persist reading: {}", e);
+                    if should_persist {
+                        if let Some(repo) = readings_repo {
+                            if let Err(e) = repo.save_reading(&reading).await {
+                                tracing::warn!("Failed to persist reading: {}", e);
+                            }
                         }
                     }
                     if let Some(repo) = usage_repo {
@@ -2171,10 +2188,12 @@ async fn execute_workflow_by_id(
     let input_json = serde_json::to_value(&input).unwrap_or_default();
     let birth_data_for_profile = input.birth_data.clone();
 
+    let runtime_input = inject_internal_auth_context(input, &user);
+
     // Execute workflow with user's consciousness level
     let result = state
         .orchestrator
-        .execute_workflow(&workflow_id, input, user.consciousness_level)
+        .execute_workflow(&workflow_id, runtime_input, user.consciousness_level)
         .await;
 
     let duration_secs = start.elapsed().as_secs_f64();
@@ -2957,7 +2976,7 @@ async fn build_runtime_orchestrator_and_bridge(
 /// Configured `AppState` with orchestrator, cache, auth, and metrics
 pub async fn build_app_state(config: &ApiConfig) -> AppState {
     // -- Orchestrator with engines --
-    let (orchestrator, bridge_manager) = build_runtime_orchestrator_and_bridge().await;
+    let (mut orchestrator, bridge_manager) = build_runtime_orchestrator_and_bridge().await;
 
     // -- Cache --
     let redis_url = config.redis_url.clone().unwrap_or_default();
@@ -3043,6 +3062,12 @@ pub async fn build_app_state(config: &ApiConfig) -> AppState {
         None
     };
 
+    if let Some(ref db_pool) = pool {
+        orchestrator.register_engine(Arc::new(noesis_orchestrator::BiofieldCaptureEngine::new(
+            db_pool.clone(),
+        )));
+    }
+
     // -- Auth (Postgres-backed API key validation, or degraded without DB) --
     let auth = AuthService::with_pool(config.jwt_secret.clone(), pool.clone());
 
@@ -3102,7 +3127,7 @@ pub async fn build_app_state(config: &ApiConfig) -> AppState {
 /// endpoints but still need a fully constructed `AppState`.
 pub async fn build_app_state_lazy_db(config: &ApiConfig) -> AppState {
     // -- Orchestrator with engines --
-    let (orchestrator, bridge_manager) = build_runtime_orchestrator_and_bridge().await;
+    let (mut orchestrator, bridge_manager) = build_runtime_orchestrator_and_bridge().await;
 
     // -- Cache --
     let redis_url = config.redis_url.clone().unwrap_or_default();
@@ -3120,6 +3145,12 @@ pub async fn build_app_state_lazy_db(config: &ApiConfig) -> AppState {
             .connect_lazy(db_url)
             .expect("Failed to create lazy database pool")
     });
+
+    if let Some(ref db_pool) = pool {
+        orchestrator.register_engine(Arc::new(noesis_orchestrator::BiofieldCaptureEngine::new(
+            db_pool.clone(),
+        )));
+    }
 
     // -- Auth (lazy Postgres-backed API key validation, or degraded without DB) --
     let auth = AuthService::with_pool(config.jwt_secret.clone(), pool.clone());

--- a/crates/noesis-api/src/lib.rs
+++ b/crates/noesis-api/src/lib.rs
@@ -137,6 +137,7 @@ use workflow_parity::log_workflow_registry_parity;
         handlers::biofield::reprocess_reading,
         handlers::biofield::list_baselines,
         handlers::biofield::create_baseline,
+        handlers::biofield::create_export,
     ),
     components(
         schemas(
@@ -698,6 +699,7 @@ pub fn create_router(state: AppState, config: &ApiConfig) -> Router {
             "/biofield/baselines",
             get(handlers::biofield::list_baselines).post(handlers::biofield::create_baseline),
         )
+        .route("/biofield/exports", post(handlers::biofield::create_export))
         .route("/admin/session", get(handlers::admin::get_session))
         .route("/admin/users", get(handlers::admin::list_users))
         .route(

--- a/crates/noesis-api/tests/biofield_capture_proxy.rs
+++ b/crates/noesis-api/tests/biofield_capture_proxy.rs
@@ -9,7 +9,13 @@ use noesis_api::{create_router, shared_metrics, ApiConfig, AppState};
 use noesis_auth::AuthService;
 use noesis_cache::CacheManager;
 use noesis_data::{
-    models::biofield::NewBiofieldSession,
+    models::{
+        biofield::{
+            NewBiofieldBaseline, NewBiofieldCaptureArtifact, NewBiofieldSession,
+            BIOFIELD_CAPTURE_ARTIFACT_SOURCE_IMAGE,
+        },
+        reading::NewReading,
+    },
     repositories::{
         biofield_repository::BiofieldRepository, readings_repository::ReadingsRepository,
         user_repository::UserRepository,
@@ -65,6 +71,10 @@ async fn ensure_biofield_schema(pool: &PgPool) {
             SELECT 1
             FROM information_schema.tables
             WHERE table_name = 'biofield_baseline_readings'
+        ) AND EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_name = 'biofield_exports'
         )
         "#,
     )
@@ -88,6 +98,8 @@ async fn ensure_biofield_schema(pool: &PgPool) {
     let migration_018 =
         fs::read_to_string(repo_root().join("migrations/018_biofield_baselines.sql"))
             .expect("root migration 018");
+    let migration_019 = fs::read_to_string(repo_root().join("migrations/019_biofield_exports.sql"))
+        .expect("root migration 019");
 
     let apply_result = async {
         let schema_exists_after_lock: bool = sqlx::query_scalar(
@@ -108,6 +120,10 @@ async fn ensure_biofield_schema(pool: &PgPool) {
                 SELECT 1
                 FROM information_schema.tables
                 WHERE table_name = 'biofield_baseline_readings'
+            ) AND EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_name = 'biofield_exports'
             )
             "#,
         )
@@ -127,6 +143,10 @@ async fn ensure_biofield_schema(pool: &PgPool) {
             .execute(pool)
             .await
             .expect("biofield migration 018 should apply to test database");
+        sqlx::raw_sql(&migration_019)
+            .execute(pool)
+            .await
+            .expect("biofield migration 019 should apply to test database");
     }
     .await;
 
@@ -438,6 +458,72 @@ impl BiofieldCaptureHarness {
             .await
             .expect("test user cleanup should succeed");
     }
+}
+
+async fn create_persisted_biofield_reading(
+    harness: &BiofieldCaptureHarness,
+    user_id: Uuid,
+    session_id: Uuid,
+    label: &str,
+    metrics: Value,
+) -> Uuid {
+    let reading_id = harness
+        .readings_repository
+        .save_reading(&NewReading {
+            user_id,
+            engine_id: "biofield-capture".to_string(),
+            workflow_id: None,
+            input_hash: format!("bf-{:.8}-{}", label, Uuid::new_v4().simple()),
+            input_data: json!({
+                "session_id": session_id,
+                "content_type": "image/jpeg",
+                "file_name": format!("{label}.jpg"),
+                "capture_metadata": {
+                    "platform": "test"
+                }
+            }),
+            result_data: json!({
+                "analysis_version": "stub-metrics/v1",
+                "metrics": metrics,
+                "quality_assessment": {
+                    "sharpness": 0.88,
+                    "contrast": 0.82,
+                    "noise_level": 0.08,
+                    "exposure": 0.54,
+                    "sufficient_quality": true
+                }
+            }),
+            witness_prompt: None,
+            consciousness_level: 0,
+            calculation_time_ms: Some(12.5),
+            client_event_id: None,
+            client_device_id: Some("test-device".to_string()),
+            device_platform: Some("test".to_string()),
+            device_app_version: Some("biofield-web/test".to_string()),
+        })
+        .await
+        .expect("reading should be created");
+
+    harness
+        .biofield_repository
+        .create_artifact(&NewBiofieldCaptureArtifact {
+            session_id,
+            reading_id: Some(reading_id),
+            artifact_kind: BIOFIELD_CAPTURE_ARTIFACT_SOURCE_IMAGE.to_string(),
+            storage_path: format!("biofield/{session_id}/{label}.jpg"),
+            mime_type: "image/jpeg".to_string(),
+            byte_size: 4_096,
+            capture_metadata: json!({
+                "file_name": format!("{label}.jpg"),
+                "capture_metadata": {
+                    "platform": "test"
+                }
+            }),
+        })
+        .await
+        .expect("artifact should be created");
+
+    reading_id
 }
 
 #[tokio::test]
@@ -1187,6 +1273,252 @@ async fn biofield_baselines_create_and_list_are_user_scoped() {
         cross_user_payload["error_code"],
         "BIOFIELD_READING_NOT_FOUND"
     );
+
+    harness.delete_user(other_user_id).await;
+    harness.delete_user(user_id).await;
+    let _ = fs::remove_dir_all(artifacts_dir);
+}
+
+#[tokio::test]
+#[serial]
+async fn biofield_reading_detail_supports_baseline_comparison() {
+    let Some(harness) = BiofieldCaptureHarness::new().await else {
+        return;
+    };
+
+    let user_id = harness.create_user_id("comparison-owner").await;
+    let session_id = harness.create_session_for_user(user_id).await;
+    let token = harness.token_for_user(user_id);
+
+    let primary_reading_id = create_persisted_biofield_reading(
+        &harness,
+        user_id,
+        session_id,
+        "comparison-primary",
+        json!({
+            "light_quanta_density": 50.0,
+            "normalized_area": 0.8,
+            "average_intensity": 0.55,
+            "energy_analysis": {
+                "low": 0.2,
+                "medium": 0.5,
+                "high": 0.3,
+                "total": 1.0
+            }
+        }),
+    )
+    .await;
+    let baseline_reading_id = create_persisted_biofield_reading(
+        &harness,
+        user_id,
+        session_id,
+        "comparison-baseline",
+        json!({
+            "light_quanta_density": 30.0,
+            "normalized_area": 0.5,
+            "average_intensity": 0.4,
+            "energy_analysis": {
+                "low": 0.1,
+                "medium": 0.6,
+                "high": 0.3,
+                "total": 1.0
+            }
+        }),
+    )
+    .await;
+
+    let baseline = harness
+        .biofield_repository
+        .create_baseline(
+            &NewBiofieldBaseline {
+                user_id,
+                name: "Reference baseline".to_string(),
+                notes: Some("Built for BF3 comparison".to_string()),
+            },
+            &[baseline_reading_id],
+        )
+        .await
+        .expect("baseline should be created");
+
+    let (status, payload) = harness
+        .send_authenticated_request(
+            "GET",
+            &format!(
+                "/api/v1/biofield/readings/{}?baseline_id={}",
+                primary_reading_id, baseline.id
+            ),
+            &token,
+        )
+        .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload["comparison"]["comparison_version"],
+        "biofield-baseline-delta/v1"
+    );
+    assert_eq!(
+        payload["comparison"]["baseline"]["baseline_id"],
+        baseline.id.to_string()
+    );
+    let delta = payload["comparison"]["deltas"]
+        .as_array()
+        .expect("comparison deltas array")
+        .iter()
+        .find(|item| item["key"] == "light_quanta_density")
+        .expect("light_quanta_density delta should exist");
+    assert_eq!(delta["reading_value"], 50.0);
+    assert_eq!(delta["baseline_value"], 30.0);
+    assert_eq!(delta["absolute_delta"], 20.0);
+
+    harness.delete_user(user_id).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn biofield_exports_persist_bundle_and_enforce_user_scope() {
+    let Some(harness) = BiofieldCaptureHarness::new().await else {
+        return;
+    };
+
+    let user_id = harness.create_user_id("export-owner").await;
+    let other_user_id = harness.create_user_id("export-other").await;
+    let session_id = harness.create_session_for_user(user_id).await;
+    let other_session_id = harness.create_session_for_user(other_user_id).await;
+    let token = harness.token_for_user(user_id);
+    let artifacts_dir = artifact_dir("export");
+    let _env = EnvGuard::set(&[(
+        "BIOFIELD_ARTIFACTS_DIR",
+        artifacts_dir.display().to_string(),
+    )]);
+
+    let reading_id = create_persisted_biofield_reading(
+        &harness,
+        user_id,
+        session_id,
+        "export-reading",
+        json!({
+            "light_quanta_density": 42.5,
+            "normalized_area": 0.67,
+            "average_intensity": 0.51,
+            "energy_analysis": {
+                "low": 0.2,
+                "medium": 0.5,
+                "high": 0.3,
+                "total": 1.0
+            }
+        }),
+    )
+    .await;
+    let baseline_reading_id = create_persisted_biofield_reading(
+        &harness,
+        user_id,
+        session_id,
+        "export-baseline",
+        json!({
+            "light_quanta_density": 40.0,
+            "normalized_area": 0.6,
+            "average_intensity": 0.49,
+            "energy_analysis": {
+                "low": 0.25,
+                "medium": 0.45,
+                "high": 0.3,
+                "total": 1.0
+            }
+        }),
+    )
+    .await;
+    let baseline = harness
+        .biofield_repository
+        .create_baseline(
+            &NewBiofieldBaseline {
+                user_id,
+                name: "Export baseline".to_string(),
+                notes: Some("Used for BF3 export proof".to_string()),
+            },
+            &[baseline_reading_id],
+        )
+        .await
+        .expect("baseline should be created");
+
+    let other_reading_id = create_persisted_biofield_reading(
+        &harness,
+        other_user_id,
+        other_session_id,
+        "export-foreign",
+        json!({
+            "light_quanta_density": 10.0,
+            "normalized_area": 0.2,
+            "average_intensity": 0.1,
+            "energy_analysis": {
+                "low": 0.4,
+                "medium": 0.4,
+                "high": 0.2,
+                "total": 1.0
+            }
+        }),
+    )
+    .await;
+
+    let (status, payload) = harness
+        .send_authenticated_json(
+            "POST",
+            "/api/v1/biofield/exports",
+            &token,
+            json!({
+                "reading_id": reading_id,
+                "baseline_id": baseline.id,
+                "format": "json",
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(payload["reading_id"], reading_id.to_string());
+    assert_eq!(payload["baseline_id"], baseline.id.to_string());
+    assert_eq!(payload["format"], "json");
+    assert_eq!(payload["bundle"]["contract_version"], "biofield-export/v1");
+    assert_eq!(
+        payload["bundle"]["reading"]["comparison"]["baseline"]["baseline_id"],
+        baseline.id.to_string()
+    );
+
+    let export_id = Uuid::parse_str(payload["export_id"].as_str().expect("export id string"))
+        .expect("valid export uuid");
+    let storage_path = payload["storage_path"]
+        .as_str()
+        .expect("storage path should exist")
+        .to_string();
+    assert!(artifacts_dir.join(&storage_path).exists());
+
+    let export_record = harness
+        .biofield_repository
+        .get_export(export_id, user_id)
+        .await
+        .expect("export lookup should succeed")
+        .expect("export should exist for owner");
+    assert_eq!(export_record.reading_id, reading_id);
+    assert_eq!(export_record.baseline_id, Some(baseline.id));
+    assert_eq!(export_record.export_format, "json");
+
+    let foreign_export = harness
+        .biofield_repository
+        .get_export(export_id, other_user_id)
+        .await
+        .expect("foreign export lookup should not error");
+    assert!(foreign_export.is_none());
+
+    let (cross_status, cross_payload) = harness
+        .send_authenticated_json(
+            "POST",
+            "/api/v1/biofield/exports",
+            &token,
+            json!({
+                "reading_id": other_reading_id,
+                "format": "json",
+            }),
+        )
+        .await;
+    assert_eq!(cross_status, StatusCode::NOT_FOUND);
+    assert_eq!(cross_payload["error_code"], "BIOFIELD_READING_NOT_FOUND");
 
     harness.delete_user(other_user_id).await;
     harness.delete_user(user_id).await;

--- a/crates/noesis-api/tests/biofield_capture_proxy.rs
+++ b/crates/noesis-api/tests/biofield_capture_proxy.rs
@@ -312,8 +312,13 @@ impl BiofieldCaptureHarness {
         let biofield_repository = Arc::new(BiofieldRepository::new(pool.clone()));
         let readings_repository = Arc::new(ReadingsRepository::new(pool.clone()));
 
+        let mut orchestrator = WorkflowOrchestrator::new();
+        orchestrator.register_engine(Arc::new(noesis_orchestrator::BiofieldCaptureEngine::new(
+            pool.clone(),
+        )));
+
         let state = AppState {
-            orchestrator: Arc::new(WorkflowOrchestrator::new()),
+            orchestrator: Arc::new(orchestrator),
             bridge_manager: Arc::new(noesis_bridge::BridgeManager::from_env()),
             cache: Arc::new(CacheManager::new(
                 String::new(),
@@ -452,6 +457,78 @@ impl BiofieldCaptureHarness {
     }
 
     async fn delete_user(&self, user_id: Uuid) {
+        sqlx::query(
+            "DELETE FROM biofield_exports WHERE user_id = $1",
+        )
+        .bind(user_id)
+        .execute(&self.pool)
+        .await
+        .expect("cleanup biofield_exports should succeed");
+
+        sqlx::query(
+            r#"
+            DELETE FROM biofield_baseline_readings
+            WHERE baseline_id IN (
+                SELECT id FROM biofield_baselines WHERE user_id = $1
+            )
+            "#,
+        )
+        .bind(user_id)
+        .execute(&self.pool)
+        .await
+        .expect("cleanup biofield_baseline_readings should succeed");
+
+        sqlx::query("DELETE FROM biofield_baselines WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&self.pool)
+            .await
+            .expect("cleanup biofield_baselines should succeed");
+
+        sqlx::query(
+            r#"
+            DELETE FROM biofield_capture_artifacts
+            WHERE session_id IN (
+                SELECT id FROM biofield_sessions WHERE user_id = $1
+            ) OR reading_id IN (
+                SELECT id FROM readings WHERE user_id = $1
+            )
+            "#,
+        )
+        .bind(user_id)
+        .execute(&self.pool)
+        .await
+        .expect("cleanup biofield_capture_artifacts should succeed");
+
+        sqlx::query("DELETE FROM biofield_sessions WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&self.pool)
+            .await
+            .expect("cleanup biofield_sessions should succeed");
+
+        sqlx::query("DELETE FROM progression_logs WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&self.pool)
+            .await
+            .expect("cleanup progression_logs should succeed");
+
+        sqlx::query("DELETE FROM history_sync_state WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&self.pool)
+            .await
+            .expect("cleanup history_sync_state should succeed");
+
+        sqlx::query("DELETE FROM readings WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&self.pool)
+            .await
+            .expect("cleanup readings should succeed");
+
+        sqlx::query("DELETE FROM user_devices WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&self.pool)
+            .await
+            .expect("cleanup user_devices should succeed");
+
         sqlx::query("DELETE FROM users WHERE id = $1")
             .bind(user_id)
             .execute(&self.pool)
@@ -1370,6 +1447,91 @@ async fn biofield_reading_detail_supports_baseline_comparison() {
     assert_eq!(delta["baseline_value"], 30.0);
     assert_eq!(delta["absolute_delta"], 20.0);
 
+    harness.delete_user(user_id).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn biofield_capture_engine_route_resolves_owner_reading() {
+    let Some(harness) = BiofieldCaptureHarness::new().await else {
+        return;
+    };
+
+    let user_id = harness.create_user_id("engine-route").await;
+    let session_id = harness.create_session_for_user(user_id).await;
+    let reading_id = create_persisted_biofield_reading(
+        &harness,
+        user_id,
+        session_id,
+        "engine-route",
+        json!({
+            "light_quanta_density": 48.0,
+            "normalized_area": 0.62,
+            "average_intensity": 172.0,
+            "fractal_dimension": 1.41,
+            "body_symmetry": 0.77,
+            "pattern_regularity": 0.58
+        }),
+    )
+    .await;
+    let token = harness.token_for_user(user_id);
+    let reading_count_before = harness
+        .readings_repository
+        .count_readings(user_id, Some("biofield-capture"))
+        .await
+        .expect("reading count before route call should succeed");
+
+    let (status, payload) = harness
+        .send_authenticated_json(
+            "POST",
+            "/api/v1/engines/biofield-capture/calculate",
+            &token,
+            json!({
+                "options": {
+                    "biofield_capture": {
+                        "reading_id": reading_id
+                    }
+                }
+            }),
+        )
+        .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["engine_id"], "biofield-capture");
+    assert_eq!(payload["result"]["reading_id"], reading_id.to_string());
+    assert_eq!(
+        payload["result"]["analysis"]["analysis_version"],
+        "stub-metrics/v1"
+    );
+    assert_eq!(
+        payload["result"]["quality_assessment"]["sufficient_quality"],
+        true
+    );
+    assert!(payload["witness_prompt"].as_str().unwrap_or_default().len() > 8);
+
+    let reading_count_after = harness
+        .readings_repository
+        .count_readings(user_id, Some("biofield-capture"))
+        .await
+        .expect("reading count after route call should succeed");
+    assert_eq!(reading_count_before, 1);
+    assert_eq!(reading_count_after, reading_count_before);
+
+    sqlx::query("DELETE FROM biofield_capture_artifacts WHERE session_id = $1")
+        .bind(session_id)
+        .execute(&harness.pool)
+        .await
+        .expect("cleanup artifacts");
+    sqlx::query("DELETE FROM biofield_sessions WHERE id = $1")
+        .bind(session_id)
+        .execute(&harness.pool)
+        .await
+        .expect("cleanup session");
+    sqlx::query("DELETE FROM readings WHERE id = $1")
+        .bind(reading_id)
+        .execute(&harness.pool)
+        .await
+        .expect("cleanup reading");
     harness.delete_user(user_id).await;
 }
 

--- a/crates/noesis-api/tests/biofield_handler_smoke.rs
+++ b/crates/noesis-api/tests/biofield_handler_smoke.rs
@@ -38,6 +38,7 @@ async fn biofield_handler_smoke_routes_exist_under_api_v1() {
         ),
         ("GET", "/api/v1/biofield/baselines", None),
         ("POST", "/api/v1/biofield/baselines", Some(json!({}))),
+        ("POST", "/api/v1/biofield/exports", Some(json!({}))),
     ];
 
     for (method, uri, body) in unauthorized_cases {
@@ -82,6 +83,7 @@ async fn biofield_handler_smoke_openapi_contains_biofield_paths() {
         "/api/v1/biofield/readings/{reading_id}",
         "/api/v1/biofield/readings/{reading_id}/reprocess",
         "/api/v1/biofield/baselines",
+        "/api/v1/biofield/exports",
     ];
 
     for path in expected {

--- a/crates/noesis-api/tests/workflow_tests.rs
+++ b/crates/noesis-api/tests/workflow_tests.rs
@@ -130,6 +130,32 @@ fn create_vimshottari_input_with_moon() -> Value {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
+async fn test_engine_list_includes_biofield_capture_when_db_is_configured() {
+    if std::env::var("DATABASE_URL")
+        .or_else(|_| std::env::var("TEST_DATABASE_URL"))
+        .is_err()
+    {
+        eprintln!("Skipping engine-list DB bootstrap test: DATABASE_URL not set");
+        return;
+    }
+
+    let router = get_test_router().await;
+    let token = generate_test_token(5);
+
+    let (status, body) = authenticated_get(router, "/api/v1/engines", &token).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let engines = body["engines"].as_array().expect("engines should be array");
+    let engine_ids: Vec<&str> = engines.iter().filter_map(|e| e.as_str()).collect();
+
+    assert!(
+        engine_ids.contains(&"biofield-capture"),
+        "Engine list should include biofield-capture when DB is configured: {:?}",
+        engine_ids
+    );
+}
+
+#[tokio::test]
 async fn test_engine_list_includes_gene_keys_and_vimshottari() {
     let router = get_test_router().await;
     let token = generate_test_token(5);

--- a/crates/noesis-data/src/models/biofield.rs
+++ b/crates/noesis-data/src/models/biofield.rs
@@ -11,6 +11,7 @@ pub const BIOFIELD_CAPTURE_ARTIFACT_SOURCE_IMAGE: &str = "source-image";
 pub const BIOFIELD_CAPTURE_ARTIFACT_SEGMENTATION_MASK: &str = "segmentation-mask";
 pub const BIOFIELD_CAPTURE_ARTIFACT_ANALYSIS_OVERLAY: &str = "analysis-overlay";
 pub const BIOFIELD_CAPTURE_ARTIFACT_THUMBNAIL: &str = "thumbnail";
+pub const BIOFIELD_EXPORT_FORMAT_JSON: &str = "json";
 
 pub const BIOFIELD_SESSION_STATUSES: [&str; 3] = [
     BIOFIELD_SESSION_STATUS_ACTIVE,
@@ -25,12 +26,18 @@ pub const BIOFIELD_CAPTURE_ARTIFACT_KINDS: [&str; 4] = [
     BIOFIELD_CAPTURE_ARTIFACT_THUMBNAIL,
 ];
 
+pub const BIOFIELD_EXPORT_FORMATS: [&str; 1] = [BIOFIELD_EXPORT_FORMAT_JSON];
+
 pub fn is_valid_biofield_session_status(status: &str) -> bool {
     BIOFIELD_SESSION_STATUSES.contains(&status)
 }
 
 pub fn is_valid_biofield_capture_artifact_kind(kind: &str) -> bool {
     BIOFIELD_CAPTURE_ARTIFACT_KINDS.contains(&kind)
+}
+
+pub fn is_valid_biofield_export_format(format: &str) -> bool {
+    BIOFIELD_EXPORT_FORMATS.contains(&format)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
@@ -118,6 +125,32 @@ pub struct NewBiofieldBaseline {
     pub notes: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct BiofieldExport {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub reading_id: Uuid,
+    pub baseline_id: Option<Uuid>,
+    pub export_format: String,
+    pub file_name: String,
+    pub storage_path: String,
+    pub mime_type: String,
+    pub byte_size: i64,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewBiofieldExport {
+    pub user_id: Uuid,
+    pub reading_id: Uuid,
+    pub baseline_id: Option<Uuid>,
+    pub export_format: String,
+    pub file_name: String,
+    pub storage_path: String,
+    pub mime_type: String,
+    pub byte_size: i64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -157,5 +190,12 @@ mod tests {
         assert!(session.client_device_id.is_none());
         assert!(session.viewer_version.is_none());
         assert!(session.notes.is_none());
+    }
+
+    #[test]
+    fn biofield_models_export_format_values_are_stable() {
+        assert_eq!(BIOFIELD_EXPORT_FORMATS, ["json"]);
+        assert!(is_valid_biofield_export_format("json"));
+        assert!(!is_valid_biofield_export_format("pdf"));
     }
 }

--- a/crates/noesis-data/src/repositories/biofield_repository.rs
+++ b/crates/noesis-data/src/repositories/biofield_repository.rs
@@ -1,8 +1,9 @@
 use crate::models::biofield::{
-    BiofieldBaseline, BiofieldBaselineSummaryRecord, BiofieldCaptureArtifact, BiofieldSession,
-    NewBiofieldBaseline, NewBiofieldCaptureArtifact, NewBiofieldSession,
-    BIOFIELD_SESSION_STATUS_ACTIVE, BIOFIELD_SESSION_STATUS_CLOSED,
+    BiofieldBaseline, BiofieldBaselineSummaryRecord, BiofieldCaptureArtifact, BiofieldExport,
+    BiofieldSession, NewBiofieldBaseline, NewBiofieldCaptureArtifact, NewBiofieldExport,
+    NewBiofieldSession, BIOFIELD_SESSION_STATUS_ACTIVE, BIOFIELD_SESSION_STATUS_CLOSED,
 };
+use crate::models::reading::Reading;
 use sqlx::{Error, PgPool};
 use uuid::Uuid;
 
@@ -174,6 +175,60 @@ impl BiofieldRepository {
         .await
     }
 
+    pub async fn get_baseline_summary(
+        &self,
+        baseline_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Option<BiofieldBaselineSummaryRecord>, Error> {
+        sqlx::query_as::<_, BiofieldBaselineSummaryRecord>(
+            r#"
+            SELECT
+                baseline.id,
+                baseline.user_id,
+                baseline.name,
+                baseline.notes,
+                baseline.created_at,
+                baseline.updated_at,
+                COUNT(link.reading_id)::BIGINT AS reading_count
+            FROM biofield_baselines AS baseline
+            LEFT JOIN biofield_baseline_readings AS link
+                ON link.baseline_id = baseline.id
+            WHERE baseline.id = $1
+              AND baseline.user_id = $2
+            GROUP BY baseline.id
+            "#,
+        )
+        .bind(baseline_id)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    pub async fn list_baseline_readings(
+        &self,
+        baseline_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Vec<Reading>, Error> {
+        sqlx::query_as::<_, Reading>(
+            r#"
+            SELECT readings.*
+            FROM biofield_baseline_readings AS link
+            INNER JOIN biofield_baselines AS baseline
+                ON baseline.id = link.baseline_id
+            INNER JOIN readings
+                ON readings.id = link.reading_id
+            WHERE link.baseline_id = $1
+              AND baseline.user_id = $2
+              AND readings.user_id = $2
+            ORDER BY link.sort_order ASC, readings.created_at ASC
+            "#,
+        )
+        .bind(baseline_id)
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await
+    }
+
     pub async fn create_baseline(
         &self,
         baseline: &NewBiofieldBaseline,
@@ -239,12 +294,51 @@ impl BiofieldRepository {
         .fetch_all(&self.pool)
         .await
     }
+
+    pub async fn create_export(&self, export: &NewBiofieldExport) -> Result<BiofieldExport, Error> {
+        sqlx::query_as::<_, BiofieldExport>(
+            r#"
+            INSERT INTO biofield_exports (
+                user_id, reading_id, baseline_id, export_format, file_name,
+                storage_path, mime_type, byte_size
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING *
+            "#,
+        )
+        .bind(export.user_id)
+        .bind(export.reading_id)
+        .bind(export.baseline_id)
+        .bind(&export.export_format)
+        .bind(&export.file_name)
+        .bind(&export.storage_path)
+        .bind(&export.mime_type)
+        .bind(export.byte_size)
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    pub async fn get_export(
+        &self,
+        export_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Option<BiofieldExport>, Error> {
+        sqlx::query_as::<_, BiofieldExport>(
+            "SELECT * FROM biofield_exports WHERE id = $1 AND user_id = $2",
+        )
+        .bind(export_id)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::biofield::BIOFIELD_CAPTURE_ARTIFACT_SOURCE_IMAGE;
+    use crate::models::biofield::{
+        NewBiofieldBaseline, NewBiofieldExport, BIOFIELD_CAPTURE_ARTIFACT_SOURCE_IMAGE,
+    };
     use crate::models::reading::NewReading;
     use crate::repositories::readings_repository::ReadingsRepository;
     use crate::repositories::user_repository::UserRepository;
@@ -283,6 +377,10 @@ mod tests {
                 SELECT 1
                 FROM information_schema.tables
                 WHERE table_name = 'biofield_baseline_readings'
+            ) AND EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_name = 'biofield_exports'
             )
             "#,
         )
@@ -306,6 +404,9 @@ mod tests {
         let migration_018 =
             fs::read_to_string(repo_root().join("migrations/018_biofield_baselines.sql"))
                 .expect("root migration 018");
+        let migration_019 =
+            fs::read_to_string(repo_root().join("migrations/019_biofield_exports.sql"))
+                .expect("root migration 019");
 
         let apply_result = async {
             let schema_exists_after_lock: bool = sqlx::query_scalar(
@@ -326,6 +427,10 @@ mod tests {
                     SELECT 1
                     FROM information_schema.tables
                     WHERE table_name = 'biofield_baseline_readings'
+                ) AND EXISTS (
+                    SELECT 1
+                    FROM information_schema.tables
+                    WHERE table_name = 'biofield_exports'
                 )
                 "#,
             )
@@ -345,6 +450,10 @@ mod tests {
                 .execute(pool)
                 .await
                 .expect("biofield migration 018 should apply to test database");
+            sqlx::raw_sql(&migration_019)
+                .execute(pool)
+                .await
+                .expect("biofield migration 019 should apply to test database");
         }
         .await;
 
@@ -564,6 +673,161 @@ mod tests {
             .execute(&pool)
             .await
             .expect("cleanup readings");
+        sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user.id)
+            .execute(&pool)
+            .await
+            .expect("cleanup users");
+    }
+
+    #[tokio::test]
+    async fn biofield_repository_lists_baseline_readings_and_gets_exports() {
+        let Some(pool) = connect_test_db().await else {
+            return;
+        };
+
+        let user_repo = UserRepository::new(pool.clone());
+        let readings_repo = ReadingsRepository::new(pool.clone());
+        let biofield_repo = BiofieldRepository::new(pool.clone());
+        let email = format!("biofield-export-{}@example.com", Uuid::new_v4());
+
+        let user = user_repo
+            .create_user(&email, "test_password_hash", "Biofield Export Test User")
+            .await
+            .expect("Failed to create test user");
+
+        let session = biofield_repo
+            .create_session(&NewBiofieldSession::new(user.id))
+            .await
+            .expect("session should be created");
+
+        let first_reading_id = readings_repo
+            .save_reading(&NewReading {
+                user_id: user.id,
+                engine_id: "biofield-capture".to_string(),
+                workflow_id: None,
+                input_hash: format!("biofield-export-input-{}", Uuid::new_v4()),
+                input_data: json!({
+                    "session_id": session.id,
+                    "content_type": "image/jpeg"
+                }),
+                result_data: json!({
+                    "analysis_version": "stub-metrics/v1",
+                    "metrics": { "light_quanta_density": 40.0 },
+                    "quality_assessment": { "sufficient_quality": true }
+                }),
+                witness_prompt: None,
+                consciousness_level: 0,
+                calculation_time_ms: Some(8.0),
+                client_event_id: None,
+                client_device_id: None,
+                device_platform: None,
+                device_app_version: None,
+            })
+            .await
+            .expect("first reading should be created");
+
+        let second_reading_id = readings_repo
+            .save_reading(&NewReading {
+                user_id: user.id,
+                engine_id: "biofield-capture".to_string(),
+                workflow_id: None,
+                input_hash: format!("biofield-export-input-{}", Uuid::new_v4()),
+                input_data: json!({
+                    "session_id": session.id,
+                    "content_type": "image/jpeg"
+                }),
+                result_data: json!({
+                    "analysis_version": "stub-metrics/v1",
+                    "metrics": { "light_quanta_density": 35.0 },
+                    "quality_assessment": { "sufficient_quality": true }
+                }),
+                witness_prompt: None,
+                consciousness_level: 0,
+                calculation_time_ms: Some(8.0),
+                client_event_id: None,
+                client_device_id: None,
+                device_platform: None,
+                device_app_version: None,
+            })
+            .await
+            .expect("second reading should be created");
+
+        let baseline = biofield_repo
+            .create_baseline(
+                &NewBiofieldBaseline {
+                    user_id: user.id,
+                    name: "Reference baseline".to_string(),
+                    notes: Some("Created for repository verification".to_string()),
+                },
+                &[first_reading_id, second_reading_id],
+            )
+            .await
+            .expect("baseline should be created");
+
+        let baseline_readings = biofield_repo
+            .list_baseline_readings(baseline.id, user.id)
+            .await
+            .expect("baseline readings should list");
+        assert_eq!(baseline_readings.len(), 2);
+        assert_eq!(baseline_readings[0].id, first_reading_id);
+        assert_eq!(baseline_readings[1].id, second_reading_id);
+
+        let export = biofield_repo
+            .create_export(&NewBiofieldExport {
+                user_id: user.id,
+                reading_id: first_reading_id,
+                baseline_id: Some(baseline.id),
+                export_format: "json".to_string(),
+                file_name: "biofield-reading.json".to_string(),
+                storage_path: format!("biofield/{}/exports/export.json", session.id),
+                mime_type: "application/json".to_string(),
+                byte_size: 1024,
+            })
+            .await
+            .expect("export should be created");
+
+        let fetched_export = biofield_repo
+            .get_export(export.id, user.id)
+            .await
+            .expect("export fetch should succeed")
+            .expect("export should exist");
+        assert_eq!(fetched_export.reading_id, first_reading_id);
+        assert_eq!(fetched_export.baseline_id, Some(baseline.id));
+        assert_eq!(fetched_export.export_format, "json");
+
+        let missing_export = biofield_repo
+            .get_export(export.id, Uuid::new_v4())
+            .await
+            .expect("cross-user export fetch should not error");
+        assert!(missing_export.is_none());
+
+        sqlx::query("DELETE FROM biofield_exports WHERE id = $1")
+            .bind(export.id)
+            .execute(&pool)
+            .await
+            .expect("cleanup biofield_exports");
+        sqlx::query("DELETE FROM biofield_baseline_readings WHERE baseline_id = $1")
+            .bind(baseline.id)
+            .execute(&pool)
+            .await
+            .expect("cleanup biofield_baseline_readings");
+        sqlx::query("DELETE FROM biofield_baselines WHERE id = $1")
+            .bind(baseline.id)
+            .execute(&pool)
+            .await
+            .expect("cleanup biofield_baselines");
+        sqlx::query("DELETE FROM readings WHERE id = $1 OR id = $2")
+            .bind(first_reading_id)
+            .bind(second_reading_id)
+            .execute(&pool)
+            .await
+            .expect("cleanup readings");
+        sqlx::query("DELETE FROM biofield_sessions WHERE id = $1")
+            .bind(session.id)
+            .execute(&pool)
+            .await
+            .expect("cleanup biofield_sessions");
         sqlx::query("DELETE FROM users WHERE id = $1")
             .bind(user.id)
             .execute(&pool)

--- a/crates/noesis-orchestrator/Cargo.toml
+++ b/crates/noesis-orchestrator/Cargo.toml
@@ -11,6 +11,7 @@ noesis-witness = { path = "../noesis-witness" }
 noesis-bridge = { path = "../noesis-bridge" }
 engine-biorhythm = { path = "../engine-biorhythm" }
 engine-biofield = { path = "../engine-biofield" }
+engine-biofield-capture = { path = "../engine-biofield-capture" }
 engine-face-reading = { path = "../engine-face-reading" }
 engine-gene-keys = { path = "../engine-gene-keys" }
 engine-human-design = { path = "../engine-human-design" }
@@ -30,6 +31,7 @@ async-trait = "0.1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }
+sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-rustls"] }
 
 [[bench]]
 name = "workflow_bench"

--- a/crates/noesis-orchestrator/src/lib.rs
+++ b/crates/noesis-orchestrator/src/lib.rs
@@ -63,6 +63,7 @@ pub use noesis_bridge::{BridgeEngine, BridgeManager, DEFAULT_TS_SERVER_URL};
 
 // Re-export engine types for convenience
 pub use engine_biofield::BiofieldEngine;
+pub use engine_biofield_capture::BiofieldCaptureEngine;
 
 use chrono::Utc;
 use futures::future::join_all;
@@ -274,6 +275,11 @@ impl WorkflowOrchestrator {
     ///
     /// This keeps engine-construction details out of transport crates so API
     /// handlers only depend on the orchestrator boundary.
+    ///
+    /// Note: data-backed engines that need a database connection (for example
+    /// `biofield-capture`) are intentionally not registered here. Transport
+    /// crates may opt into those engines only when a repository-backed runtime
+    /// is actually available.
     pub fn register_native_runtime_engines(&mut self) {
         self.register_engine(Arc::new(engine_panchanga::PanchangaEngine::new()));
         self.register_engine(Arc::new(engine_numerology::NumerologyEngine::new()));

--- a/crates/noesis-orchestrator/src/workflow/executor.rs
+++ b/crates/noesis-orchestrator/src/workflow/executor.rs
@@ -351,7 +351,11 @@ mod tests {
         assert_eq!(output.engine_results.len(), 3);
 
         let snapshot = executor.execution_routing_snapshot();
-        assert_eq!(snapshot.orchestrated_execute_calls, 3);
+        // WorkflowExecutor uses the richer workflow registry, where birth-blueprint
+        // attempts numerology, human-design, vimshottari, biofield, and face-reading.
+        // The mock setup only registers the first three, so output count is 3 while
+        // routed execution count is still 5.
+        assert_eq!(snapshot.orchestrated_execute_calls, 5);
         assert_eq!(snapshot.direct_execute_calls, 0);
         assert_eq!(snapshot.bypass_count, 0);
     }

--- a/crates/noesis-orchestrator/tests/trait_conformance_tests.rs
+++ b/crates/noesis-orchestrator/tests/trait_conformance_tests.rs
@@ -1,5 +1,6 @@
 use chrono::{TimeZone, Utc};
 use engine_biofield::BiofieldEngine;
+use engine_biofield_capture::BiofieldCaptureEngine;
 use engine_biorhythm::BiorhythmEngine;
 use engine_face_reading::FaceReadingEngine;
 use engine_gene_keys::GeneKeysEngine;
@@ -12,6 +13,7 @@ use engine_vedic_clock::VedicClockEngine;
 use engine_vimshottari::VimshottariEngine;
 use noesis_core::{BirthData, ConsciousnessEngine, EngineInput, Precision};
 use serde_json::json;
+use sqlx::postgres::PgPoolOptions;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -57,6 +59,16 @@ fn assert_engine_conformance(
 fn trait_conformance_biofield() {
     let engine = BiofieldEngine::new();
     assert_engine_conformance(&engine, "biofield", 1);
+}
+
+#[tokio::test]
+async fn trait_conformance_biofield_capture() {
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect_lazy("postgres://localhost/noesis_test")
+        .expect("lazy pool should build");
+    let engine = BiofieldCaptureEngine::new(pool);
+    assert_engine_conformance(&engine, "biofield-capture", 1);
 }
 
 #[test]

--- a/docs/runbooks/biofield-capture-analysis.md
+++ b/docs/runbooks/biofield-capture-analysis.md
@@ -1,11 +1,11 @@
 # Biofield Capture Analysis Runbook
 
 Date: 2026-04-09
-Status: BF2 local verification path
+Status: BF3 local verification path
 
 ## Purpose
 
-This runbook covers the local verification path for the post-BF1 biofield slice.
+This runbook covers the local verification path for the current biofield vertical slice.
 
 It proves that:
 
@@ -19,6 +19,8 @@ It proves that:
 - the reading detail route returns the persisted analysis payload and artifact metadata
 - a stored source artifact can be reprocessed into a new reading
 - a baseline can be created from selected readings and listed back to the user
+- reading detail can return baseline comparison deltas
+- an export bundle can be created, persisted, and downloaded locally
 
 ## Expected Local Ports
 
@@ -26,6 +28,8 @@ It proves that:
 - `noesis-server`: `8080`
 - `biofield_cv_service`: `8002`
 - `postgres`: `5432`
+
+If local `8080` is occupied, pick another API port and pass it consistently to the API process, web env, and smoke command.
 
 ## Required Environment
 
@@ -133,7 +137,7 @@ bash /Volumes/madara/2026/witnessos/Selemene-engine/scripts/smoke_biofield_web.s
 
 ## Expected Results
 
-The BF2 smoke path should prove all of the following:
+The BF3 smoke path should prove all of the following:
 
 - `/login`, `/viewer`, and `/history` return `200`
 - `/health/live` returns `200`
@@ -147,11 +151,14 @@ The BF2 smoke path should prove all of the following:
 - `GET /api/v1/biofield/readings/:reprocessed_reading_id` resolves
 - `POST /api/v1/biofield/baselines` creates a baseline from the original and reprocessed readings
 - `GET /api/v1/biofield/baselines` returns the created baseline
+- `GET /api/v1/biofield/readings/:reading_id?baseline_id=...` returns comparison deltas
+- `POST /api/v1/biofield/exports` returns persisted export metadata and a bundle payload
+- the returned export `storage_path` exists under the configured biofield artifact root
 - `POST /api/v1/biofield/sessions/:session_id/close` returns `closed`
 
 ## What This Runbook Proves
 
-This BF2 runbook proves the next storage-backed slice beyond BF1:
+This BF3 runbook proves the current storage-backed slice beyond BF2:
 
 - authenticated session lifecycle
 - capture ingestion through Noesis
@@ -161,6 +168,8 @@ This BF2 runbook proves the next storage-backed slice beyond BF1:
 - real source-artifact file persistence
 - reprocess from stored source artifact
 - baseline creation and list
+- reading-vs-baseline comparison deltas
+- synchronous persisted JSON export bundles
 - history list
 - reading detail
 
@@ -168,7 +177,7 @@ This BF2 runbook proves the next storage-backed slice beyond BF1:
 
 This runbook does not yet prove later-phase scope such as:
 
-- baseline comparison deltas/visualization
-- exports
+- richer baseline comparison visualization beyond the thin reading-detail surface
+- alternate export formats
 - downstream synthesis into non-biofield product surfaces
 - real computer-vision upgrade beyond the current Python stub

--- a/migrations/019_biofield_exports.sql
+++ b/migrations/019_biofield_exports.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS biofield_exports (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    reading_id UUID NOT NULL REFERENCES readings(id) ON DELETE CASCADE,
+    baseline_id UUID NULL REFERENCES biofield_baselines(id) ON DELETE SET NULL,
+    export_format TEXT NOT NULL,
+    file_name TEXT NOT NULL,
+    storage_path TEXT NOT NULL,
+    mime_type TEXT NOT NULL,
+    byte_size BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT biofield_exports_format_check CHECK (export_format IN ('json')),
+    CONSTRAINT biofield_exports_file_name_non_empty CHECK (char_length(trim(file_name)) > 0),
+    CONSTRAINT biofield_exports_storage_path_non_empty CHECK (char_length(trim(storage_path)) > 0),
+    CONSTRAINT biofield_exports_mime_type_non_empty CHECK (char_length(trim(mime_type)) > 0),
+    CONSTRAINT biofield_exports_byte_size_non_negative CHECK (byte_size >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_biofield_exports_user_created_at
+    ON biofield_exports (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_biofield_exports_reading_created_at
+    ON biofield_exports (reading_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_biofield_exports_baseline_created_at
+    ON biofield_exports (baseline_id, created_at DESC)
+    WHERE baseline_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_biofield_exports_storage_path
+    ON biofield_exports (storage_path);

--- a/packages/biofield-api-client/src/biofield-client.test.ts
+++ b/packages/biofield-api-client/src/biofield-client.test.ts
@@ -43,29 +43,41 @@ describe("BiofieldClient", () => {
     );
   });
 
-  it("posts reprocess and baseline routes against the frozen namespace", async () => {
+  it("supports comparison-aware detail fetches plus reprocess and baseline routes", async () => {
     const fetchMock = vi.fn(async () =>
       new Response(JSON.stringify({ reading_id: "reading-2" }), { status: 200 }),
     );
 
     const client = new BiofieldClient("https://example.com", { fetchImpl: fetchMock as typeof fetch });
+    await client.getReading("reading-1", { baselineId: "baseline-1" });
     await client.reprocessReading("reading-1");
     await client.listBaselines();
     await client.createBaseline({ name: "Morning", reading_ids: ["reading-1"] });
+    await client.createExport({ reading_id: "reading-1", baseline_id: "baseline-1" });
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
+      "https://example.com/api/v1/biofield/readings/reading-1?baseline_id=baseline-1",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
       "https://example.com/api/v1/biofield/readings/reading-1/reprocess",
       expect.objectContaining({ method: "POST" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
+      3,
       "https://example.com/api/v1/biofield/baselines",
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
-      3,
+      4,
       "https://example.com/api/v1/biofield/baselines",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
+      "https://example.com/api/v1/biofield/exports",
       expect.objectContaining({ method: "POST" }),
     );
   });

--- a/packages/biofield-api-client/src/biofield-client.ts
+++ b/packages/biofield-api-client/src/biofield-client.ts
@@ -1,10 +1,12 @@
 import type {
   BiofieldCaptureResult,
+  BiofieldExportResult,
   BiofieldReadingDetail,
   BiofieldReprocessResult,
   BiofieldSession,
   CloseBiofieldSessionRequest,
   CreateBiofieldBaselineRequest,
+  CreateBiofieldExportRequest,
   CreateBiofieldSessionRequest,
   ListBiofieldBaselinesResponse,
   ListBiofieldReadingsResponse,
@@ -26,6 +28,10 @@ interface ErrorPayloadShape {
   error_message?: string;
   error?: string;
   detail?: string;
+}
+
+export interface GetBiofieldReadingParams {
+  baselineId?: string;
 }
 
 export class BiofieldClientError extends Error {
@@ -95,8 +101,19 @@ export class BiofieldClient {
     });
   }
 
-  async getReading(readingId: string): Promise<BiofieldReadingDetail> {
-    return this.request<BiofieldReadingDetail>(`/api/v1/biofield/readings/${readingId}`, {
+  async getReading(
+    readingId: string,
+    params: GetBiofieldReadingParams = {},
+  ): Promise<BiofieldReadingDetail> {
+    const search = new URLSearchParams();
+
+    if (params.baselineId) {
+      search.set("baseline_id", params.baselineId);
+    }
+
+    const suffix = search.size > 0 ? `?${search.toString()}` : "";
+
+    return this.request<BiofieldReadingDetail>(`/api/v1/biofield/readings/${readingId}${suffix}`, {
       method: "GET",
     });
   }
@@ -130,6 +147,15 @@ export class BiofieldClient {
         body: JSON.stringify(input),
       },
     );
+  }
+
+  async createExport(
+    input: CreateBiofieldExportRequest,
+  ): Promise<BiofieldExportResult> {
+    return this.request<BiofieldExportResult>("/api/v1/biofield/exports", {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
   }
 
   async uploadCapture(

--- a/packages/biofield-domain/src/index.test.ts
+++ b/packages/biofield-domain/src/index.test.ts
@@ -3,7 +3,9 @@ import {
   BIOFIELD_CAPTURE_STATES,
   BIOFIELD_ENGINE_ID,
   BIOFIELD_SESSION_STATUSES,
+  type BiofieldBaselineComparison,
   type BiofieldBaselineSummary,
+  type BiofieldExportResult,
   type BiofieldReadingSummary,
 } from "./index.js";
 
@@ -49,5 +51,49 @@ describe("biofield-domain", () => {
 
     expect(baseline.reading_count).toBe(2);
     expect(baseline.name).toContain("Morning");
+  });
+
+  it("defines comparison and export shapes for the deferred slice", () => {
+    const comparison: BiofieldBaselineComparison = {
+      comparison_version: "biofield-baseline-delta/v1",
+      baseline: {
+        baseline_id: "baseline-1",
+        name: "Morning baseline",
+        reading_count: 2,
+        created_at: "2026-04-09T12:05:00Z",
+        updated_at: "2026-04-09T12:06:00Z",
+      },
+      deltas: [
+        {
+          key: "light_quanta_density",
+          reading_value: 42.5,
+          baseline_value: 40.0,
+          absolute_delta: 2.5,
+          relative_delta: 0.0625,
+        },
+      ],
+    };
+
+    const exportResult: BiofieldExportResult = {
+      export_id: "export-1",
+      reading_id: "reading-1",
+      baseline_id: "baseline-1",
+      format: "json",
+      file_name: "biofield-reading-reading-1.json",
+      mime_type: "application/json",
+      byte_size: 512,
+      created_at: "2026-04-09T12:07:00Z",
+      storage_path: "biofield/session-1/exports/export-1.json",
+      bundle: {
+        contract_version: "biofield-export/v1",
+        reading: {
+          comparison,
+        },
+      },
+    };
+
+    expect(comparison.deltas[0].absolute_delta).toBe(2.5);
+    expect(exportResult.format).toBe("json");
+    expect(exportResult.bundle.contract_version).toBe("biofield-export/v1");
   });
 });

--- a/packages/biofield-domain/src/index.ts
+++ b/packages/biofield-domain/src/index.ts
@@ -97,6 +97,20 @@ export interface ListBiofieldReadingsResponse {
   offset: number;
 }
 
+export interface BiofieldMetricDelta {
+  key: string;
+  reading_value: number;
+  baseline_value: number;
+  absolute_delta: number;
+  relative_delta?: number | null;
+}
+
+export interface BiofieldBaselineComparison {
+  comparison_version: string;
+  baseline: BiofieldBaselineSummary;
+  deltas: BiofieldMetricDelta[];
+}
+
 export interface BiofieldReadingDetail {
   reading_id: string;
   session_id: string;
@@ -106,6 +120,7 @@ export interface BiofieldReadingDetail {
   result: Record<string, unknown>;
   quality: QualityAssessment;
   artifacts: BiofieldArtifactSummary[];
+  comparison?: BiofieldBaselineComparison | null;
 }
 
 export interface BiofieldCaptureResult {
@@ -144,4 +159,25 @@ export interface BiofieldBaselineSummary {
 
 export interface ListBiofieldBaselinesResponse {
   items: BiofieldBaselineSummary[];
+}
+
+export type BiofieldExportFormat = "json";
+
+export interface CreateBiofieldExportRequest {
+  reading_id: string;
+  baseline_id?: string;
+  format?: BiofieldExportFormat;
+}
+
+export interface BiofieldExportResult {
+  export_id: string;
+  reading_id: string;
+  baseline_id?: string | null;
+  format: BiofieldExportFormat;
+  file_name: string;
+  mime_type: string;
+  byte_size: number;
+  created_at: string;
+  storage_path: string;
+  bundle: Record<string, unknown>;
 }

--- a/scripts/smoke_biofield_web.sh
+++ b/scripts/smoke_biofield_web.sh
@@ -21,8 +21,11 @@ REPROCESS_BODY="$TMP_DIR/reprocess.json"
 REPROCESS_DETAIL_BODY="$TMP_DIR/reprocess-detail.json"
 BASELINE_CREATE_BODY="$TMP_DIR/baseline-create.json"
 BASELINE_LIST_BODY="$TMP_DIR/baseline-list.json"
+COMPARISON_BODY="$TMP_DIR/comparison.json"
+EXPORT_BODY="$TMP_DIR/export.json"
 CLOSE_BODY="$TMP_DIR/close.json"
 GENERATED_IMAGE="$TMP_DIR/smoke.png"
+ARTIFACT_ROOT="${BIOFIELD_ARTIFACTS_DIR:-$(pwd)/.runtime/biofield-artifacts}"
 
 cleanup() {
   rm -rf "$TMP_DIR"
@@ -154,7 +157,7 @@ if [[ ! -f "$BIOFIELD_CAPTURE_IMAGE" ]]; then
   fail "BIOFIELD_CAPTURE_IMAGE does not exist: $BIOFIELD_CAPTURE_IMAGE"
 fi
 
-echo "Running biofield-web BF2 smoke checks"
+echo "Running biofield-web BF3 smoke checks"
 echo "BIOFIELD_WEB_URL=$BIOFIELD_WEB_URL"
 echo "API_BASE_URL=$API_BASE_URL"
 echo "PYTHON_BIOFIELD_URL=$PYTHON_BIOFIELD_URL"
@@ -279,6 +282,7 @@ if [[ -z "$BASELINE_ID" || "$BASELINE_COUNT" != "2" ]]; then
   fail "Baseline creation did not return the expected id and reading count"
 fi
 echo "✅ Baseline created with 2 readings"
+export BASELINE_ID
 
 get_json "$API_BASE_URL/api/v1/biofield/baselines" "200" "$BASELINE_LIST_BODY" "$AUTH_HEADER"
 LIST_BASELINE_ID="$(json_field "$BASELINE_LIST_BODY" items.0.baseline_id)"
@@ -287,11 +291,63 @@ if [[ "$LIST_BASELINE_ID" != "$BASELINE_ID" ]]; then
 fi
 echo "✅ Baseline list returns the created baseline"
 
+get_json "$API_BASE_URL/api/v1/biofield/readings/$READING_ID?baseline_id=$BASELINE_ID" "200" "$COMPARISON_BODY" "$AUTH_HEADER"
+COMPARISON_BASELINE_ID="$(json_field "$COMPARISON_BODY" comparison.baseline.baseline_id)"
+COMPARISON_VERSION="$(json_field "$COMPARISON_BODY" comparison.comparison_version)"
+FIRST_COMPARISON_KEY="$(json_field "$COMPARISON_BODY" comparison.deltas.0.key)"
+if [[ "$COMPARISON_BASELINE_ID" != "$BASELINE_ID" || -z "$COMPARISON_VERSION" || -z "$FIRST_COMPARISON_KEY" ]]; then
+  fail "Comparison detail did not return the expected baseline comparison payload"
+fi
+echo "✅ Comparison detail returns baseline deltas ($COMPARISON_VERSION)"
+
+EXPORT_PAYLOAD="$(python3 - <<'PY'
+import json
+import os
+print(json.dumps({
+    'reading_id': os.environ['READING_ID'],
+    'baseline_id': os.environ['BASELINE_ID'],
+    'format': 'json',
+}))
+PY
+)"
+post_json "$API_BASE_URL/api/v1/biofield/exports" "201" "$EXPORT_PAYLOAD" "$EXPORT_BODY" "$AUTH_HEADER"
+EXPORT_ID="$(json_field "$EXPORT_BODY" export_id)"
+EXPORT_FORMAT="$(json_field "$EXPORT_BODY" format)"
+EXPORT_STORAGE_PATH="$(json_field "$EXPORT_BODY" storage_path)"
+EXPORT_CONTRACT_VERSION="$(json_field "$EXPORT_BODY" bundle.contract_version)"
+if [[ -z "$EXPORT_ID" || "$EXPORT_FORMAT" != "json" || "$EXPORT_CONTRACT_VERSION" != "biofield-export/v1" ]]; then
+  fail "Export response did not return the expected persisted bundle metadata"
+fi
+if [[ ! -f "$ARTIFACT_ROOT/$EXPORT_STORAGE_PATH" ]]; then
+  fail "Expected persisted export bundle at $ARTIFACT_ROOT/$EXPORT_STORAGE_PATH"
+fi
+echo "✅ Export bundle persisted at $ARTIFACT_ROOT/$EXPORT_STORAGE_PATH"
+
 close_payload='{"reason":"smoke-complete"}'
-post_json "$API_BASE_URL/api/v1/biofield/sessions/$SESSION_ID/close" "200" "$close_payload" "$CLOSE_BODY" "$AUTH_HEADER"
+CLOSE_STATUS="$(curl -sS -o "$CLOSE_BODY" -w "%{http_code}" -X POST "$API_BASE_URL/api/v1/biofield/sessions/$SESSION_ID/close" -H "Content-Type: application/json" -H "$AUTH_HEADER" --data "$close_payload")"
+if [[ "$CLOSE_STATUS" == "429" ]]; then
+  RESET_AT="$(json_field "$CLOSE_BODY" details.reset_at)"
+  SLEEP_SECONDS="$(RESET_AT="$RESET_AT" python3 - <<'PY'
+import os
+import time
+reset_at = int(os.environ["RESET_AT"])
+print(max(1, reset_at - int(time.time()) + 1))
+PY
+)"
+  echo "⏳ Close request hit rate limit; sleeping ${SLEEP_SECONDS}s for reset"
+  sleep "$SLEEP_SECONDS"
+  post_json "$API_BASE_URL/api/v1/biofield/sessions/$SESSION_ID/close" "200" "$close_payload" "$CLOSE_BODY" "$AUTH_HEADER"
+else
+  if [[ "$CLOSE_STATUS" != "200" ]]; then
+    echo "Response body from $API_BASE_URL/api/v1/biofield/sessions/$SESSION_ID/close:" >&2
+    cat "$CLOSE_BODY" >&2
+    fail "Expected POST $API_BASE_URL/api/v1/biofield/sessions/$SESSION_ID/close to return 200, got $CLOSE_STATUS"
+  fi
+  echo "✅ POST $API_BASE_URL/api/v1/biofield/sessions/$SESSION_ID/close -> $CLOSE_STATUS"
+fi
 CLOSED_STATUS="$(json_field "$CLOSE_BODY" status)"
 if [[ "$CLOSED_STATUS" != "closed" ]]; then
   fail "Session close did not return closed status"
 fi
 
-echo "🎉 Biofield BF2 smoke checks passed"
+echo "🎉 Biofield BF3 smoke checks passed"

--- a/supabase/migrations/20260409000019_019_biofield_exports.sql
+++ b/supabase/migrations/20260409000019_019_biofield_exports.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS biofield_exports (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    reading_id UUID NOT NULL REFERENCES readings(id) ON DELETE CASCADE,
+    baseline_id UUID NULL REFERENCES biofield_baselines(id) ON DELETE SET NULL,
+    export_format TEXT NOT NULL,
+    file_name TEXT NOT NULL,
+    storage_path TEXT NOT NULL,
+    mime_type TEXT NOT NULL,
+    byte_size BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT biofield_exports_format_check CHECK (export_format IN ('json')),
+    CONSTRAINT biofield_exports_file_name_non_empty CHECK (char_length(trim(file_name)) > 0),
+    CONSTRAINT biofield_exports_storage_path_non_empty CHECK (char_length(trim(storage_path)) > 0),
+    CONSTRAINT biofield_exports_mime_type_non_empty CHECK (char_length(trim(mime_type)) > 0),
+    CONSTRAINT biofield_exports_byte_size_non_negative CHECK (byte_size >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_biofield_exports_user_created_at
+    ON biofield_exports (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_biofield_exports_reading_created_at
+    ON biofield_exports (reading_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_biofield_exports_baseline_created_at
+    ON biofield_exports (baseline_id, created_at DESC)
+    WHERE baseline_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_biofield_exports_storage_path
+    ON biofield_exports (storage_path);


### PR DESCRIPTION
## Summary
- land remaining biofield tranche commits on top of main
- includes comparison/export flows
- includes capture-derived engine seam

## Context
Stack PRs #561/#562/#563 were merged against intermediate BF branches. This PR lands the remaining head commits directly to main.

## Included commits
- d453d84a feat(biofield): add comparison and export flows
- 921b80eb feat(biofield): add capture-derived engine seam
