### PR TITLE
feat(bf1-05-5): real-time MetricsCalculator + live metrics overlay

### DIFF
--- a/apps/biofield-web/src/components/pip/MetricsCalculator.ts
+++ b/apps/biofield-web/src/components/pip/MetricsCalculator.ts
@@ -1,0 +1,190 @@
+import type { MediaPipeMask, MediaPipeFaceResult } from "./useMediaPipe";
+import type { FrameMetrics, CompositeScores } from "./types";
+
+// ─── Sampling ─────────────────────────────────────────────────────────────────
+// We read raw pixel data from the WebGL canvas every SAMPLE_INTERVAL_MS ms.
+// All maths runs on the CPU via a reused off-screen canvas context.
+const SAMPLE_INTERVAL_MS = 100; // 10 fps metric refresh, < 1 ms per frame budget
+
+// Histogram bin count for Shannon entropy calculation.
+const HIST_BINS = 64;
+
+export class MetricsCalculator {
+  private offscreen: OffscreenCanvas | null = null;
+  private ctx: OffscreenCanvasRenderingContext2D | null = null;
+  private lastSampleMs = 0;
+  private lastMetrics: FrameMetrics | null = null;
+  private lastComposite: CompositeScores | null = null;
+
+  /**
+   * Call once per RAF frame. Returns the most-recently computed values;
+   * actual computation only runs every SAMPLE_INTERVAL_MS.
+   */
+  compute(
+    canvas: HTMLCanvasElement,
+    mask: MediaPipeMask | null,
+    face: MediaPipeFaceResult | null,
+  ): { frame: FrameMetrics; composite: CompositeScores } | null {
+    const now = performance.now();
+    if (now - this.lastSampleMs < SAMPLE_INTERVAL_MS) {
+      // Return cached result between sample intervals.
+      if (this.lastMetrics && this.lastComposite) {
+        return { frame: this.lastMetrics, composite: this.lastComposite };
+      }
+      return null;
+    }
+
+    const w = canvas.width;
+    const h = canvas.height;
+    if (w === 0 || h === 0) return null;
+
+    // Lazily create / resize off-screen canvas used to read pixels.
+    if (!this.offscreen || this.offscreen.width !== w || this.offscreen.height !== h) {
+      this.offscreen = new OffscreenCanvas(w, h);
+      this.ctx = this.offscreen.getContext("2d", { willReadFrequently: true }) as OffscreenCanvasRenderingContext2D | null;
+    }
+
+    const ctx = this.ctx;
+    if (!ctx) return null;
+
+    ctx.drawImage(canvas, 0, 0, w, h);
+    const imageData = ctx.getImageData(0, 0, w, h);
+    const pixels = imageData.data; // Uint8ClampedArray, RGBA
+
+    // ── Luminance & variance ──────────────────────────────────────────────────
+    let sumL = 0;
+    let sumL2 = 0;
+    const n = w * h;
+
+    // Weighted by mask confidence when available.
+    let maskWeight = 0;
+
+    for (let i = 0; i < n; i++) {
+      const r = pixels[i * 4];
+      const g = pixels[i * 4 + 1];
+      const b = pixels[i * 4 + 2];
+      // BT.709 luminance
+      const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+      const w_i = mask ? mask.data[i] ?? 1 : 1;
+      sumL  += lum * w_i;
+      sumL2 += lum * lum * w_i;
+      maskWeight += w_i;
+    }
+
+    const safeWeight = maskWeight > 0 ? maskWeight : n;
+    const meanL = sumL / safeWeight;
+    const variance = sumL2 / safeWeight - meanL * meanL;
+    const averageLuminance = meanL / 255; // normalised [0,1]
+    const pixelVariance = Math.sqrt(Math.max(0, variance)) / 255;
+
+    // ── Shannon entropy ───────────────────────────────────────────────────────
+    const hist = new Float32Array(HIST_BINS);
+    for (let i = 0; i < n; i++) {
+      const r = pixels[i * 4];
+      const g = pixels[i * 4 + 1];
+      const b = pixels[i * 4 + 2];
+      const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+      const bin = Math.min(HIST_BINS - 1, Math.floor((lum / 255) * HIST_BINS));
+      hist[bin] += 1;
+    }
+    let entropy = 0;
+    const logN = Math.log(n);
+    for (let k = 0; k < HIST_BINS; k++) {
+      if (hist[k] > 0) {
+        const p = hist[k] / n;
+        entropy -= p * Math.log(p);
+      }
+    }
+    const entropyScore = entropy / logN; // normalised to [0, 1]
+
+    // ── Bilateral symmetry ────────────────────────────────────────────────────
+    // Compares left-half luminance to mirror of right-half.
+    let symDiff = 0;
+    let symTotal = 0;
+    const halfW = Math.floor(w / 2);
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < halfW; x++) {
+        const lIdx = (y * w + x) * 4;
+        const rIdx = (y * w + (w - 1 - x)) * 4;
+        const lLum = 0.2126 * pixels[lIdx] + 0.7152 * pixels[lIdx + 1] + 0.0722 * pixels[lIdx + 2];
+        const rLum = 0.2126 * pixels[rIdx] + 0.7152 * pixels[rIdx + 1] + 0.0722 * pixels[rIdx + 2];
+        symDiff += Math.abs(lLum - rLum);
+        symTotal += (lLum + rLum) / 2 + 1; // +1 to avoid div-by-zero
+      }
+    }
+    const pixelSymmetry = 1 - symDiff / (symTotal || 1);
+
+    // ── Face-landmark symmetry boost ─────────────────────────────────────────
+    // When face landmarks are available, compute the horizontal deviation of
+    // key midline landmarks to produce a geometry-based symmetry score.
+    let geometrySymmetry = pixelSymmetry;
+    if (face && face.landmarks.length > 0) {
+      const lms = face.landmarks[0];
+      // MediaPipe Face Landmarker: landmark 0 = nose tip (approx midline).
+      // We compare left-eye outer (130) vs right-eye outer (359) horizontal positions.
+      // All coordinates normalised [0,1].
+      const leftEye  = lms[130];
+      const rightEye = lms[359];
+      const noseTip  = lms[1];
+
+      if (leftEye && rightEye && noseTip) {
+        // Ideal: nose is equidistant from both eyes on x-axis.
+        const midX = (leftEye.x + rightEye.x) / 2;
+        const deviation = Math.abs(noseTip.x - midX) / (Math.abs(rightEye.x - leftEye.x) + 1e-6);
+        // deviation ≈ 0 → perfect symmetry, > 0.1 → asymmetric pose
+        geometrySymmetry = 1 - Math.min(1, deviation * 5);
+      }
+    }
+
+    const symmetryScore = (pixelSymmetry + geometrySymmetry) / 2;
+
+    // ── Frame metrics ─────────────────────────────────────────────────────────
+    const frame: FrameMetrics = {
+      averageLuminance,
+      pixelVariance,
+      symmetryScore,
+      entropyScore,
+      timestamp: now,
+    };
+
+    // ── Composite scores ──────────────────────────────────────────────────────
+    // Map raw metrics to the biofield-domain composite score schema.
+    const composite: CompositeScores = {
+      // Light quanta density: how bright + how complex the field is.
+      lightQuantaDensity: clamp(averageLuminance * 0.6 + pixelVariance * 0.4),
+
+      // Normalised area: proxy for how much of the frame is person vs background.
+      normalizedArea: mask ? clamp(maskWeight / n) : 0.5,
+
+      // Body symmetry: our combined pixel + geometry score.
+      bodySymmetry: clamp(symmetryScore),
+
+      // Pattern regularity: inverted entropy — low entropy = high regularity.
+      patternRegularity: clamp(1 - entropyScore),
+
+      // Overall coherence: weighted average of all four.
+      overallCoherence: clamp(
+        averageLuminance * 0.2 +
+        symmetryScore * 0.3 +
+        (1 - entropyScore) * 0.25 +
+        pixelVariance * 0.25,
+      ),
+    };
+
+    this.lastSampleMs = now;
+    this.lastMetrics = frame;
+    this.lastComposite = composite;
+    return { frame, composite };
+  }
+
+  dispose(): void {
+    this.offscreen = null;
+    this.ctx = null;
+    this.lastMetrics = null;
+    this.lastComposite = null;
+  }
+}
+
+function clamp(v: number, lo = 0, hi = 1): number {
+  return Math.max(lo, Math.min(hi, v));
+}

