### PR TITLE
feat(ci): @copilot auto-trigger + auto-ready for agent dispatch pipeline

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -127,3 +127,16 @@ GET  /health/ready                          — Readiness probe
 4. **Performance optimization**: Benchmark with `cargo bench`, validate accuracy with `tests/validation/`
 
 Always preserve the orchestrator pattern — calculations flow through `CalculationOrchestrator`, not directly from handlers to engines.
+
+## Agent Dispatch Contract
+
+When you are invoked on a PR whose head ref matches `agent/issue-<N>-*`:
+
+1. Your full task contract is in `.agent-tasks/issue-<N>.md`. Read it before writing any code.
+2. Implement against the Deliverable + Acceptance Criteria in that file.
+3. Run `cargo build && cargo test` and confirm green before pushing the final commit.
+4. Delete `.agent-tasks/issue-<N>.md` in your final commit.
+5. Convert the PR from draft to ready-for-review.
+6. Post a PR comment: `agent: done -- tests passing, ready for review`.
+
+Branch naming and the task-file marker are load-bearing — `agent-merge-lane.yml` and `agent-post-merge.yml` both depend on them. Do not rename the branch or the task file.

--- a/.github/workflows/agent-auto-ready.yml
+++ b/.github/workflows/agent-auto-ready.yml
@@ -1,0 +1,113 @@
+name: Agent Auto-Ready
+
+# Flips an agent/issue-<N>-* draft PR to ready-for-review as soon as the
+# Copilot coding agent (or any agent) finishes its work. The signal we use is
+# deletion of `.agent-tasks/issue-<N>.md` from the PR head — the contract in
+# .github/copilot-instructions.md tells the agent to delete that file in its
+# final commit. No file == agent considers itself done.
+#
+# Triggers:
+#   - pull_request (synchronize/opened/reopened): real-time, primary path
+#   - workflow_dispatch: manual sweep mode for backfill or after edge cases
+#
+# Safety gates (per PR):
+#   - Must be a draft agent/issue-* PR
+#   - Must have > 1 commit (scaffold + at least one real commit)
+#   - Task file must be gone from PR head
+#
+# No-op if any gate fails. Idempotent — re-running has no effect on already-ready PRs.
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened]
+  workflow_dispatch: {}
+
+jobs:
+  auto_ready:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Flip eligible draft PRs to ready-for-review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+
+            async function processOne(pr) {
+              const headRef = pr.head.ref;
+              if (!pr.draft || !headRef.startsWith('agent/issue-')) {
+                return { pr: pr.number, status: 'skipped (not draft agent/issue-*)' };
+              }
+
+              const m = /^agent\/issue-(\d+)-/.exec(headRef);
+              if (!m) return { pr: pr.number, status: 'skipped (no issue num in head ref)' };
+              const num = parseInt(m[1], 10);
+              const taskPath = `.agent-tasks/issue-${num}.md`;
+
+              // Gate 1: at least 2 commits (scaffold + work).
+              const { data: commits } = await github.rest.pulls.listCommits({
+                owner, repo, pull_number: pr.number, per_page: 100,
+              });
+              if (commits.length < 2) {
+                return { pr: pr.number, status: `waiting (only ${commits.length} commit)` };
+              }
+
+              // Gate 2: task file must be gone from PR head.
+              try {
+                await github.rest.repos.getContent({
+                  owner, repo, path: taskPath, ref: pr.head.sha,
+                });
+                return { pr: pr.number, status: `waiting (${taskPath} still present)` };
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+
+              // Flip draft -> ready.
+              await github.graphql(`
+                mutation($id:ID!) {
+                  markPullRequestReadyForReview(input:{pullRequestId:$id}) {
+                    pullRequest { number isDraft }
+                  }
+                }
+              `, { id: pr.node_id });
+
+              return { pr: pr.number, status: `flipped ready (issue #${num}, ${commits.length} commits)` };
+            }
+
+            // Route by trigger.
+            const results = [];
+            if (context.eventName === 'pull_request') {
+              results.push(await processOne(context.payload.pull_request));
+            } else {
+              // workflow_dispatch: sweep all open draft agent/issue-* PRs.
+              const { data: prs } = await github.rest.pulls.list({
+                owner, repo, state: 'open', per_page: 100,
+              });
+              const candidates = prs.filter(p => p.draft && p.head.ref.startsWith('agent/issue-'));
+              core.notice(`Sweep: ${candidates.length} candidate draft agent PRs`);
+              for (const p of candidates) {
+                results.push(await processOne(p));
+                await new Promise(r => setTimeout(r, 500));
+              }
+            }
+
+            // Report
+            const flipped = results.filter(r => r.status.startsWith('flipped'));
+            const waiting = results.filter(r => r.status.startsWith('waiting'));
+            const skipped = results.filter(r => r.status.startsWith('skipped'));
+            const summary = core.summary
+              .addHeading('Agent Auto-Ready')
+              .addRaw(`- Trigger: \`${context.eventName}\`\n`, true)
+              .addRaw(`- Processed: ${results.length}\n`, true)
+              .addRaw(`- Flipped ready: ${flipped.length}\n`, true)
+              .addRaw(`- Waiting (gates not met): ${waiting.length}\n`, true)
+              .addRaw(`- Skipped (not eligible): ${skipped.length}\n`, true);
+            if (results.length) {
+              summary.addCodeBlock(results.map(r => `#${r.pr}: ${r.status}`).join('\n'));
+            }
+            await summary.write();
+
+            for (const r of results) console.log(`#${r.pr}: ${r.status}`);

--- a/.github/workflows/agent-dispatch.yml
+++ b/.github/workflows/agent-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Dispatch issues to agent PRs
         uses: actions/github-script@v7
+        env:
+          COPILOT_AUTOKICK: ${{ vars.COPILOT_AUTOKICK || 'true' }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -167,6 +169,29 @@ jobs:
                 body: prBody,
                 draft: true,
               });
