### PR TITLE
test: bump health-check version assertion 3.0.0 → 3.1.0

### DIFF
--- a/crates/noesis-api/tests/integration_tests.rs
+++ b/crates/noesis-api/tests/integration_tests.rs
@@ -210,7 +210,7 @@ async fn test_health_check_no_auth_required() {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["status"], "ok");
-    assert_eq!(body["version"], "3.0.0");
+    assert_eq!(body["version"], "3.1.0");
 }
 
 #[tokio::test]


### PR DESCRIPTION
PR #652 bumped the API version to 3.1.0. The health endpoint now reports `3.1.0`, so `test_health_check_no_auth_required` was failing with a stale assertion. One-line fix.