### PR TITLE
chore(ci): remove obsolete clippy lint suppressions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         run: cargo fmt --all -- --check
       
       - name: Run Clippy
-        run: cargo clippy --all-targets -- -D warnings -A clippy::manual_range_contains -A clippy::bool_assert_comparison
+        run: cargo clippy --all-targets -- -D warnings
 
   workflow-parity:
     name: Workflow Registry Parity


### PR DESCRIPTION
Removes `-A clippy::manual_range_contains` and `-A clippy::bool_assert_comparison` from the CI lint command.

## Why now?

These suppressions were added in commits `5ec6826` and `886600c` as holds while pre-existing violations were being fixed. Both lints are now violation-free:

```
cargo clippy --all-targets -- -W clippy::manual_range_contains -W clippy::bool_assert_comparison
# → 0 warnings
```

Verified across all engine crates (`engine-panchanga`, `engine-biorhythm`, `engine-human-design`, `engine-vimshottari`, `engine-transits`, `engine-biofield`, `noesis-orchestrator`, `noesis-api`, `noesis-integration`).

## Change

```diff
- cargo clippy --all-targets -- -D warnings -A clippy::manual_range_contains -A clippy::bool_assert_comparison
+ cargo clippy --all-targets -- -D warnings
```

CI will verify this is clean before merge.