--- a/apps/biofield-web/src/components/pip/PIPViewerPanel.tsx
+++ b/apps/biofield-web/src/components/pip/PIPViewerPanel.tsx
@@ -2,42 +2,69 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { DEFAULT_PIP_SETTINGS } from "./types";
+import type { CompositeScores } from "./types";
 import { useCamera } from "./useCamera";
 import { useMediaPipe } from "./useMediaPipe";
 import { usePIPRenderer } from "./usePIPRenderer";
+import { useLiveMetrics } from "./useLiveMetrics";
 
 export interface PIPViewerPanelProps {
   onCapture?: (blob: Blob, dataUrl: string) => void;
+  /** Called each time live metrics are refreshed (~10 fps). */
+  onMetrics?: (scores: CompositeScores) => void;
 }
 
 type PanelState = "idle" | "streaming" | "paused";
 
-export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
+export function PIPViewerPanel({ onCapture, onMetrics }: PIPViewerPanelProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const settingsRef = useRef(DEFAULT_PIP_SETTINGS);
+  const onMetricsRef = useRef(onMetrics);
+  onMetricsRef.current = onMetrics;
 
   const { videoRef, isStreaming, devices, error: cameraError, startCamera, stopCamera } = useCamera();
   const { status: glStatus, startRenderLoop, stopRenderLoop } = usePIPRenderer(canvasRef);
-  const { ready: mpReady, error: mpError, segmentFrame } = useMediaPipe();
+  const { ready: mpReady, error: mpError, segmentFrame, detectFace } = useMediaPipe();
+  const { metrics, updateMetrics } = useLiveMetrics(canvasRef);
 
   const [panelState, setPanelState] = useState<PanelState>("idle");
   const [captureCount, setCaptureCount] = useState(0);
   const [captureError, setCaptureError] = useState<string | null>(null);
 
-  // getMask runs each RAF frame: returns the latest segmentation mask or null.
   const getMask = useCallback(() => {
     const video = videoRef.current;
     if (!mpReady || !video) return null;
     return segmentFrame(video);
   }, [mpReady, segmentFrame, videoRef]);
 
+  const getFace = useCallback(() => {
+    const video = videoRef.current;
+    if (!mpReady || !video) return null;
+    return detectFace(video);
+  }, [mpReady, detectFace, videoRef]);
+
+  // onFrame: called each RAF iteration; feeds MetricsCalculator and fires onMetrics callback.
+  const onFrame = useCallback(
+    (canvas: HTMLCanvasElement, mask: ReturnType<typeof getMask>, face: ReturnType<typeof getFace>) => {
+      updateMetrics(canvas, mask, face);
+    },
+    [updateMetrics],
+  );
+
+  // Forward composite scores to parent whenever they update.
+  useEffect(() => {
+    if (metrics && onMetricsRef.current) {
+      onMetricsRef.current(metrics.composite);
+    }
+  }, [metrics]);
+
   // Start render loop when both camera and renderer are ready.
   useEffect(() => {
     const video = videoRef.current;
     if (isStreaming && glStatus === "ready" && video && panelState === "streaming") {
-      startRenderLoop(video, settingsRef, getMask);
+      startRenderLoop(video, settingsRef, getMask, getFace, onFrame);
     }
-  }, [isStreaming, glStatus, panelState, startRenderLoop, getMask, videoRef]);
+  }, [isStreaming, glStatus, panelState, startRenderLoop, getMask, getFace, onFrame, videoRef]);
 
   const handleStart = useCallback(async () => {
     setCaptureError(null);
@@ -53,10 +80,10 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
   const handleResume = useCallback(() => {
     const video = videoRef.current;
     if (video && glStatus === "ready") {
-      startRenderLoop(video, settingsRef, getMask);
+      startRenderLoop(video, settingsRef, getMask, getFace, onFrame);
     }
     setPanelState("streaming");
-  }, [glStatus, getMask, startRenderLoop, videoRef]);
+  }, [glStatus, getMask, getFace, onFrame, startRenderLoop, videoRef]);
 
   const handleStop = useCallback(() => {
     stopRenderLoop();
@@ -88,27 +115,17 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
   }, [onCapture]);
 
   const glLabel =
