### PR TITLE
feat(bf1-05-3-4): MediaPipe selfie segmentation + mask uniform in PIP viewer

### DIFF
--- a/apps/biofield-web/src/components/pip/PIPRenderer.ts
+++ b/apps/biofield-web/src/components/pip/PIPRenderer.ts
@@ -1,4 +1,5 @@
 import type { PIPSettings } from "./types";
+import type { MediaPipeMask } from "./useMediaPipe";
 
 // ─── Vertex shader ────────────────────────────────────────────────────────────
 const VERT_SRC = `#version 300 es
@@ -14,6 +15,8 @@ const FRAG_SRC = `#version 300 es
 precision highp float;
 
 uniform sampler2D u_video;
+uniform sampler2D u_mask;      // MediaPipe selfie segmentation confidence mask
+uniform float u_maskStrength;  // 0 = mask off, 1 = full mask gating
 uniform float u_time;
 uniform float u_noiseScale;
 uniform float u_noiseSpeed;
@@ -85,11 +88,16 @@ void main() {
   float gate = smoothstep(u_threshold - 0.1, u_threshold + 0.1, n);
   vec3  pip  = biofieldPalette(n);
 
-  fragColor = vec4(mix(video.rgb, pip, u_intensity * gate), 1.0);
+  // Segmentation mask: confidence value is in the red channel.
+  // u_maskStrength = 0 → ignore mask, 1 → only show biofield on person pixels.
+  float personConf = texture(u_mask, v_texCoord).r;
+  float maskGate   = mix(1.0, personConf, u_maskStrength);
+
+  fragColor = vec4(mix(video.rgb, pip, u_intensity * gate * maskGate), 1.0);
 }`;
 
 const UNIFORM_NAMES = [
-  "u_video", "u_time", "u_noiseScale", "u_noiseSpeed",
+  "u_video", "u_mask", "u_maskStrength", "u_time", "u_noiseScale", "u_noiseSpeed",
   "u_layerCount", "u_intensity", "u_colorShift", "u_threshold",
 ] as const;
 
@@ -99,6 +107,7 @@ export class PIPRenderer {
   private gl: WebGL2RenderingContext | null = null;
   private program: WebGLProgram | null = null;
   private videoTexture: WebGLTexture | null = null;
+  private maskTexture: WebGLTexture | null = null;
   private vao: WebGLVertexArrayObject | null = null;
   private uniforms: Partial<Record<UniformName, WebGLUniformLocation | null>> = {};
 
@@ -146,6 +155,18 @@ export class PIPRenderer {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
     this.videoTexture = tex;
 
+    // Mask texture — updated each frame from MediaPipe confidence mask.
+    const maskTex = gl.createTexture();
+    if (!maskTex) return false;
+    gl.bindTexture(gl.TEXTURE_2D, maskTex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    // Seed a 1×1 white pixel so the shader has a valid sampler before any mask arrives.
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.R32F, 1, 1, 0, gl.RED, gl.FLOAT, new Float32Array([1]));
+    this.maskTexture = maskTex;
+
     for (const name of UNIFORM_NAMES) {
       this.uniforms[name] = gl.getUniformLocation(prog, name);
     }
@@ -153,7 +174,7 @@ export class PIPRenderer {
     return true;
   }
 
-  render(video: HTMLVideoElement, timeMs: number, s: PIPSettings): void {
+  render(video: HTMLVideoElement, timeMs: number, s: PIPSettings, mask?: MediaPipeMask | null): void {
     const gl = this.gl;
     if (!gl || !this.program || !this.vao) return;
 
@@ -172,12 +193,29 @@ export class PIPRenderer {
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, video);
     }
 
+    // Upload segmentation mask when available (single-channel float R32F).
+    const maskStrength = mask ? 1.0 : 0.0;
+    if (mask) {
+      gl.bindTexture(gl.TEXTURE_2D, this.maskTexture);
+      gl.texImage2D(
+        gl.TEXTURE_2D, 0, gl.R32F,
+        mask.width, mask.height, 0,
+        gl.RED, gl.FLOAT, mask.data,
+      );
+    }
+
     gl.useProgram(this.program);
     gl.bindVertexArray(this.vao);
+
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, this.videoTexture);
 
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, this.maskTexture);
+
     gl.uniform1i(this.uniforms.u_video ?? null, 0);
+    gl.uniform1i(this.uniforms.u_mask ?? null, 1);
+    gl.uniform1f(this.uniforms.u_maskStrength ?? null, maskStrength);
     gl.uniform1f(this.uniforms.u_time ?? null, timeMs / 1000);
     gl.uniform1f(this.uniforms.u_noiseScale ?? null, s.noiseScale);
     gl.uniform1f(this.uniforms.u_noiseSpeed ?? null, s.noiseSpeed);
@@ -194,6 +232,7 @@ export class PIPRenderer {
     const gl = this.gl;
     if (!gl) return;
     if (this.videoTexture) gl.deleteTexture(this.videoTexture);
+    if (this.maskTexture)  gl.deleteTexture(this.maskTexture);
     if (this.program)      gl.deleteProgram(this.program);
     if (this.vao)          gl.deleteVertexArray(this.vao);
     this.gl = null;

--- a/apps/biofield-web/src/components/pip/PIPViewerPanel.tsx
+++ b/apps/biofield-web/src/components/pip/PIPViewerPanel.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { DEFAULT_PIP_SETTINGS } from "./types";
 import { useCamera } from "./useCamera";
+import { useMediaPipe } from "./useMediaPipe";
 import { usePIPRenderer } from "./usePIPRenderer";
 
 export interface PIPViewerPanelProps {
@@ -17,18 +18,26 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
 
   const { videoRef, isStreaming, devices, error: cameraError, startCamera, stopCamera } = useCamera();
   const { status: glStatus, startRenderLoop, stopRenderLoop } = usePIPRenderer(canvasRef);
+  const { ready: mpReady, error: mpError, segmentFrame } = useMediaPipe();
 
   const [panelState, setPanelState] = useState<PanelState>("idle");
   const [captureCount, setCaptureCount] = useState(0);
   const [captureError, setCaptureError] = useState<string | null>(null);
 
+  // getMask runs each RAF frame: returns the latest segmentation mask or null.
+  const getMask = useCallback(() => {
+    const video = videoRef.current;
+    if (!mpReady || !video) return null;
+    return segmentFrame(video);
+  }, [mpReady, segmentFrame, videoRef]);
+
   // Start render loop when both camera and renderer are ready.
   useEffect(() => {
     const video = videoRef.current;
     if (isStreaming && glStatus === "ready" && video && panelState === "streaming") {
-      startRenderLoop(video, settingsRef);
+      startRenderLoop(video, settingsRef, getMask);
     }
-  }, [isStreaming, glStatus, panelState, startRenderLoop, videoRef]);
+  }, [isStreaming, glStatus, panelState, startRenderLoop, getMask, videoRef]);
 
   const handleStart = useCallback(async () => {
     setCaptureError(null);
@@ -44,10 +53,10 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
   const handleResume = useCallback(() => {
     const video = videoRef.current;
     if (video && glStatus === "ready") {
-      startRenderLoop(video, settingsRef);
+      startRenderLoop(video, settingsRef, getMask);
     }
     setPanelState("streaming");
-  }, [glStatus, startRenderLoop, videoRef]);
+  }, [glStatus, getMask, startRenderLoop, videoRef]);
 
   const handleStop = useCallback(() => {
     stopRenderLoop();
@@ -69,13 +78,6 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
         const reader = new FileReader();
         reader.onloadend = () => {
           const dataUrl = reader.result as string;
-          // BF1-05.2 will wire this to POST /api/v1/biofield/sessions/:id/captures
-          console.info("[PIPViewer] capture", {
-            engineId: "biofield-pip",
-            size: blob.size,
-            width: canvas.width,
-            height: canvas.height,
-          });
           onCapture?.(blob, dataUrl);
           setCaptureCount((n) => n + 1);
         };
@@ -91,6 +93,12 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
       : glStatus === "error"
         ? "WebGL2 ✗"
         : "WebGL2 …";
+
+  const mpLabel = mpError
+    ? "MP ✗"
+    : mpReady
+      ? "MP ✓"
+      : "MP …";
 
   const cameraLabel =
     panelState === "streaming"
@@ -115,6 +123,12 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
           className={`biofield-status-pill ${glStatus === "ready" ? "biofield-status-pill-good" : glStatus === "error" ? "" : "biofield-status-pill-warn"}`}
         >
           {glLabel}
+        </span>
+        <span
+          className={`biofield-status-pill ${mpReady ? "biofield-status-pill-good" : mpError ? "" : "biofield-status-pill-warn"}`}
+          title={mpError ?? undefined}
+        >
+          {mpLabel}
         </span>
         <span
           className={`biofield-status-pill ${panelState === "streaming" ? "biofield-status-pill-good" : panelState === "paused" ? "biofield-status-pill-warn" : ""}`}
@@ -219,10 +233,7 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
       )}
 
       <p className="biofield-copy" style={{ marginTop: "0.75rem" }}>
-        Captures save locally as PNG.{" "}
-        <span className="biofield-mono" style={{ fontSize: "0.75em", opacity: 0.7 }}>
-          API upload wired in BF1-05.2
-        </span>
+        Segmentation mask{mpReady ? " active" : " loading"} — biofield overlay is person-gated.
       </p>
     </section>
   );

--- a/apps/biofield-web/src/components/pip/useMediaPipe.ts
+++ b/apps/biofield-web/src/components/pip/useMediaPipe.ts
@@ -1,0 +1,221 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ─── Inline MediaPipe type definitions ────────────────────────────────────────
+// These mirror the @mediapipe/tasks-vision API surface. The actual module is
+// loaded at runtime from the MediaPipe CDN ESM bundle to avoid requiring npm.
+
+interface FilesetResolverStatic {
+  forVisionTasks(basePath: string): Promise<WasmFileset>;
+}
+
+interface WasmFileset {
+  wasmLoaderPath: string;
+  wasmBinaryPath: string;
+}
+
+interface ImageSegmenterOptions {
+  baseOptions: { modelAssetPath: string; delegate?: "GPU" | "CPU" };
+  outputCategoryMask?: boolean;
+  outputConfidenceMasks?: boolean;
+  runningMode?: "IMAGE" | "VIDEO";
+}
+
+interface SegmentationMask {
+  /** Float32 confidence values per pixel (0=background, 1=person). */
+  getAsFloat32Array(): Float32Array;
+  width: number;
+  height: number;
+  close(): void;
+}
+
+interface ImageSegmenterResult {
+  confidenceMasks?: SegmentationMask[];
+  categoryMask?: SegmentationMask;
+  close(): void;
+}
+
+interface ImageSegmenterStatic {
+  createFromOptions(fileset: WasmFileset, options: ImageSegmenterOptions): Promise<ImageSegmenterInstance>;
+}
+
+interface ImageSegmenterInstance {
+  segmentForVideo(source: HTMLVideoElement, timestampMs: number): ImageSegmenterResult;
+  close(): void;
+}
+
+interface FaceLandmarkerOptions {
+  baseOptions: { modelAssetPath: string; delegate?: "GPU" | "CPU" };
+  runningMode?: "IMAGE" | "VIDEO";
+  numFaces?: number;
+  minFaceDetectionConfidence?: number;
+  minTrackingConfidence?: number;
+}
+
+interface NormalizedLandmark {
+  x: number;
+  y: number;
+  z: number;
+}
+
+interface FaceLandmarkerResult {
+  faceLandmarks: NormalizedLandmark[][];
+  close(): void;
+}
+
+interface FaceLandmarkerStatic {
+  createFromOptions(fileset: WasmFileset, options: FaceLandmarkerOptions): Promise<FaceLandmarkerInstance>;
+}
+
+interface FaceLandmarkerInstance {
+  detectForVideo(source: HTMLVideoElement, timestampMs: number): FaceLandmarkerResult;
+  close(): void;
+}
+
+interface MediaPipeVisionModule {
+  FilesetResolver: FilesetResolverStatic;
+  ImageSegmenter: ImageSegmenterStatic;
+  FaceLandmarker: FaceLandmarkerStatic;
+}
+
+// ─── Model URLs ───────────────────────────────────────────────────────────────
+const MP_CDN = "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14";
+const SELFIE_SEGMENTATION_MODEL =
+  "https://storage.googleapis.com/mediapipe-models/image_segmenter/selfie_segmenter/float16/latest/selfie_segmenter.tflite";
+const FACE_LANDMARK_MODEL =
+  "https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task";
+
+export interface MediaPipeMask {
+  /** Confidence float32 array (0=background, 1=person), row-major. */
+  data: Float32Array;
+  width: number;
+  height: number;
+}
+
+export interface MediaPipeFaceResult {
+  landmarks: NormalizedLandmark[][];
+}
+
+export interface UseMediaPipeResult {
+  ready: boolean;
+  error: string | null;
+  /** Run segmentation on current video frame. Returns null until ready. */
+  segmentFrame(video: HTMLVideoElement): MediaPipeMask | null;
+  /** Run face landmark detection on current video frame. Returns null until ready. */
+  detectFace(video: HTMLVideoElement): MediaPipeFaceResult | null;
+}
+
+/**
+ * Loads MediaPipe Tasks Vision from CDN and initialises the Selfie Segmenter
+ * and Face Landmarker. The CDN bundle loads WASM lazily on first call.
+ *
+ * Requires a network connection to cdn.jsdelivr.net and storage.googleapis.com.
+ * No npm dependency needed — the module is imported via indirect dynamic import.
+ */
+export function useMediaPipe(): UseMediaPipeResult {
+  const segmenterRef = useRef<ImageSegmenterInstance | null>(null);
+  const faceRef = useRef<FaceLandmarkerInstance | null>(null);
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function init() {
+      try {
+        // Indirect dynamic import bypasses TypeScript's URL import check while
+        // preserving full type safety via the inline interface above.
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval
+        const mp = await new Function("u", "return import(u)")(
+          `${MP_CDN}/vision_bundle.mjs`,
+        ) as MediaPipeVisionModule;
+
+        const fileset = await mp.FilesetResolver.forVisionTasks(
+          `${MP_CDN}/wasm`,
+        );
+
+        const [segmenter, face] = await Promise.all([
+          mp.ImageSegmenter.createFromOptions(fileset, {
+            baseOptions: {
+              modelAssetPath: SELFIE_SEGMENTATION_MODEL,
+              delegate: "GPU",
+            },
+            outputConfidenceMasks: true,
+            runningMode: "VIDEO",
+          }),
+          mp.FaceLandmarker.createFromOptions(fileset, {
+            baseOptions: {
+              modelAssetPath: FACE_LANDMARK_MODEL,
+              delegate: "GPU",
+            },
+            runningMode: "VIDEO",
+            numFaces: 1,
+            minFaceDetectionConfidence: 0.5,
+            minTrackingConfidence: 0.5,
+          }),
+        ]);
+
+        if (cancelled) {
+          segmenter.close();
+          face.close();
+          return;
+        }
+
+        segmenterRef.current = segmenter;
+        faceRef.current = face;
+        setReady(true);
+      } catch (err) {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : "MediaPipe init failed";
+          console.warn("[useMediaPipe]", message);
+          setError(message);
+        }
+      }
+    }
+
+    void init();
+
+    return () => {
+      cancelled = true;
+      segmenterRef.current?.close();
+      faceRef.current?.close();
+      segmenterRef.current = null;
+      faceRef.current = null;
+      setReady(false);
+      setError(null);
+    };
+  }, []);
+
+  const segmentFrame = useCallback((video: HTMLVideoElement): MediaPipeMask | null => {
+    const seg = segmenterRef.current;
+    if (!seg || video.readyState < video.HAVE_CURRENT_DATA) return null;
+
+    const result = seg.segmentForVideo(video, performance.now());
+    const mask = result.confidenceMasks?.[0];
+    if (!mask) {
+      result.close();
+      return null;
+    }
+
+    const out: MediaPipeMask = {
+      data: mask.getAsFloat32Array().slice(), // copy before mask.close()
+      width: mask.width,
+      height: mask.height,
+    };
+    result.close();
+    return out;
+  }, []);
+
+  const detectFace = useCallback((video: HTMLVideoElement): MediaPipeFaceResult | null => {
+    const face = faceRef.current;
+    if (!face || video.readyState < video.HAVE_CURRENT_DATA) return null;
+
+    const result = face.detectForVideo(video, performance.now());
+    const out: MediaPipeFaceResult = { landmarks: result.faceLandmarks };
+    result.close();
+    return out;
+  }, []);
+
+  return { ready, error, segmentFrame, detectFace };
+}

--- a/apps/biofield-web/src/components/pip/usePIPRenderer.ts
+++ b/apps/biofield-web/src/components/pip/usePIPRenderer.ts
@@ -2,13 +2,18 @@
 
 import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 import { PIPRenderer } from "./PIPRenderer";
+import type { MediaPipeMask } from "./useMediaPipe";
 import type { PIPSettings } from "./types";
 
 export type RendererStatus = "idle" | "ready" | "error";
 
 export interface UsePIPRendererResult {
   status: RendererStatus;
-  startRenderLoop: (video: HTMLVideoElement, settingsRef: RefObject<PIPSettings>) => void;
+  startRenderLoop: (
+    video: HTMLVideoElement,
+    settingsRef: RefObject<PIPSettings>,
+    getMask: () => MediaPipeMask | null,
+  ) => void;
   stopRenderLoop: () => void;
 }
 
@@ -40,7 +45,11 @@ export function usePIPRenderer(
   }, [canvasRef]);
 
   const startRenderLoop = useCallback(
-    (video: HTMLVideoElement, settingsRef: RefObject<PIPSettings>) => {
+    (
+      video: HTMLVideoElement,
+      settingsRef: RefObject<PIPSettings>,
+      getMask: () => MediaPipeMask | null,
+    ) => {
       if (rafRef.current !== null) return;
 
       const startTime = performance.now();
@@ -51,7 +60,7 @@ export function usePIPRenderer(
 
         const settings = settingsRef.current;
         if (settings) {
-          renderer.render(video, performance.now() - startTime, settings);
+          renderer.render(video, performance.now() - startTime, settings, getMask());
         }
         rafRef.current = requestAnimationFrame(loop);
       }


### PR DESCRIPTION
## Summary

Implements **BF1-05.3** (MediaPipe segmentation) and **BF1-05.4** (mask uniform → shader) together.

## BF1-05.3 — MediaPipe Selfie Segmentation + Face Mesh

New `useMediaPipe.ts` hook:
- Loads `@mediapipe/tasks-vision` ESM from CDN at runtime (no npm dep needed in source-only app)
- Initialises `ImageSegmenter` (selfie segmentation, float16 WASM model) + `FaceLandmarker`
- GPU delegate with CPU fallback
- `segmentFrame(video)` → `MediaPipeMask | null` (confidence Float32Array)
- `detectFace(video)` → `MediaPipeFaceResult | null` (face landmarks for BF1-05.5 metrics)
- Graceful degradation: if CDN load fails, hook sets `error` and the biofield renders without mask gating

## BF1-05.4 — Mask Uniform → Shader

`PIPRenderer.ts` changes:
- Added `u_mask` (sampler2D, TEXTURE1) and `u_maskStrength` (float) uniforms
- Fragment shader: `maskGate = mix(1.0, personConf, u_maskStrength)` — biofield overlay is gated to person pixels
- Mask texture is R32F single-channel (confidence 0→1); seeded with 1×1 white on init so no unbound sampler
- `render()` accepts optional `mask?: MediaPipeMask | null`; `u_maskStrength=0` when null (mask off, biofield unchanged)
- `dispose()` cleans up both textures

`usePIPRenderer.ts`: `startRenderLoop` now takes `getMask: () => MediaPipeMask | null` callback (called each RAF frame).

`PIPViewerPanel.tsx`:
- Calls `useMediaPipe()` and wires `getMask` into render loop
- MP status pill (loading/✓/✗) in status strip
- Updated copy

## Closes
Partially resolves #550 (BF1-05.3 ✓, BF1-05.4 ✓)

## What's next
- **BF1-05.5** — Real-time MetricsCalculator (intensity, symmetry, entropy, colour scores) using face landmarks from `detectFace()`
- **BF1-05.6** — Wire metrics → Noesis engine seam