### PR TITLE
feat(admin-web): ADR-30–34 — telemetry, a11y, visual regression, design polish, rollout checklist

### DIFF
--- a/apps/admin-web/app/(protected)/layout.tsx
+++ b/apps/admin-web/app/(protected)/layout.tsx
@@ -9,6 +9,7 @@ import { CommandPalette, useCommandPaletteToggle } from "@/components/command-pa
 import { clearAuthToken, getAuthToken } from "@/lib/auth";
 import { ApiClientError, getAdminSession } from "@/lib/api";
 import { hasPermission, requiredPermissionForPath } from "@/lib/permissions";
+import { trackEvent } from "@/lib/telemetry";
 import type { AdminSession } from "@/types/admin";
 
 interface NavItem {
@@ -194,6 +195,7 @@ export default function ProtectedLayout({ children }: { children: React.ReactNod
   const permissionCount = session?.permissions.length ?? 0;
 
   const handleSignOut = useCallback(() => {
+    trackEvent("admin_sign_out");
     clearAuthToken();
     router.replace("/login");
   }, [router]);
@@ -314,8 +316,8 @@ export default function ProtectedLayout({ children }: { children: React.ReactNod
         <div className="nav-section-stack">
           {navSections.map((section) => (
             <section key={section.label} className="nav-section">
-              <div className="telemetry-caption nav-section-label">{section.label}</div>
-              <nav className="nav-list">
+              <div className="telemetry-caption nav-section-label" aria-hidden="true">{section.label}</div>
+              <nav className="nav-list" aria-label={section.label}>
                 {section.items.map((item) => {
                   const allowed = hasPermission(session.permissions, item.permission);
                   const active = relativePath === item.href;
@@ -325,9 +327,11 @@ export default function ProtectedLayout({ children }: { children: React.ReactNod
                       href={item.href}
                       className={`nav-item ${active ? "active" : ""}`}
                       title={allowed ? "" : `Requires ${item.permission}`}
+                      aria-current={active ? "page" : undefined}
+                      aria-disabled={!allowed || undefined}
                     >
                       <span>{item.label}</span>
-                      <span className={`pill ${allowed ? "ok" : "danger"}`}>
+                      <span className={`pill ${allowed ? "ok" : "danger"}`} aria-hidden="true">
                         {allowed ? "ready" : "locked"}
                       </span>
                     </Link>

--- a/apps/admin-web/app/api/telemetry/route.ts
+++ b/apps/admin-web/app/api/telemetry/route.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+interface TelemetryEvent {
+  name: string;
+  props?: Record<string, unknown>;
+  ts?: number;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const event = (await request.json()) as TelemetryEvent;
+    // Structured log to stdout — Railway captures these as structured events.
+    console.log(
+      JSON.stringify({
+        source: "admin-telemetry",
+        name: event.name,
+        props: event.props ?? {},
+        ts: event.ts ?? Date.now(),
+        ip: request.headers.get("x-forwarded-for") ?? "unknown"
+      })
+    );
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+}

--- a/apps/admin-web/app/globals.css
+++ b/apps/admin-web/app/globals.css
@@ -19,6 +19,11 @@
   --glow-verdant: rgba(74, 124, 89, 0.12);
   --danger: #ef6b73;
   --danger-soft: rgba(239, 107, 115, 0.18);
+  /* Layout tokens */
+  --sidebar-w: minmax(260px, 296px);
+  --gap-shell: 1rem;
+  --gap-card: 0.9rem;
+  --gap-section: 0.55rem;
 }
 
 * {
@@ -62,12 +67,14 @@ a {
 
 .admin-shell {
   display: grid;
-  grid-template-columns: 252px 1fr;
+  grid-template-columns: var(--sidebar-w) minmax(0, 1fr);
   min-height: 100vh;
 }
 
+/* shell-v2 retained for backward compatibility; effectively a no-op since
+   .admin-shell already uses --sidebar-w. */
 .shell-v2 {
-  grid-template-columns: minmax(260px, 296px) minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-w) minmax(0, 1fr);
 }
 
 .sidebar {
@@ -549,7 +556,7 @@ tbody tr.clickable-row {
 }
 
 tbody tr.clickable-row:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--accent-strong);
   outline-offset: -2px;
 }
 

--- a/apps/admin-web/app/layout.tsx
+++ b/apps/admin-web/app/layout.tsx
@@ -22,6 +22,8 @@ const ibmPlexMono = IBM_Plex_Mono({
   display: "swap"
 });
 
+export { reportWebVitals } from "@/lib/telemetry-vitals";
+
 export const metadata: Metadata = {
   title: "Selemene Admin",
   description: "Admin portal for key management, users, and platform operations"

--- a/apps/admin-web/package.json
+++ b/apps/admin-web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start -p 3001",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit --incremental false"
+    "typecheck": "tsc --noEmit --incremental false",
+    "test:visual": "playwright test"
   },
   "dependencies": {
     "next": "16.1.6",
@@ -16,6 +17,7 @@
     "recharts": "^2.15.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
     "@types/node": "20.17.57",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",

--- a/apps/admin-web/playwright.config.ts
+++ b/apps/admin-web/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/visual",
+  outputDir: "./tests/visual/.results",
+  snapshotDir: "./tests/visual/.snapshots",
+  reporter: [["html", { open: "never", outputFolder: "tests/visual/.report" }]],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3001",
+    screenshot: "only-on-failure",
+    trace: "on-first-retry"
+  },
+  projects: [
+    {
+      name: "desktop-chrome",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 900 }
+      }
+    }
+  ]
+});

--- a/apps/admin-web/src/components/command-palette.tsx
+++ b/apps/admin-web/src/components/command-palette.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { ModalSurface } from "@/components/overlay-surface";
+import { trackEvent } from "@/lib/telemetry";
 
 function joinClasses(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
@@ -120,6 +121,11 @@ export function CommandPalette({
       return;
     }
 
+    trackEvent("command_palette_select", {
+      id: selected.id,
+      section: selected.section,
+      title: selected.title
+    });
     handleClose();
     selected.onSelect();
   }
@@ -179,6 +185,13 @@ export function CommandPalette({
             onChange={(event) => setQuery(event.target.value)}
             onKeyDown={onListKeyDown}
             placeholder="Search routes and actions"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-expanded={filteredItems.length > 0}
+            aria-controls="command-palette-listbox"
+            aria-activedescendant={
+              filteredItems[activeIndex] ? `cp-item-${filteredItems[activeIndex].id}` : undefined
+            }
           />
         </label>
 
@@ -189,7 +202,7 @@ export function CommandPalette({
             <div className="helper">Try a route name, action, or keyword like audit, refresh, or sign out.</div>
           </div>
         ) : (
-          <div className="command-palette-results" role="listbox" aria-label="Available commands">
+          <div className="command-palette-results" id="command-palette-listbox" role="listbox" aria-label="Available commands">
             {groupedItems.map((group) => (
               <section key={group.section} className="command-palette-group">
                 <div className="telemetry-caption command-palette-group-label">{group.section}</div>
@@ -199,6 +212,7 @@ export function CommandPalette({
                     return (
                       <button
                         key={item.id}
+                        id={`cp-item-${item.id}`}
                         type="button"
                         role="option"
                         aria-selected={active}

--- a/apps/admin-web/src/components/overlay-surface.tsx
+++ b/apps/admin-web/src/components/overlay-surface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useId, type ReactNode } from "react";
 
 function joinClasses(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
@@ -45,6 +45,7 @@ export function ModalSurface({
   children
 }: OverlayBaseProps) {
   useEscapeToClose(open, onClose);
+  const titleId = useId();
 
   if (!open) {
     return null;
@@ -57,12 +58,13 @@ export function ModalSurface({
         onClick={(event) => event.stopPropagation()}
         role="dialog"
         aria-modal="true"
+        aria-labelledby={title ? titleId : undefined}
       >
         {eyebrow || title || summary ? (
           <header className="overlay-surface-header">
             <div>
               {eyebrow ? <div className="eyebrow">{eyebrow}</div> : null}
-              {title ? <h3>{title}</h3> : null}
+              {title ? <h3 id={titleId}>{title}</h3> : null}
               {summary ? <p className="helper">{summary}</p> : null}
             </div>
             <button type="button" className="overlay-close" onClick={onClose} aria-label="Close dialog">
@@ -88,6 +90,7 @@ export function DrawerSurface({
   children
 }: OverlayBaseProps) {
   useEscapeToClose(open, onClose);
+  const titleId = useId();
 
   if (!open) {
     return null;
@@ -100,11 +103,12 @@ export function DrawerSurface({
         onClick={(event) => event.stopPropagation()}
         role="dialog"
         aria-modal="true"
+        aria-labelledby={title ? titleId : undefined}
       >
         <header className="overlay-surface-header">
           <div>
             {eyebrow ? <div className="eyebrow">{eyebrow}</div> : null}
-            {title ? <h3>{title}</h3> : null}
+            {title ? <h3 id={titleId}>{title}</h3> : null}
             {summary ? <p className="helper">{summary}</p> : null}
           </div>
           <button type="button" className="overlay-close" onClick={onClose} aria-label="Close drawer">

--- a/apps/admin-web/src/lib/telemetry-vitals.ts
+++ b/apps/admin-web/src/lib/telemetry-vitals.ts
@@ -1,0 +1,14 @@
+import { trackVital } from "@/lib/telemetry";
+
+// Shape emitted by Next.js reportWebVitals hook
+interface NextWebVitalsMetric {
+  id: string;
+  name: string;
+  startTime: number;
+  value: number;
+  label: "web-vital" | "custom";
+}
+
+export function reportWebVitals(metric: NextWebVitalsMetric): void {
+  trackVital({ name: metric.name, value: metric.value, id: metric.id });
+}

--- a/apps/admin-web/src/lib/telemetry.ts
+++ b/apps/admin-web/src/lib/telemetry.ts
@@ -1,0 +1,44 @@
+"use client";
+
+export interface TelemetryEvent {
+  name: string;
+  props?: Record<string, unknown>;
+  ts?: number;
+}
+
+const isDev = process.env.NODE_ENV === "development";
+
+/**
+ * Emit a structured telemetry event.
+ *
+ * In development: logs to console.debug.
+ * In production: POSTs to /api/telemetry via navigator.sendBeacon (fire-and-forget,
+ * survives page unloads) with a fetch fallback.
+ */
+export function trackEvent(name: string, props?: Record<string, unknown>): void {
+  const event: TelemetryEvent = { name, props, ts: Date.now() };
+
+  if (isDev) {
+    console.debug("[telemetry]", event);
+    return;
+  }
+
+  const payload = JSON.stringify(event);
+  if (typeof navigator !== "undefined" && navigator.sendBeacon) {
+    const blob = new Blob([payload], { type: "application/json" });
+    navigator.sendBeacon("/api/telemetry", blob);
+  } else {
+    // Fallback for environments without sendBeacon (SSR guard, older browsers)
+    void fetch("/api/telemetry", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload,
+      keepalive: true
+    }).catch(() => undefined);
+  }
+}
+
+/** Report a Core Web Vital measurement. */
+export function trackVital(metric: { name: string; value: number; id: string }): void {
+  trackEvent("web_vital", { metric: metric.name, value: metric.value, id: metric.id });
+}

--- a/apps/admin-web/tests/visual/admin-baseline.test.ts
+++ b/apps/admin-web/tests/visual/admin-baseline.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Admin web visual regression baseline.
+ *
+ * These tests capture screenshots of key protected routes and compare them
+ * against a committed baseline. They require the admin-web dev server to be
+ * running on PLAYWRIGHT_BASE_URL (default: http://localhost:3001) and a valid
+ * admin session cookie/localStorage token.
+ *
+ * To capture a fresh baseline:
+ *   pnpm exec playwright test --update-snapshots
+ *
+ * To run regression checks:
+ *   pnpm exec playwright test
+ *
+ * CI: see docs/qa/visual-regression.md for the documented workflow.
+ */
+
+const ROUTES = [
+  { path: "/dashboard", name: "dashboard" },
+  { path: "/users", name: "users" },
+  { path: "/api-keys", name: "api-keys" },
+  { path: "/history-sync", name: "history-sync" },
+  { path: "/analytics", name: "analytics" },
+  { path: "/system", name: "system" },
+  { path: "/audit", name: "audit" }
+] as const;
+
+/** Storage state path; generate with `playwright codegen --save-storage=auth.json` */
+const AUTH_STATE = process.env.PLAYWRIGHT_AUTH_STATE ?? "./tests/visual/auth.json";
+
+test.use({ storageState: AUTH_STATE });
+
+for (const route of ROUTES) {
+  test(`${route.name} — visual baseline`, async ({ page }) => {
+    await page.goto(route.path);
+    // Wait for shell to settle past the loading skeleton
+    await page.waitForSelector(".shell-main-grid", { timeout: 8000 });
+    await expect(page).toHaveScreenshot(`${route.name}.png`, {
+      fullPage: false,
+      maxDiffPixelRatio: 0.02
+    });
+  });
+}

--- a/apps/admin-web/tsconfig.json
+++ b/apps/admin-web/tsconfig.json
@@ -36,6 +36,8 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "tests/**",
+    "playwright.config.ts"
   ]
 }

--- a/docs/qa/a11y-checklist.md
+++ b/docs/qa/a11y-checklist.md
@@ -1,0 +1,86 @@
+# Accessibility QA Checklist — Admin Web
+
+> ADR-32 | Area: QA | Owner: Tech Lead
+
+## Scope
+
+This document records the accessibility validation pass for the admin shell redesign. Each section maps to a UI area and its keyboard/AT acceptance criteria.
+
+---
+
+## 1. Shell Navigation
+
+| Journey | Expected behaviour | Status |
+|---|---|---|
+| Tab through sidebar nav links | Focus moves sequentially; active link has `aria-current="page"` | ✅ Implemented |
+| Enter on locked nav item | Navigates (permission error shown on destination); lock state conveyed via `aria-disabled` | ✅ Implemented |
+| Tab to topbar action rail buttons | All 4 buttons reachable; focus rings visible (2px Solar Bronze outline) | ✅ CSS `:focus-visible` rule present |
+
+## 2. Command Palette (Cmd/Ctrl + K)
+
+| Journey | Expected behaviour | Status |
+|---|---|---|
+| Activate with keyboard shortcut | Palette opens; focus placed on search input | ✅ `requestAnimationFrame` focus call |
+| Search input role | `role="combobox"` with `aria-autocomplete="list"`, `aria-expanded`, `aria-controls`, `aria-activedescendant` | ✅ Implemented |
+| Arrow key navigation | Up/Down moves highlight; `aria-activedescendant` updates to point at active item ID | ✅ Implemented |
+| Enter to select | Executes item; palette closes; focus returns naturally | ✅ |
+| Escape to close | Palette closes | ✅ `useEscapeToClose` |
+| Screen reader announces active item | `aria-activedescendant` + `aria-selected` on `role="option"` items | ✅ Implemented |
+
+## 3. Modal Dialogs (ModalSurface)
+
+| Journey | Expected behaviour | Status |
+|---|---|---|
+| Dialog role and label | `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing to title `<h3>` | ✅ Implemented |
+| Escape to close | Closes dialog | ✅ `useEscapeToClose` |
+| Close button | `aria-label="Close dialog"` | ✅ |
+| Focus trap | Focus should not leave the modal while open | ⚠️ **Deferred** — no focus trap hook implemented; manual testing required |
+
+## 4. Drawer Panels (DrawerSurface)
+
+| Journey | Expected behaviour | Status |
+|---|---|---|
+| Drawer role and label | `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing to title | ✅ Implemented |
+| Escape to close | Closes drawer | ✅ |
+| Close button | `aria-label="Close drawer"` | ✅ |
+
+## 5. Data Tables
+
+| Journey | Expected behaviour | Status |
+|---|---|---|
+| Table headers | `<th scope="col">` on all column headers | 🔲 **Needs review** — route-level tables use custom markup |
+| Row selection checkboxes | `aria-label` describing selected row | 🔲 **Needs review** |
+| Sortable columns | `aria-sort` attribute when sorted | 🔲 **Needs review** |
+
+## 6. Bulk Action Bar
+
+| Journey | Expected behaviour | Status |
+|---|---|---|
+| Bar announced | `aria-label="{itemLabel} bulk actions"` on section | ✅ Already present |
+| Select/Clear buttons | Standard buttons, focusable | ✅ |
+| Disabled state on Clear | `disabled` attribute when `selectedCount === 0` | ✅ |
+
+## 7. Form Inputs
+
+| Journey | Expected behaviour | Status |
+|---|---|---|
+| Filter/search inputs | Associated `<label>` or `aria-label` | 🔲 **Needs review per route** |
+| Error messages | `aria-describedby` linking input to error text | 🔲 **Needs review** |
+
+---
+
+## Known Deferred Items
+
+- **Focus trap in modals/drawers**: No `focus-trap` library installed. A future sprint should add focus trapping so keyboard users cannot tab out of an open modal.
+- **Table-level a11y**: Individual route pages (users, api-keys, audit) need per-column `scope="col"` headers and `aria-sort` reviewed.
+- **Dynamic ARIA live regions**: Bulk action count changes and state banners should use `aria-live="polite"` for screen reader announcements.
+
+## Test Evidence
+
+Run keyboard-only journeys in Chrome with VoiceOver (macOS) or NVDA (Windows):
+1. Login → Dashboard via keyboard only
+2. Open/close command palette, select a route item
+3. Open a drawer, tab through fields, close
+4. Use bulk action bar on Users page
+
+Attach screen recordings as PR comments when closing deferred items.

--- a/docs/qa/visual-regression.md
+++ b/docs/qa/visual-regression.md
@@ -1,0 +1,77 @@
+# Visual Regression Workflow — Admin Web
+
+> ADR-31 | Area: QA | Owner: Tech Lead
+
+## Overview
+
+Screenshot-based regression tests guard the admin shell and core pages against unintentional visual drift. Tests live in `apps/admin-web/tests/visual/` and use Playwright.
+
+## Covered Routes
+
+| Route | Screenshot name |
+|---|---|
+| `/dashboard` | `dashboard.png` |
+| `/users` | `users.png` |
+| `/api-keys` | `api-keys.png` |
+| `/history-sync` | `history-sync.png` |
+| `/analytics` | `analytics.png` |
+| `/system` | `system.png` |
+| `/audit` | `audit.png` |
+
+Viewport: **1440 × 900** (desktop Chrome). Threshold: ≤ 2% pixel diff ratio.
+
+## Prerequisites
+
+1. Install Playwright browsers: `npx playwright install chromium`
+2. Generate an admin auth session file:
+   ```bash
+   npx playwright codegen --save-storage=tests/visual/auth.json http://localhost:3001/login
+   ```
+   Log in through the Discord OAuth flow. The resulting `auth.json` stores cookies/localStorage for subsequent test runs.
+
+3. Start the dev server: `npm run dev` (port 3001)
+
+## Capturing a Baseline
+
+Run once after a major design change to commit new reference screenshots:
+
+```bash
+cd apps/admin-web
+npx playwright test --update-snapshots
+```
+
+Baseline images land in `tests/visual/.snapshots/`. **Commit them** — they are the regression reference.
+
+## Running Regression Checks
+
+```bash
+cd apps/admin-web
+npm run test:visual
+# or
+npx playwright test
+```
+
+A diff report is written to `tests/visual/.report/index.html`.
+
+## CI Integration
+
+Add to your pipeline (example GitHub Actions step):
+
+```yaml
+- name: Install Playwright browsers
+  run: npx playwright install --with-deps chromium
+  working-directory: apps/admin-web
+
+- name: Run visual regression
+  run: npm run test:visual
+  working-directory: apps/admin-web
+  env:
+    PLAYWRIGHT_BASE_URL: ${{ secrets.ADMIN_STAGING_URL }}
+    PLAYWRIGHT_AUTH_STATE: tests/visual/auth.json
+```
+
+The `auth.json` must be a CI secret or re-generated per run via a login script.
+
+## Updating Snapshots After Intentional Changes
+
+After any approved design change, run with `--update-snapshots`, review the diffs in the HTML report, then commit the updated baseline images alongside the code change.

--- a/docs/release/admin-web-canary-checklist.md
+++ b/docs/release/admin-web-canary-checklist.md
@@ -1,0 +1,84 @@
+# Admin Web Rollout & Canary Checklist
+
+> ADR-34 | Area: Docs | Owner: Tech Lead
+> Prepared for: admin dashboard redesign (P4 / ADR-18 → ADR-34)
+
+---
+
+## Pre-Deployment Verification
+
+### Build & Static Analysis
+- [ ] `npm run build` passes with zero errors in `apps/admin-web/`
+- [ ] `npm run typecheck` clean
+- [ ] `npm run lint` clean
+- [ ] No new `console.error` calls introduced in production code paths
+
+### Functional Smoke (staging)
+- [ ] Login via Discord OAuth completes and redirects to `/dashboard`
+- [ ] All 7 nav routes render without JS errors: Dashboard, Users, API Keys, History Sync, Analytics, System, Audit
+- [ ] Command palette opens (Cmd/Ctrl+K), filters items, navigates on Enter, closes on Escape
+- [ ] Drawer opens and closes on Users and API Keys pages
+- [ ] Bulk selection and clear work on at least one table page
+- [ ] Sign-out clears token and returns to `/login`
+
+### Accessibility (pre-launch)
+- [ ] a11y-checklist.md items marked ✅ are confirmed in staging (see `docs/qa/a11y-checklist.md`)
+- [ ] Keyboard-only sign-in → dashboard navigation completes
+- [ ] Command palette keyboard journey works (Cmd+K → Arrow → Enter)
+- [ ] No critical WCAG 2.1 AA violations from axe-core browser extension on Dashboard and Users routes
+
+### Visual Regression
+- [ ] Playwright baseline captured against staging: `npx playwright test --update-snapshots`
+- [ ] No unexpected diffs on Chrome 1440 × 900 (see `docs/qa/visual-regression.md`)
+
+---
+
+## Telemetry Verification (ADR-30)
+
+- [ ] `POST /api/telemetry` responds 200 on staging
+- [ ] Command palette select events appear in Railway log stream within 30 s of interaction
+- [ ] Sign-out event logged: `{ name: "admin_sign_out" }`
+- [ ] Core Web Vitals reported in log stream (LCP, CLS, FID) after first page load
+
+---
+
+## Canary Rollout Plan
+
+### Phase 1 — Internal (0 → 10% of admin sessions)
+- Deploy to Railway production
+- Enable for internal operators only (bypass traffic split or use feature-flag user list)
+- Monitor Railway log stream for: `5xx` spikes, `admin_sign_out` rate, telemetry volume
+- Canary window: **48 hours**
+
+### Phase 2 — Broadened (10% → 50%)
+- Confirm no P0/P1 regressions from Phase 1
+- Confirm visual regression baseline matches production screenshots
+- Canary window: **48 hours**
+
+### Phase 3 — Full rollout (50% → 100%)
+- Final sign-off from Tech Lead
+- Confirm ADR-30 through ADR-33 acceptance criteria all ✅
+- Merge canary flag / enable for all sessions
+
+---
+
+## Rollback Procedure
+
+1. Revert to previous Railway deployment via the Railway dashboard (Deployments → rollback to last known good)
+2. Or: `git revert <merge-commit-sha>` on `main` + force-deploy
+3. Confirm via `/health/ready` that the API is healthy
+4. Post incident note in #engineering with: root cause, affected window, rollback time
+
+---
+
+## Final Acceptance Sign-off
+
+| ADR | Owner | Acceptance criteria met | Notes |
+|---|---|---|---|
+| ADR-30 (Telemetry) | Backend Eng | ☐ | Events visible in Railway logs |
+| ADR-31 (Visual regression) | Tech Lead | ☐ | Playwright baseline committed |
+| ADR-32 (A11y QA) | Tech Lead | ☐ | Keyboard journeys confirmed |
+| ADR-33 (Design polish) | Frontend Eng | ☐ | Consistency pass reviewed |
+| ADR-34 (Rollout) | Tech Lead | ☐ | This checklist completed |
+
+> Final acceptance: Tech Lead signs off after all rows above are ✅ and Phase 3 rollout is complete.


### PR DESCRIPTION
## Summary

Delivers all 5 remaining admin web ADRs in a single wave:

### ADR-30 (#544) — Interaction telemetry
- `src/lib/telemetry.ts`: `trackEvent()` via `navigator.sendBeacon` + fetch fallback; `trackVital()` for Core Web Vitals
- `app/api/telemetry/route.ts`: Edge API route that logs structured JSON to Railway stdout
- `app/layout.tsx`: exports `reportWebVitals` for Next.js CWV reporting
- **Wired events**: `command_palette_select` (includes section/id/title), `admin_sign_out`

### ADR-31 (#545) — Screenshot visual regression
- `playwright.config.ts`: desktop Chrome 1440×900, 2% diff threshold
- `tests/visual/admin-baseline.test.ts`: 7 route baselines with auth state
- `docs/qa/visual-regression.md`: baseline capture, snapshot update, CI integration

### ADR-32 (#546) — Accessibility QA
- `overlay-surface.tsx`: `aria-labelledby` (via `useId`) on ModalSurface + DrawerSurface
- `command-palette.tsx`: `role=combobox`, `aria-autocomplete`, `aria-expanded`, `aria-controls`, `aria-activedescendant`, item `id` attributes
- `layout.tsx`: `aria-current=page` on active nav, `aria-label` on nav sections, `aria-hidden` on decorative pills
- `docs/qa/a11y-checklist.md`: keyboard journey matrix with ✅/⚠️/🔲 status

### ADR-33 (#547) — Design polish
- Consolidate sidebar width into `--sidebar-w` CSS variable (removes dead 252px hardcode)
- Add layout tokens: `--gap-shell`, `--gap-card`, `--gap-section`
- Fix `clickable-row:focus-visible` to use `var(--accent-strong)` (consistent with global rule)

### ADR-34 (#548) — Rollout + canary checklist
- `docs/release/admin-web-canary-checklist.md`: pre-deploy verification, telemetry validation, 3-phase canary plan, rollback procedure, final sign-off table

## Validation
- `npm run typecheck` ✅
- `npm run lint` ✅

Closes #544
Closes #545
Closes #546
Closes #547
Closes #548