### PR TITLE
feat(biofield): wire PIP capture blob → API upload (BF1-05.2)

### DIFF
--- a/apps/biofield-web/app/(protected)/viewer/page.tsx
+++ b/apps/biofield-web/app/(protected)/viewer/page.tsx
@@ -240,15 +240,50 @@ export default function ViewerPage() {
     }
   }
 
-  // BF1-05.1: PIP capture callback — logs locally for now.
-  // BF1-05.2 will wire blob → POST /api/v1/biofield/sessions/:id/captures.
-  const handlePIPCapture = useCallback((blob: Blob, _dataUrl: string) => {
-    console.info("[PIPViewer] capture queued for upload", {
-      engineId: "biofield-pip",
-      size: blob.size,
-      sessionId: currentSession?.id ?? null,
-    });
-  }, [currentSession]);
+  // BF1-05.2: Wire PIP blob → POST /api/v1/biofield/sessions/:id/captures.
+  const handlePIPCapture = useCallback(async (blob: Blob, _dataUrl: string) => {
+    if (!client || !currentSession) {
+      console.warn("[PIPViewer] no active session — capture not uploaded");
+      return;
+    }
+
+    setIsUploading(true);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    const file = new File([blob], "pip-capture.png", { type: blob.type || "image/png" });
+    const formData = new FormData();
+    formData.append("image", file);
+    formData.append("options", JSON.stringify({ mode: "capture", source: "pip-camera" }));
+    formData.append(
+      "capture_metadata",
+      JSON.stringify({
+        platform: "web",
+        source: "pip-camera",
+        file_name: "pip-capture.png",
+        file_size: blob.size,
+        file_type: file.type,
+        viewport:
+          typeof window !== "undefined"
+            ? { width: window.innerWidth, height: window.innerHeight }
+            : undefined,
+      }),
+    );
+
+    try {
+      const result = await client.uploadCapture(currentSession.id, formData);
+      setCaptureResult(result);
+      setStatusMessage(`PIP capture analyzed with ${result.analysis_version}.`);
+    } catch (error) {
+      if (error instanceof BiofieldClientError && error.status === 401) {
+        handleAuthFailure();
+        return;
+      }
+      setErrorMessage(error instanceof Error ? error.message : "Failed to upload PIP capture.");
+    } finally {
+      setIsUploading(false);
+    }
+  }, [client, currentSession]);
 
   const activeMetricRows = captureResult
     ? METRIC_KEYS.map((key) => ({ key, value: captureResult.metrics[key] }))


### PR DESCRIPTION
## Summary

Implements BF1-05.2: the `handlePIPCapture` callback in `viewer/page.tsx` now uploads blobs from the PIP camera directly to the biofield captures API.

### What changed

**`apps/biofield-web/app/(protected)/viewer/page.tsx`**
- Replaced stub callback (console.info only) with full async upload flow
- Guards on `client` + `currentSession` presence — warns and returns early if no active session
- Wraps `Blob` in a `File` object (`pip-capture.png`) for multipart compatibility
- Builds `FormData`: `image`, `options` (`source: pip-camera`), `capture_metadata`
- Calls `client.uploadCapture(currentSession.id, formData)` — same path as file upload
- Sets `captureResult` + status message on success
- Handles 401 (redirects to login) and other errors via `setErrorMessage`
- Reuses `isUploading` state so UI controls disable during upload

### Scope

BF1-05.2 complete. BF1-05.3–05.6 (MediaPipe segmentation, mask uniform, real-time metrics, engine seam) remain tracked in #550.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>