### PR TITLE
feat(ci): agent merge lane + post-merge cleanup

### DIFF
--- a/.github/workflows/agent-merge-lane.yml
+++ b/.github/workflows/agent-merge-lane.yml
@@ -1,0 +1,145 @@
+name: Agent Merge Lane
+
+on:
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: "Lane to merge (qa-docs|backend|all)"
+        required: false
+        default: "qa-docs"
+        type: choice
+        options:
+          - qa-docs
+          - backend
+          - all
+      limit:
+        description: "Max PRs to merge in this batch"
+        required: false
+        default: "5"
+        type: string
+      dry_run:
+        description: "If true, report candidates without merging"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  merge_lane:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Merge eligible agent PRs in lane
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const lane = core.getInput('lane') || 'qa-docs';
+            const limit = parseInt(core.getInput('limit') || '5', 10);
+            const dryRun = String(core.getInput('dry_run')) === 'true';
+            const { owner, repo } = context.repo;
+
+            function issueNumFromHead(headRef) {
+              const m = /^agent\/issue-(\d+)-/.exec(headRef || '');
+              return m ? parseInt(m[1], 10) : null;
+            }
+
+            function laneForArea(area) {
+              if (area === 'area:qa' || area === 'area:docs') return 'qa-docs';
+              if (area === 'area:backend' || area === 'area:data') return 'backend';
+              return 'all';
+            }
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const agentPulls = pulls.filter(p => p.head.ref.startsWith('agent/issue-'));
+            const candidates = [];
+
+            for (const pr of agentPulls) {
+              if (pr.draft) continue;
+              const issueNum = issueNumFromHead(pr.head.ref);
+              if (!issueNum) continue;
+
+              let area = '';
+              try {
+                const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: issueNum });
+                const labels = (issue.labels || []).map(l => typeof l === 'string' ? l : l.name);
+                area = labels.find(l => l.startsWith('area:')) || '';
+              } catch (e) {
+                core.warning(`Could not load issue #${issueNum} for PR #${pr.number}: ${e.message}`);
+                continue;
+              }
+
+              const prLane = laneForArea(area);
+              if (lane !== 'all' && prLane !== lane) continue;
+
+              candidates.push({
+                number: pr.number,
+                title: pr.title,
+                headSha: pr.head.sha,
+                issueNum,
+                area,
+                lane: prLane,
+              });
+            }
+
+            candidates.sort((a, b) => a.number - b.number);
+            const batch = candidates.slice(0, limit);
+
+            core.notice(`Lane=${lane} dry_run=${dryRun} eligible=${candidates.length} merging=${batch.length}`);
+            if (!batch.length) {
+              core.summary.addHeading('Agent Merge Lane').addRaw('No eligible non-draft PRs for this lane.', true).write();
+              return;
+            }
+
+            const merged = [];
+            const failed = [];
+
+            for (const item of batch) {
+              if (dryRun) {
+                merged.push({ ...item, dryRun: true });
+                continue;
+              }
+
+              try {
+                await github.rest.pulls.merge({
+                  owner,
+                  repo,
+                  pull_number: item.number,
+                  merge_method: 'squash',
+                  sha: item.headSha,
+                  commit_title: `[agent][${item.lane}] ${item.title}`,
+                });
+                merged.push(item);
+              } catch (e) {
+                failed.push({ ...item, error: e.message });
+              }
+            }
+
+            const summary = core.summary.addHeading('Agent Merge Lane Batch');
+            summary.addRaw(`- Lane: ${lane}\n`, true);
+            summary.addRaw(`- Dry run: ${dryRun}\n`, true);
+            summary.addRaw(`- Eligible: ${candidates.length}\n`, true);
+            summary.addRaw(`- Attempted: ${batch.length}\n`, true);
+            summary.addRaw(`- Merged: ${merged.length}\n`, true);
+            summary.addRaw(`- Failed: ${failed.length}\n`, true);
+
+            if (merged.length) {
+              summary.addHeading('Merged').addCodeBlock(
+                merged.map(m => `#${m.number} issue=#${m.issueNum} area=${m.area} lane=${m.lane}${m.dryRun ? ' (dry-run)' : ''}`).join('\n')
+              );
+            }
+            if (failed.length) {
+              summary.addHeading('Failed').addCodeBlock(
+                failed.map(f => `#${f.number} issue=#${f.issueNum} area=${f.area} error=${f.error}`).join('\n')
+              );
+            }
+
+            await summary.write();

--- a/.github/workflows/agent-post-merge.yml
+++ b/.github/workflows/agent-post-merge.yml
@@ -1,0 +1,67 @@
+name: Agent Post-Merge Cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'agent/issue-')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: write
+
+    steps:
+      - name: Auto-close/auto-label linked issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const headRef = pr.head.ref || '';
+            const m = /^agent\/issue-(\d+)-/.exec(headRef);
+            if (!m) {
+              core.notice(`Head ref ${headRef} does not match agent issue pattern.`);
+              return;
+            }
+
+            const issueNum = parseInt(m[1], 10);
+
+            const ensureLabel = async (name, color, description) => {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                } else {
+                  throw e;
+                }
+              }
+            };
+
+            await ensureLabel('agent-merged', '0E8A16', 'Issue merged via agent lane workflow');
+            await ensureLabel('agent-batch-merged', '1D76DB', 'Issue merged in an automated merge batch');
+
+            try {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNum, name: 'agent-ready' });
+            } catch (_) {}
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: issueNum,
+              labels: ['agent-merged', 'agent-batch-merged'],
+            });
+
+            const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: issueNum });
+            if (issue.state !== 'closed') {
+              await github.rest.issues.update({ owner, repo, issue_number: issueNum, state: 'closed' });
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNum,
+              body: `Auto-cleanup after merge of PR #${pr.number}: issue closed and labeled for agent batch tracking.`,
+            });


### PR DESCRIPTION
Adds:\n- Agent Merge Lane workflow (workflow_dispatch) to merge non-draft agent PRs in batches, lane-prioritized (qa-docs first)\n- Agent Post-Merge Cleanup workflow to remove agent-ready, add merged labels, and close linked issue if still open\n\nThis enables continuous issue burn-down once agent PRs are marked ready.