### PR TITLE
fix(oauth): allow /login/discord-callback for biofield-web

### DIFF
--- a/crates/noesis-api/src/handlers/oauth.rs
+++ b/crates/noesis-api/src/handlers/oauth.rs
@@ -23,6 +23,7 @@ const OAUTH_DEFAULT_API_KEY_PERMISSIONS: &[&str] = &["basic:access"];
 const ALLOWED_DISCORD_CALLBACK_PATHS: &[&str] = &[
     "/admin/login/discord-callback",
     "/admin/auth/discord/callback",
+    "/login/discord-callback", // biofield-web
 ];
 
 fn normalize_callback_path(path: &str) -> String {


### PR DESCRIPTION
## Problem
The Rust API was rejecting Discord OAuth redirect URI overrides from biofield-web with:

> Discord redirect URI path is not allowed for the admin dashboard.

`ALLOWED_DISCORD_CALLBACK_PATHS` only contained the admin-web paths — the biofield-web path `/login/discord-callback` was never whitelisted.

## Fix
Adds `/login/discord-callback` to the allowlist. One-line change in `oauth.rs`. OAuth tests pass.

## Impact
- Fixes Discord sign-in on biofield-web locally and in production
- No change to admin-web behaviour