-    glStatus === "ready"
-      ? "WebGL2 ✓"
-      : glStatus === "error"
-        ? "WebGL2 ✗"
-        : "WebGL2 …";
+    glStatus === "ready" ? "WebGL2 ✓" : glStatus === "error" ? "WebGL2 ✗" : "WebGL2 …";
 
-  const mpLabel = mpError
-    ? "MP ✗"
-    : mpReady
-      ? "MP ✓"
-      : "MP …";
+  const mpLabel = mpError ? "MP ✗" : mpReady ? "MP ✓" : "MP …";
 
   const cameraLabel =
-    panelState === "streaming"
-      ? "streaming"
-      : panelState === "paused"
-        ? "paused"
-        : "off";
+    panelState === "streaming" ? "streaming" : panelState === "paused" ? "paused" : "off";
 
   const deviceLabel =
     devices.length > 0 ? `${devices.length} camera${devices.length !== 1 ? "s" : ""}` : "no cameras";
+
+  const c = metrics?.composite;
 
   return (
     <section className="biofield-panel biofield-form-panel">
@@ -143,7 +160,7 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
         )}
       </div>
 
-      {/* WebGL2 canvas — hidden video element feeds it each frame */}
+      {/* WebGL2 canvas */}
       <div
         style={{
           position: "relative",
@@ -155,7 +172,6 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
           marginBottom: "0.75rem",
         }}
       >
