### PR TITLE
fix(ci): unblock Lint + Security Audit after Rust 1.95 + RUSTSEC-2026 advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,4 +4,7 @@ ignore = [
     "RUSTSEC-2023-0071",  # rsa — no patch available
     "RUSTSEC-2024-0363",  # sqlx — 0.8 upgrade tracked separately
     "RUSTSEC-2026-0002",  # lru — unsound IterMut, no patch yet
+    "RUSTSEC-2026-0098",  # rustls-webpki 0.101.7 (via reqwest 0.11) — name constraints; codebase doesn't assert URI names. Reqwest 0.12 upgrade tracked separately.
+    "RUSTSEC-2026-0099",  # rustls-webpki 0.101.7 (via reqwest 0.11) — wildcard name constraints; no name constraint use. Reqwest 0.12 upgrade tracked separately.
+    "RUSTSEC-2026-0104",  # rustls-webpki 0.101.7 (via reqwest 0.11) — CRL parsing panic; codebase doesn't parse CRLs. Reqwest 0.12 upgrade tracked separately.
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,7 +4164,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -4200,9 +4200,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/engine-vimshottari/src/wisdom_data.rs
+++ b/crates/engine-vimshottari/src/wisdom_data.rs
@@ -341,8 +341,8 @@ fn load_nakshatras() -> Vec<Nakshatra> {
 
     let mut nakshatras: Vec<_> = data
         .nakshatras
-        .into_iter()
-        .filter_map(|(_, entry)| {
+        .into_values()
+        .filter_map(|entry| {
             VedicPlanet::from_str(&entry.ruling_planet).map(|planet| Nakshatra {
                 number: entry.number,
                 name: entry.name,

--- a/crates/noesis-api/src/handlers/biofield.rs
+++ b/crates/noesis-api/src/handlers/biofield.rs
@@ -492,24 +492,23 @@ async fn parse_capture_multipart(
         let field_name = field.name().unwrap_or_default().to_string();
 
         match field_name.as_str() {
-            "image" | "file" => {
-                if parsed.image_bytes.is_none() {
-                    let content_type = field
-                        .content_type()
-                        .map(str::to_string)
-                        .unwrap_or_else(|| "application/octet-stream".to_string());
-                    let file_name = field.file_name().map(str::to_string);
-                    let bytes = field.bytes().await.map_err(|error| {
-                        capture_invalid_response(
-                            format!("Failed to read uploaded file: {error}"),
-                            Some(serde_json::json!({ "field": field_name })),
-                        )
-                    })?;
-                    parsed.image_bytes = Some(bytes.to_vec());
-                    parsed.image_content_type = Some(content_type);
-                    parsed.image_file_name = file_name;
-                }
+            "image" | "file" if parsed.image_bytes.is_none() => {
+                let content_type = field
+                    .content_type()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "application/octet-stream".to_string());
+                let file_name = field.file_name().map(str::to_string);
+                let bytes = field.bytes().await.map_err(|error| {
+                    capture_invalid_response(
+                        format!("Failed to read uploaded file: {error}"),
+                        Some(serde_json::json!({ "field": field_name })),
+                    )
+                })?;
+                parsed.image_bytes = Some(bytes.to_vec());
+                parsed.image_content_type = Some(content_type);
+                parsed.image_file_name = file_name;
             }
+            "image" | "file" => {}
             "algorithms" => {
                 let text = field.text().await.map_err(|error| {
                     capture_invalid_response(

--- a/crates/noesis-vedic-api/src/ashtakavarga/totals.rs
+++ b/crates/noesis-vedic-api/src/ashtakavarga/totals.rs
@@ -35,7 +35,7 @@ pub fn calculate_analysis(sarva: &SarvaAshtakavarga) -> AshtakavargaAnalysis {
         .collect();
 
     // Sort by points descending
-    sign_strengths.sort_by(|a, b| b.points.cmp(&a.points));
+    sign_strengths.sort_by_key(|s| std::cmp::Reverse(s.points));
 
     let strongest_signs: Vec<SignStrength> = sign_strengths.iter().take(3).cloned().collect();
 

--- a/crates/noesis-vedic-api/src/hora_alarms/scheduler.rs
+++ b/crates/noesis-vedic-api/src/hora_alarms/scheduler.rs
@@ -80,7 +80,7 @@ impl HoraAlarmScheduler {
 
         // Sort by notification time
         self.pending_notifications
-            .sort_by(|a, b| a.notification_time.cmp(&b.notification_time));
+            .sort_by_key(|n| n.notification_time);
     }
 
     /// Get pending notifications

--- a/crates/noesis-vedic-api/src/panchang/choghadiya.rs
+++ b/crates/noesis-vedic-api/src/panchang/choghadiya.rs
@@ -426,7 +426,7 @@ pub fn get_recommendations(
     }
 
     // Sort by score descending
-    recommendations.sort_by(|a, b| b.score.cmp(&a.score));
+    recommendations.sort_by_key(|r| std::cmp::Reverse(r.score));
 
     recommendations
 }


### PR DESCRIPTION
## Summary

Unblocks main's CI which has been red on **Lint** (4 errors after Rust stable 1.95.0 introduced new clippy lints) and **Security Audit** (3 `rustls-webpki` vulnerabilities) since the upstream releases. Every open PR — including #598 (witness contract CI wiring) and #600 (agent-ready dispatch test) — is gated by these.

## Lint (4 errors)

| File:Line | Lint | Fix |
|---|---|---|
| [engine-vimshottari/src/wisdom_data.rs:342](crates/engine-vimshottari/src/wisdom_data.rs) | `clippy::iter_kv_map` | `.into_iter().filter_map(\|(_, entry)\|` → `.into_values().filter_map(\|entry\|` |
| [noesis-vedic-api/src/panchang/choghadiya.rs:429](crates/noesis-vedic-api/src/panchang/choghadiya.rs) | `clippy::unnecessary_sort_by` | `sort_by(\|a,b\| b.score.cmp(&a.score))` → `sort_by_key(\|r\| std::cmp::Reverse(r.score))` |
| [noesis-vedic-api/src/ashtakavarga/totals.rs:38](crates/noesis-vedic-api/src/ashtakavarga/totals.rs) | `clippy::unnecessary_sort_by` | descending sort → `sort_by_key(\|s\| std::cmp::Reverse(s.points))` |
| [noesis-vedic-api/src/hora_alarms/scheduler.rs:82](crates/noesis-vedic-api/src/hora_alarms/scheduler.rs) | `clippy::unnecessary_sort_by` | ascending sort → `sort_by_key(\|n\| n.notification_time)` |

## Security Audit (3 vulnerabilities)

All three are `rustls-webpki` — same advisory IDs hit both the `0.103.10` and `0.101.7` versions in Cargo.lock.

**Fixed via Cargo.lock bump:** `rustls-webpki 0.103.10 → 0.103.13` (path: `reqwest 0.12 → utoipa-swagger-ui / sentry / noesis-sdk`).

**Ignored in `.cargo/audit.toml`:** the `0.101.7` path (via `noesis-western-api → reqwest 0.11`) has **no patched 0.101.x release**. The proper fix is bumping reqwest 0.11→0.12 across `noesis-western-api`, which is a major change tracked separately. Practical exposure is nil — codebase doesn't assert URI/wildcard name constraints or parse CRLs.

| Advisory | Status |
|---|---|
| RUSTSEC-2026-0098 (URI name constraints) | Patched via 0.103.13 bump; 0.101.7 ignored |
| RUSTSEC-2026-0099 (wildcard name constraints) | Patched via 0.103.13 bump; 0.101.7 ignored |
| RUSTSEC-2026-0104 (CRL parsing panic) | Patched via 0.103.13 bump; 0.101.7 ignored |

## Verification

- `cargo clippy -p engine-vimshottari --all-targets -- -D warnings` ✅ clean
- `cargo clippy -p noesis-vedic-api --all-targets -- -D warnings` ✅ clean (modulo pre-existing `assert!(true)` placeholder tests fired by master clippy's `assertions_on_constants`, not on Rust 1.95 stable — out of scope)
- `cargo audit` ✅ no vulnerabilities (only allowed unmaintained warnings remain)

## Follow-up

Recommend filing as future agent-ready issues:
- Bump `reqwest 0.11 → 0.12` in `noesis-western-api` (lets us drop the 3 audit ignores)
- Replace unmaintained `backoff` with `backon` (RUSTSEC-2025-0012)
- Pin `dtolnay/rust-toolchain@1.95` to avoid future stable-clippy regressions, OR address future lints proactively