+
+              // Kick GitHub Copilot coding agent on the new draft PR (toggle via repo var COPILOT_AUTOKICK)
+              const autoKick = (process.env.COPILOT_AUTOKICK || 'true').toLowerCase() === 'true';
+              if (autoKick) {
+                const kickBody = [
+                  `@copilot Implement everything in \`.agent-tasks/issue-${num}.md\`.`,
+                  ``,
+                  `Acceptance:`,
+                  `- All items in the issue's Acceptance Criteria pass`,
+                  `- \`cargo build && cargo test\` is green`,
+                  `- Delete \`.agent-tasks/issue-${num}.md\` in your final commit`,
+                  `- Convert this PR from draft to ready-for-review`,
+                  `- Post \`agent: done -- tests passing, ready for review\``,
+                ].join('\n');
+                await github.rest.issues.createComment({
+                  owner, repo,
+                  issue_number: pr.number,
+                  body: kickBody,
+                });
+                console.log(`#${num}: posted @copilot kickoff on PR #${pr.number}`);
+              } else {
+                console.log(`#${num}: COPILOT_AUTOKICK disabled, skipping @copilot kickoff`);
+              }
 
               // Comment on the source issue
               await github.rest.issues.createComment({

--- a/scripts/dispatch-copilot.sh
+++ b/scripts/dispatch-copilot.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Trigger the GitHub Copilot coding agent on agent/issue-* draft PRs by
+# posting an @copilot kickoff comment that points at .agent-tasks/issue-<N>.md.
+#
+# Modes:
+#   --pr <num>      Kick a single PR by number
+#   --issue <num>   Resolve agent/issue-<num>-* head ref -> PR -> kick
+#   --all-ready     Walk every open agent/issue-* draft PR; skip ones already
+#                   kicked (any existing comment whose body starts with @copilot)
+
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-}"
+PR_NUM=""
+ISSUE_NUM=""
+ALL_READY=false
+LANE="all"
+DRY_RUN=false
+SLEEP_SECONDS="0.5"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/dispatch-copilot.sh [options]
+
+Modes (exactly one of):
+  --pr <num>            Kick a single PR by number
+  --issue <num>         Resolve agent/issue-<num>-* head ref -> PR -> kick
+  --all-ready           Kick every un-kicked open agent/issue-* draft PR
+
+Options:
+  --repo <owner/repo>   Repo (default: $GITHUB_REPOSITORY or `gh repo view`)
+  --lane <name>         Filter --all-ready by lane: qa-docs|backend|all (default: all)
+                        Mapping matches agent-merge-lane.yml:
+                          area:qa, area:docs       -> qa-docs
+                          area:backend, area:data  -> backend
+                          (anything else)          -> all
+  --dry-run             Print intended actions, post nothing
+  --sleep-seconds <f>   Delay between kicks in --all-ready (default: 0.5)
+  --help, -h            Show help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)             PR_NUM="${2:-}";          shift 2 ;;
+    --issue)          ISSUE_NUM="${2:-}";       shift 2 ;;
+    --all-ready)      ALL_READY=true;           shift ;;
+    --lane)           LANE="${2:-all}";         shift 2 ;;
+    --repo)           REPO="${2:-}";            shift 2 ;;
+    --dry-run)        DRY_RUN=true;             shift ;;
+    --sleep-seconds)  SLEEP_SECONDS="${2:-0.5}"; shift 2 ;;
+    --help|-h)        usage; exit 0 ;;
+    *)                echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+case "$LANE" in
+  qa-docs|backend|all) ;;
+  *) echo "Error: --lane must be one of: qa-docs, backend, all (got: $LANE)" >&2; exit 1 ;;
+esac
+
+for bin in gh jq; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "Error: required binary '$bin' not found." >&2
+    exit 1
+  fi
+done
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || true)"
+fi
+if [[ -z "$REPO" ]]; then
+  echo "Error: repo is required (pass --repo or set GITHUB_REPOSITORY)." >&2
+  exit 1
+fi
+
+mode_count=0
+[[ -n "$PR_NUM" ]] && mode_count=$((mode_count + 1))
+[[ -n "$ISSUE_NUM" ]] && mode_count=$((mode_count + 1))
+[[ "$ALL_READY" == true ]] && mode_count=$((mode_count + 1))
+if [[ "$mode_count" -ne 1 ]]; then
+  echo "Error: pass exactly one of --pr, --issue, --all-ready." >&2
+  usage
+  exit 1
+fi
+
+# Build kickoff body (issue number injected per-PR).
+kickoff_body() {
+  local n="$1"
+  cat <<EOF
+@copilot Implement everything in \`.agent-tasks/issue-${n}.md\`.
+
+Acceptance:
+- All items in the issue's Acceptance Criteria pass
+- \`cargo build && cargo test\` is green
+- Delete \`.agent-tasks/issue-${n}.md\` in your final commit
+- Convert this PR from draft to ready-for-review
+- Post \`agent: done -- tests passing, ready for review\`
+EOF
+}
+
+# Extract issue number from agent/issue-<N>-... head ref. Echoes "" if no match.
+issue_num_from_head() {
+  local head="$1"
+  echo "$head" | sed -nE 's#^agent/issue-([0-9]+)-.*$#\1#p'
+}
+
+# Mirror of agent-merge-lane.yml::laneForArea — keep in sync.
+lane_for_area() {
+  case "$1" in
+    "area:qa"|"area:docs")     echo "qa-docs" ;;
+    "area:backend"|"area:data") echo "backend" ;;
+    *)                          echo "all" ;;
+  esac
+}
+
+# Fetch the area:* label for an issue number (echoes "" if none / lookup fails).
+area_for_issue() {
+  local n="$1"
+  [[ -z "$n" ]] && { echo ""; return; }
+  gh issue view "$n" --repo "$REPO" --json labels \
+    --jq '[.labels[].name | select(startswith("area:"))][0] // ""' 2>/dev/null || echo ""
+}
+
+# Has this PR already been kicked? (any comment body starting with "@copilot")
+already_kicked() {
+  local pr="$1"
+  local count
+  count="$(
+    gh pr view "$pr" --repo "$REPO" --json comments \
+      --jq '[.comments[].body | select(startswith("@copilot"))] | length' 2>/dev/null || echo 0
+  )"
+  [[ "$count" -gt 0 ]]
+}
+
+# Resolve --issue N to PR number; echoes "" if no matching open PR.
+pr_for_issue() {
+  local issue="$1"
+  gh pr list --repo "$REPO" --state open --limit 200 \
+    --json number,headRefName \
+    --jq ".[] | select(.headRefName | startswith(\"agent/issue-${issue}-\")) | .number" \
+    | head -n 1
+}
+
+# Kick a single PR (skips if already kicked).
+kick_pr() {
+  local pr="$1"
+  local head="$2"
+
+  local n
+  n="$(issue_num_from_head "$head")"
+  if [[ -z "$n" ]]; then
+    echo "  skip PR #${pr}: head ref '${head}' is not agent/issue-<N>-*"
+    return 0
+  fi
+
+  if already_kicked "$pr"; then
+    echo "  skip PR #${pr} (issue #${n}): already has an @copilot comment"
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "  dry-run kick PR #${pr} (issue #${n})"
+    return 0
+  fi
+
+  local body
+  body="$(kickoff_body "$n")"
+  gh pr comment "$pr" --repo "$REPO" --body "$body" >/dev/null
+  echo "  kicked PR #${pr} (issue #${n})"
+}
+
+echo "Copilot dispatch start"
+echo "  repo: $REPO"
+echo "  mode: $([[ "$DRY_RUN" == true ]] && echo dry-run || echo apply)"
+echo "  lane: $LANE"
+
+if [[ -n "$PR_NUM" ]]; then
+  head="$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefName --jq '.headRefName')"
+  kick_pr "$PR_NUM" "$head"
+elif [[ -n "$ISSUE_NUM" ]]; then
+  pr="$(pr_for_issue "$ISSUE_NUM")"
+  if [[ -z "$pr" ]]; then
+    echo "Error: no open PR with head ref agent/issue-${ISSUE_NUM}-* in $REPO" >&2
+    exit 1
+  fi
+  kick_pr "$pr" "agent/issue-${ISSUE_NUM}-"
+else
+  # --all-ready: enumerate open agent/issue-* PRs (drafts AND non-drafts; the
+  # already-kicked check is what gates re-posting, not draft state). Avoid
+  # `mapfile` for macOS bash 3.2 compatibility.
+  candidates="$(
+    gh pr list --repo "$REPO" --state open --limit 200 \
+      --json number,headRefName,isDraft \
+      --jq '.[] | select(.headRefName | startswith("agent/issue-")) | "\(.number)\t\(.headRefName)\t\(.isDraft)"'
+  )"
+
+  if [[ -z "$candidates" ]]; then
+    count=0
+  else
+    count="$(printf '%s\n' "$candidates" | wc -l | tr -d ' ')"
+  fi
+  echo "  candidates: $count"
+
+  if [[ "$count" -gt 0 ]]; then
+    while IFS=$'\t' read -r pr head _is_draft; do
+      [[ -z "$pr" ]] && continue
+
+      if [[ "$LANE" != "all" ]]; then
+        n="$(issue_num_from_head "$head")"
+        area="$(area_for_issue "$n")"
+        pr_lane="$(lane_for_area "$area")"
+        if [[ "$pr_lane" != "$LANE" ]]; then
+          echo "  skip PR #${pr} (issue #${n:-?}): lane=${pr_lane:-unknown} != ${LANE} (area=${area:-none})"
+          continue
+        fi
+      fi
+
+      kick_pr "$pr" "$head"
+      sleep "$SLEEP_SECONDS"
+    done <<< "$candidates"
+  fi
+fi
+
+echo "Copilot dispatch complete."


### PR DESCRIPTION
## Summary

Closes the two remaining manual touchpoints in the agent dispatch pipeline so each wave runs hands-free:

- **`agent-dispatch.yml`**: posts `@copilot` kickoff on every newly-created draft PR (gated by `vars.COPILOT_AUTOKICK`, default `true`).
- **`agent-auto-ready.yml`** (new): flips draft → ready when the agent has deleted `.agent-tasks/issue-N.md` and pushed at least one real commit. Triggers on `pull_request: synchronize` (real-time) and `workflow_dispatch` (manual sweep for backfill).
- **`copilot-instructions.md`**: appended Agent Dispatch Contract documenting the load-bearing branch and task-file conventions.
- **`scripts/dispatch-copilot.sh`** (new): local CLI for ad-hoc / backfill kicks. Supports `--pr`, `--issue`, `--all-ready`, `--lane qa-docs|backend|all`, `--dry-run`. Lane mapping mirrors `agent-merge-lane.yml`.

End-to-end: label `agent-ready` → `agent-dispatch.yml` scaffolds + kicks → Copilot codes + deletes task file → `agent-auto-ready.yml` flips ready → `agent-merge-lane.yml` merges → `agent-post-merge.yml` cleans up.

## Test plan

- [x] CLI sanity ping on PR #569 — Copilot replied (Claude Sonnet 4.6 backend) → confirms Enterprise wiring
- [x] Real kick on PR #569 — agent wrote real code (`feat(engine-biorhythm): extract types into dedicated types.rs module`), deleted task file, but left as draft → confirmed need for `agent-auto-ready.yml`
- [x] qa-docs lane fired (10 PRs); awaiting Copilot completion
- [x] PR #569 manually flipped ready as one-time bridge; eligible for `agent-merge-lane.yml --lane backend`
- [ ] After this PR merges to main: future Copilot pushes auto-flip ready via `pull_request: synchronize` trigger
- [ ] For PRs that finish before this lands on main: `gh workflow run agent-auto-ready.yml` to sweep manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)