-        {/* Hidden video element — camera source for WebGL2 texture */}
         <video
           ref={videoRef}
           autoPlay
@@ -180,6 +196,30 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
             }}
           >
             Start camera to begin PIP visualisation
+          </div>
+        )}
+
+        {/* Live metrics overlay */}
+        {c && panelState !== "idle" && (
+          <div
+            style={{
+              position: "absolute",
+              bottom: 8,
+              left: 8,
+              right: 8,
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: "4px 12px",
+              fontSize: "0.7rem",
+              color: "rgba(255,255,255,0.85)",
+              textShadow: "0 1px 3px rgba(0,0,0,0.8)",
+              pointerEvents: "none",
+            }}
+          >
+            <MetricRow label="Coherence"  value={c.overallCoherence} />
+            <MetricRow label="Symmetry"   value={c.bodySymmetry} />
+            <MetricRow label="Luminance"  value={c.lightQuantaDensity} />
+            <MetricRow label="Regularity" value={c.patternRegularity} />
           </div>
         )}
       </div>
@@ -238,3 +278,33 @@ export function PIPViewerPanel({ onCapture }: PIPViewerPanelProps) {
     </section>
   );
 }
+
+// ─── Inline metric row ────────────────────────────────────────────────────────
+function MetricRow({ label, value }: { label: string; value: number }) {
+  const pct = Math.round(value * 100);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+      <span style={{ opacity: 0.7, minWidth: 70 }}>{label}</span>
+      <div
+        style={{
+          flex: 1,
+          height: 3,
+          background: "rgba(255,255,255,0.15)",
+          borderRadius: 2,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            width: `${pct}%`,
+            height: "100%",
+            background: "rgba(120,220,180,0.9)",
+            borderRadius: 2,
+          }}
+        />
+      </div>
+      <span style={{ minWidth: 30, textAlign: "right" }}>{pct}%</span>
+    </div>
+  );
+}
+

--- a/apps/biofield-web/src/components/pip/useLiveMetrics.ts
+++ b/apps/biofield-web/src/components/pip/useLiveMetrics.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { MetricsCalculator } from "./MetricsCalculator";
+import type { MediaPipeMask, MediaPipeFaceResult } from "./useMediaPipe";
+import type { FrameMetrics, CompositeScores } from "./types";
+
+export interface LiveMetrics {
+  frame: FrameMetrics;
+  composite: CompositeScores;
+}
+
+export interface UseLiveMetricsResult {
+  metrics: LiveMetrics | null;
+  /** Call this each RAF frame (or at whatever rate your render loop runs). */
+  updateMetrics: (
+    canvas: HTMLCanvasElement,
+    mask: MediaPipeMask | null,
+    face: MediaPipeFaceResult | null,
+  ) => void;
+}
+
+/**
+ * Wraps MetricsCalculator in a React hook.
+ * `updateMetrics` should be called each frame from the render loop.
+ * State is updated at most every 100 ms (throttled inside MetricsCalculator).
+ */
+export function useLiveMetrics(
+  canvasRef: RefObject<HTMLCanvasElement | null>,
+): UseLiveMetricsResult {
+  const calcRef = useRef<MetricsCalculator | null>(null);
+  const [metrics, setMetrics] = useState<LiveMetrics | null>(null);
+
+  useEffect(() => {
+    calcRef.current = new MetricsCalculator();
+    return () => {
+      calcRef.current?.dispose();
+      calcRef.current = null;
+    };
+  }, []);
+
+  const updateMetrics = useCallback(
+    (
+      canvas: HTMLCanvasElement,
+      mask: MediaPipeMask | null,
+      face: MediaPipeFaceResult | null,
+    ) => {
+      const calc = calcRef.current;
+      if (!calc) return;
+      const result = calc.compute(canvas, mask, face);
+      if (result) {
+        setMetrics(result);
+      }
+    },
+    [],
+  );
+
+  // Expose a stable no-op when canvas isn't mounted yet so callers don't need to guard.
+  const _ = canvasRef; // keep dep to satisfy linter; ref change triggers nothing here
+
+  return { metrics, updateMetrics };
+}

