### PR TITLE
docs(readme): add 'Agent dispatch' section documenting agent-ready label flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,6 +778,34 @@ See the [deployment docs](docs/deployment/README.md) for production setup.
 
 ---
 
+## ✦ Agent dispatch
+
+Selemene ships an automated contributor pipeline: any open issue with the `agent-ready` label is auto-converted into a draft PR implemented by the GitHub Copilot coding agent. Useful for well-scoped tasks where the issue body fully specifies the deliverable.
+
+**Trigger:** apply the `agent-ready` label to an open issue.
+
+**What happens (in order):**
+
+1. [`agent-dispatch.yml`](.github/workflows/agent-dispatch.yml) creates branch `agent/issue-{N}-{slug}` off main, opens a draft PR with the issue spec + checklist, and commits a task file at `.agent-tasks/issue-{N}.md`.
+2. The dispatch workflow posts an `@copilot Implement everything in .agent-tasks/issue-{N}.md.` comment on the PR (controlled by repo var `COPILOT_AUTOKICK`, default `true`).
+3. The Copilot coding agent picks up the kickoff, implements per the spec, and **deletes** `.agent-tasks/issue-{N}.md` in its final commit to signal done.
+4. [`agent-auto-ready.yml`](.github/workflows/agent-auto-ready.yml) detects the deleted task file (gated on >1 commit + draft + `agent/issue-*` head) and flips the PR from draft → ready-for-review.
+5. On merge, [`agent-post-merge.yml`](.github/workflows/agent-post-merge.yml) closes the linked issue and applies the `agent-merged` label.
+
+**Backfill mode** — for issues already labeled before the dispatch workflow was added, run **Actions → Agent Issue Dispatch → Run workflow** (leave input empty for all open `agent-ready` issues, or pass a comma-separated issue list).
+
+**Batch merge** — [`agent-merge-lane.yml`](.github/workflows/agent-merge-lane.yml) supports manual dispatch to merge eligible agent PRs by lane (`qa-docs`, `backend`, `all`) with an optional `dry_run`.
+
+**Gotchas:**
+
+- Issue body must fully specify the deliverable + acceptance criteria — the bot reads only `.agent-tasks/issue-{N}.md`, not the surrounding repo context.
+- Idempotent: if the dispatch fires twice on the same issue, the second run skips because an `agent/issue-{N}-*` PR already exists.
+- The auto-ready gate requires >1 commit (scaffold + at least one bot commit) — empty draft PRs stay draft.
+
+<br>
+
+---
+
 ## ✦ Acknowledgments
 
 <sub>This work stands on the shoulders of **Maharishi Parashara** (Vimshottari Dasha), **Ra Uru Hu** (Human Design), **Richard Rudd** (Gene Keys), **B.V. Raman** (Vedic astrology), and the **Swiss Ephemeris Team**.</sub>


### PR DESCRIPTION
## Summary

Documents the automated contributor pipeline shipped via #568, #596, #597 in a new `## ✦ Agent dispatch` section between the Contributing and Acknowledgments sections of the README.

## Why now (and why by hand)

This is the manual implementation of issue #599. The dispatch loop fired correctly when #599 was labeled `agent-ready`:

1. ✅ `agent-dispatch.yml` created branch `agent/issue-599-docs-add-agent-dispatch-section-to-readme`
2. ✅ Draft PR #600 opened with the spec
3. ✅ `@copilot Implement everything in .agent-tasks/issue-599.md.` kickoff posted

But stage 4 (Copilot coding agent picking up the kickoff) never started — the bot has been dormant since 2 days ago. Refiling by hand so the README documentation actually ships. PR #600 closed with redirect note.

## What's added

The new section covers:

- **Trigger** — apply the `agent-ready` label
- **5-stage flow** — dispatch → @copilot kickoff → bot impl → auto-ready flip → post-merge cleanup
- **Links** to all four workflow files (`agent-dispatch.yml`, `agent-auto-ready.yml`, `agent-merge-lane.yml`, `agent-post-merge.yml`)
- **Backfill mode** — manual workflow_dispatch to process pre-labeled issues
- **Batch merge** — `agent-merge-lane.yml` with lane + `dry_run` options
- **Gotchas** — issue spec quality, idempotency, auto-ready gate requirement

## Placement

After Contributing, before Acknowledgments. Contributors land on the manual flow first; the agent dispatch is positioned as the automated alternative for well-scoped issues.

## Test plan

- [ ] Section renders correctly on github.com/Sheshiyer/Selemene-engine (markdown headings, code formatting, workflow file links)
- [ ] CI passes (no Rust changes; Lint depends on PR #601 to land first)

Closes #599