### PR TITLE
[HV-T01 #853] HD MG/G boundary — documented as divergence

### DIFF
--- a/.swarm/humdes-validation/handoffs/HV-T01-claude.md
+++ b/.swarm/humdes-validation/handoffs/HV-T01-claude.md
@@ -2,6 +2,12 @@
 
 > Self-contained handoff packet. Read this only, then begin work.
 
+**Status:** Resolved — documented as known divergence (option b). Selemene's
+strict classifier is canonically correct; humdes' MG label for 7 fixtures is
+internally inconsistent with humdes' own type-mechanics prose. See the new
+"MG/G boundary decision" section in `tests/fixtures/humdes/README.md` for the
+full trace and reasoning. No code change to `analysis.rs` was needed.
+
 ## Issue
 [#853 — HD engine: investigate 7 MG-vs-Generator classification mismatches](https://github.com/Sheshiyer/Selemene-engine/issues/853)
 

--- a/tests/fixtures/humdes/README.md
+++ b/tests/fixtures/humdes/README.md
@@ -67,11 +67,112 @@ Field-by-field accuracy vs humdes ground truth:
 | type                 | 82 / 89   | 7 cases of MG-vs-G classification disagreement |
 
 The 7 type disagreements all match the same pattern: humdes labels
-"ManifestingGenerator", Selemene engine labels "Generator". This is a
-**known taxonomy boundary** in HD software — humdes is permissive (any G
-with a defined motor-to-Throat is MG), Selemene is strict (G is default,
-MG requires specific channel configuration). Documenting this divergence
-is itself a finding worth reviewing.
+"ManifestingGenerator", Selemene engine labels "Generator". See
+"MG/G boundary decision" below for the resolution.
+
+## MG/G boundary decision
+
+**Decision (HV-T01, issue #853):** Selemene's strict classifier is
+**canonically correct**. The 7 humdes "MG" labels are accepted as a
+known classifier divergence, not as Selemene bugs. No code change to
+`crates/engine-human-design/src/analysis.rs` is required.
+
+### The canonical definition
+
+Ra Uru Hu's original Human Design typology defines a Manifesting
+Generator as a chart with:
+
+1. The **Sacral Centre defined**, AND
+2. The **Throat Centre connected by a defined channel to one of the
+   four motor centres** — Sacral, Heart, Solar Plexus, or Root.
+
+Humdes' own mechanics-tab prose agrees verbatim with this definition.
+From the mechanics body for fixture `c517b66135` (`personal/Ghanshyam`):
+
+> "The Manifesting Generator has a defined Sacral Centre in the Rave
+> Chart, and the Throat is always connected by Channels to at least one
+> of the four motors — the Sacral, the Heart Centre, the Solar Plexus
+> or the Root."
+
+Selemene's `determine_type` + `is_throat_connected_to_motor` enforce
+exactly this rule (motor centres are explicitly `Heart | SolarPlexus |
+Root | Sacral`). Selemene returns `Generator` whenever the throat is
+defined but connected only to non-motor centres (Ajna, Spleen, G,
+Head). This is faithful to the original system.
+
+### Why the 7 fixtures don't qualify
+
+For each of the 7 disagreements, the engine output shows the Throat is
+defined but **none** of the throat-touching channels reach a motor
+centre:
+
+| Fixture | Throat channels found | Motors touching Throat |
+|---|---|---|
+| `compatibility/9ce5ce4168/2` | 17-62 (Ajna), 48-16 (Spleen) | none |
+| `family/0e2d49dced/2`         | 17-62 (Ajna), 48-16 (Spleen) | none |
+| `personal/2a88b52b48/1`       | 8-1 (G)                       | none |
+| `personal/62fed3949a/1`       | 33-13 (G)                     | none |
+| `personal/a2b9b1f2b8/1`       | 17-62 (Ajna), 48-16 (Spleen) | none |
+| `personal/c517b66135/1`       | 17-62 (Ajna), 48-16 (Spleen) | none |
+| `personal/fd3fcad39b/1`       | 17-62 (Ajna), 48-16 (Spleen) | none |
+
+Concretely for `c517b66135` (Ghanshyam, the worked example): defined
+centres are `{Ajna, Throat, Sacral, Spleen, Root, G}`; the four active
+channels are `17-62` (Ajna↔Throat), `48-16` (Spleen↔Throat), `5-15`
+(Sacral↔G) and `32-54` (Spleen↔Root). There is **no path** — direct
+**or transitive** — from Sacral to Throat through motor centres. The
+Sacral connects only to G; the Throat connects only to Ajna and
+Spleen. Per Ra's typology this is a pure Generator with a defined
+Throat, not a Manifesting Generator.
+
+The recurring pattern (5 of 7 fixtures share the same gate signature,
+suggesting these are the same person captured in multiple readings) is
+the **48-16 Spleen-to-Throat channel** ("Wavelength"). Spleen is an
+awareness centre, not a motor — so its presence doesn't satisfy the
+MG criterion regardless of how broadly the rule is read.
+
+### Why humdes labels these as MG anyway
+
+Humdes' classifier is permissive in a way their own descriptive text
+isn't: empirically it labels a chart MG whenever **the Sacral is
+defined and the Throat has any active channel**, regardless of which
+centre that channel reaches. This is internally inconsistent (their
+prose says "one of the four motors") but matches the labels on the
+ground.
+
+We do not match humdes' label here because:
+
+1. It contradicts Ra Uru Hu's foundational definition of Type.
+2. It contradicts humdes' own type-description prose, which Selemene's
+   logic agrees with verbatim.
+3. Selemene's strict rule preserves the meaningful distinction between
+   "energy type with manifesting aura" (true MG) and "Generator who
+   happens to have a defined Throat" (just a Generator). Collapsing
+   these two erases the typology's clinical value.
+
+### Operational consequences
+
+- The validation harness's `type` field will continue to report
+  82/89 (92.1%) when run against the humdes corpus. This is the
+  ceiling for that corpus; further increases on this field require
+  switching to a stricter ground-truth source.
+- The HV-T01 investigation explicitly accepts this gap. Any future
+  drift below 82/89 is a real regression in Selemene and should be
+  investigated.
+- If a downstream consumer needs to mirror humdes' permissive
+  classification (e.g. for a side-by-side comparison UI), add a
+  separate `humdes_compat_type` field rather than weakening the
+  canonical `hd_type` field. Don't touch `analysis.rs::determine_type`.
+
+### Reproducing the trace
+
+The seven fixtures above were inspected by running the HD engine
+against each via `engine_human_design::generate_hd_chart` and dumping
+defined centres + active channels. The same can be reproduced by
+loading any of the fixture `01_input.json` files into the engine
+through `HumanDesignEngine::calculate` and reading the
+`centers`/`channels` keys of the JSON result. The validation report
+itself (above) emits the seven fixture ids.
 
 ## Training-data backend design
 


### PR DESCRIPTION
Closes #853

## Summary
- Outcome: **documented as known divergence**. No change to `analysis.rs`.
- Fixtures affected: 7 (all 7 of the MG-vs-G mismatches from the validation report).
- Files touched: `tests/fixtures/humdes/README.md` (new "MG/G boundary decision" section), `.swarm/humdes-validation/handoffs/HV-T01-claude.md` (status banner).

## Decision

Selemene's strict classifier is **canonically correct**: Ra Uru Hu's typology defines a Manifesting Generator as a chart with a defined Sacral AND the Throat connected by a defined channel to one of the four motor centres (Sacral, Heart, Solar Plexus, Root). Humdes' own mechanics-tab prose agrees verbatim with this rule. Yet humdes' classifier labels 7 of our 89 fixtures as MG despite none of them having any motor-to-Throat channel — direct or transitive. For example, fixture `personal/c517b66135` (Ghanshyam) has the Throat connected only to Ajna (17-62) and Spleen (48-16) — neither a motor — and the Sacral connected only to G (5-15), with no path joining the two through a motor. Selemene therefore correctly returns `Generator`. The right action is to document this as humdes' classifier being permissive in a way their own description text isn't, rather than weaken Selemene's logic to match a labeling inconsistency that contradicts the foundational definition.

## Evidence

Per-fixture trace (defined centres + Throat-touching channels):

| Fixture | Throat channels | Motors touching Throat |
|---|---|---|
| `compatibility/9ce5ce4168/2` | 17-62 (Ajna), 48-16 (Spleen) | none |
| `family/0e2d49dced/2`        | 17-62 (Ajna), 48-16 (Spleen) | none |
| `personal/2a88b52b48/1`      | 8-1 (G)                       | none |
| `personal/62fed3949a/1`      | 33-13 (G)                     | none |
| `personal/a2b9b1f2b8/1`      | 17-62 (Ajna), 48-16 (Spleen) | none |
| `personal/c517b66135/1`      | 17-62 (Ajna), 48-16 (Spleen) | none |
| `personal/fd3fcad39b/1`      | 17-62 (Ajna), 48-16 (Spleen) | none |

Baseline validation report (before this PR):
```
type                matched  82/ 89  ( 92.1%)  skipped= 0
```

After this PR (identical — no code change):
```
type                matched  82/ 89  ( 92.1%)  skipped= 0
```

## Verification

```
cargo clippy --package engine-human-design -- -D warnings   # clean
cargo test   --package engine-human-design                  # 100% pass
cargo test   --package engine-human-design --test humdes_validation_tests -- --ignored --nocapture   # type=82/89, same 7 fixtures
```

Note: `cargo fmt --package engine-human-design --check` reports formatting drift in `crates/engine-human-design/tests/humdes_validation_tests.rs`. This drift **predates this PR** (it's in the merged base commit a5c60e48 from PR #857) and is outside the allowed edit surface for HV-T01. It should be addressed in a separate cleanup PR.

## Files touched
- `tests/fixtures/humdes/README.md` — new "MG/G boundary decision" section with the per-fixture trace and reasoning.
- `.swarm/humdes-validation/handoffs/HV-T01-claude.md` — added a status banner pointing to the README section.

## Handoff signal
On merge, will post on #853:
> HV-T01 merged on `<commit>`. Validation documents a known divergence (humdes classifier is permissive vs Ra Uru Hu's canonical typology; Selemene faithful). Next: HV-T02 (#854) can land independently.