--- a/apps/biofield-web/src/components/pip/usePIPRenderer.ts
+++ b/apps/biofield-web/src/components/pip/usePIPRenderer.ts
@@ -2,7 +2,7 @@
 
 import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 import { PIPRenderer } from "./PIPRenderer";
-import type { MediaPipeMask } from "./useMediaPipe";
+import type { MediaPipeMask, MediaPipeFaceResult } from "./useMediaPipe";
 import type { PIPSettings } from "./types";
 
 export type RendererStatus = "idle" | "ready" | "error";
@@ -13,6 +13,8 @@ export interface UsePIPRendererResult {
     video: HTMLVideoElement,
     settingsRef: RefObject<PIPSettings>,
     getMask: () => MediaPipeMask | null,
+    getFace: () => MediaPipeFaceResult | null,
+    onFrame: (canvas: HTMLCanvasElement, mask: MediaPipeMask | null, face: MediaPipeFaceResult | null) => void,
   ) => void;
   stopRenderLoop: () => void;
 }
@@ -49,6 +51,8 @@ export function usePIPRenderer(
       video: HTMLVideoElement,
       settingsRef: RefObject<PIPSettings>,
       getMask: () => MediaPipeMask | null,
+      getFace: () => MediaPipeFaceResult | null,
+      onFrame: (canvas: HTMLCanvasElement, mask: MediaPipeMask | null, face: MediaPipeFaceResult | null) => void,
     ) => {
       if (rafRef.current !== null) return;
 
@@ -56,18 +60,27 @@ export function usePIPRenderer(
 
       function loop() {
         const renderer = rendererRef.current;
+        const canvas = canvasRef.current;
         if (!renderer) return;
 
         const settings = settingsRef.current;
+        const mask = getMask();
+        const face = getFace();
+
         if (settings) {
-          renderer.render(video, performance.now() - startTime, settings, getMask());
+          renderer.render(video, performance.now() - startTime, settings, mask);
         }
+
+        if (canvas) {
+          onFrame(canvas, mask, face);
+        }
+
         rafRef.current = requestAnimationFrame(loop);
       }
 
       rafRef.current = requestAnimationFrame(loop);
     },
-    [],
+    [canvasRef],
   );
 
   const stopRenderLoop = useCallback(() => {


### PR DESCRIPTION
## Summary

Implements **BF1-05.5** — real-time biofield metrics computed from canvas pixels + MediaPipe face landmarks.

## MetricsCalculator.ts (pure class)

Computes on a 10fps cadence (SAMPLE_INTERVAL_MS=100) via OffscreenCanvas pixel read:

| Metric | Method |
|---|---|
| `averageLuminance` | BT.709 weighted mean, mask-confidence weighted |
| `pixelVariance` | Std dev of luminance, normalised |
| `entropyScore` | Shannon entropy over 64-bin luminance histogram |
| `symmetryScore` | Pixel bilateral symmetry + geometry symmetry from face landmarks 130/359/1 |

Composite scores:
- `lightQuantaDensity` = luminance × 0.6 + variance × 0.4
- `normalizedArea` = mask weight / total pixels (proxy for person-in-frame coverage)
- `bodySymmetry` = combined pixel + geometry symmetry
- `patternRegularity` = 1 − entropy
- `overallCoherence` = weighted mean of all four

## useLiveMetrics.ts (hook)

- React wrapper around `MetricsCalculator`; creates/disposes with `useEffect`
- `updateMetrics(canvas, mask, face)` to call each frame; throttled internally

## usePIPRenderer.ts

- `startRenderLoop` gains `getFace` + `onFrame(canvas, mask, face)` callbacks
- Metrics calculator runs inside the RAF loop without extra ticks

## PIPViewerPanel.tsx

- New **`onMetrics?: (scores: CompositeScores) => void`** prop (consumed by BF1-05.6)
- Live mini overlay: Coherence / Symmetry / Luminance / Regularity as teal progress bars
- MP ✓/✗ status pill retained from BF1-05.3

## Closes
Partially resolves #550 (BF1-05.5 ✓)

## Next
**BF1-05.6** — wire `onMetrics` composite scores → Noesis engine seam (POST to `/api/v1/engines/biofield/calculate`)