### PR TITLE
[HV-T03 #855] Cross-engine humdes smoke tests for panchanga + numerology

### DIFF
--- a/crates/engine-numerology/tests/humdes_smoke_tests.rs
+++ b/crates/engine-numerology/tests/humdes_smoke_tests.rs
@@ -1,0 +1,198 @@
+//! Cross-engine smoke validation: run the Numerology engine against every
+//! humdes fixture and report successes/failures.
+//!
+//! Numerology needs only `birth_data.name` and `birth_data.date` (no
+//! lat/lng/time), so this loop does NOT gate on `has_coords` — every fixture
+//! is exercised.
+//!
+//! Run only the smoke tests (fast, run on every `cargo test`):
+//!     cargo test --package engine-numerology --test humdes_smoke_tests
+//!
+//! Run the long-running per-fixture report:
+//!     cargo test --package engine-numerology --test humdes_smoke_tests \
+//!         -- --ignored --nocapture
+
+use engine_numerology::NumerologyEngine;
+use noesis_core::{ConsciousnessEngine, EngineInput};
+use serde::Deserialize;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Instant;
+
+// --- Fixture types -------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct HumdesIndex {
+    #[allow(dead_code)]
+    source: String,
+    total_persons: usize,
+    entries: Vec<HumdesEntry>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct HumdesEntry {
+    #[serde(rename = "type")]
+    reading_type: String,
+    reading_hash: String,
+    #[allow(dead_code)]
+    person_index: u32,
+    input: String,
+    #[allow(dead_code)]
+    has_coords: bool,
+}
+
+// --- Paths ---------------------------------------------------------------
+
+/// Resolve `<workspace_root>/tests/fixtures/humdes`.
+/// CARGO_MANIFEST_DIR points to the engine crate, so we go up two parents.
+fn fixtures_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("tests/fixtures/humdes"))
+        .expect("locate workspace root from crate dir")
+}
+
+fn load_index() -> Option<HumdesIndex> {
+    let path = fixtures_root().join("_index.json");
+    if !path.exists() {
+        return None;
+    }
+    let s = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    Some(serde_json::from_str(&s).expect("parse _index.json"))
+}
+
+fn load_input(rel: &str) -> EngineInput {
+    let path = fixtures_root().join(rel);
+    let s = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    serde_json::from_str(&s).unwrap_or_else(|e| panic!("parse {}: {}", path.display(), e))
+}
+
+// --- Smoke tests (run on every `cargo test`) ----------------------------
+
+#[test]
+fn humdes_fixtures_directory_present() {
+    let root = fixtures_root();
+    assert!(
+        root.exists(),
+        "humdes fixtures missing at {} — run \
+         `python humdes_to_selemene.py` in humdes-extractor first.",
+        root.display()
+    );
+    assert!(root.join("_index.json").exists(), "_index.json missing");
+}
+
+#[test]
+fn humdes_first_3_inputs_have_name_and_date() {
+    let idx = match load_index() {
+        Some(i) => i,
+        None => {
+            eprintln!("(skipped — no _index.json)");
+            return;
+        }
+    };
+    assert!(idx.total_persons > 0, "no persons in index");
+    let n = idx.entries.len().min(3);
+    for entry in &idx.entries[..n] {
+        let input = load_input(&entry.input);
+        let bd = input
+            .birth_data
+            .as_ref()
+            .unwrap_or_else(|| panic!("missing birth_data in {}", entry.input));
+        // Numerology needs name + date.
+        assert!(
+            bd.name.as_ref().map(|n| !n.is_empty()).unwrap_or(false),
+            "missing/empty name in {}",
+            entry.input
+        );
+        assert!(!bd.date.is_empty(), "empty date in {}", entry.input);
+    }
+}
+
+// --- Full smoke report (long-running, ignored by default) ----------------
+
+#[tokio::test]
+#[ignore = "long-running: runs Numerology engine on every humdes fixture (~89 persons)"]
+async fn humdes_numerology_smoke_all_fixtures() {
+    let idx = load_index().expect("humdes fixtures missing — run humdes_to_selemene.py first");
+    println!(
+        "\n========== HUMDES Numerology smoke ==========\
+         \n  source persons : {}\
+         \n  fixtures path  : {}\n",
+        idx.total_persons,
+        fixtures_root().display()
+    );
+
+    let engine = NumerologyEngine::new();
+    let mut ok = 0_usize;
+    let mut fail = 0_usize;
+    let mut skipped_no_name = 0_usize;
+    let mut failures: Vec<String> = vec![];
+    let mut total_ms = 0.0_f64;
+
+    for (i, entry) in idx.entries.iter().enumerate() {
+        let id = format!(
+            "{:3}/{:3} {} {}",
+            i + 1,
+            idx.entries.len(),
+            entry.reading_type,
+            &entry.reading_hash[..10.min(entry.reading_hash.len())],
+        );
+
+        let input = load_input(&entry.input);
+        // Numerology requires a non-empty name; skip (counted) if missing
+        // so the report distinguishes "fixture-side gap" from "engine-side bug".
+        let has_name = input
+            .birth_data
+            .as_ref()
+            .and_then(|bd| bd.name.as_ref())
+            .map(|n| !n.trim().is_empty())
+            .unwrap_or(false);
+        if !has_name {
+            skipped_no_name += 1;
+            continue;
+        }
+
+        let start = Instant::now();
+        match engine.calculate(input).await {
+            Ok(out) => {
+                ok += 1;
+                total_ms += out.metadata.calculation_time_ms;
+            }
+            Err(e) => {
+                fail += 1;
+                if failures.len() < 5 {
+                    failures.push(format!(
+                        "  {}  {}  err={:?}  wall={:.2}ms",
+                        id,
+                        entry.input,
+                        e,
+                        start.elapsed().as_secs_f64() * 1000.0
+                    ));
+                }
+            }
+        }
+    }
+
+    println!("--- numerology humdes smoke ---");
+    println!("  ok               : {}", ok);
+    println!("  fail             : {}", fail);
+    println!("  skipped (no name): {}", skipped_no_name);
+    if ok > 0 {
+        println!("  avg calc ms      : {:.4}", total_ms / ok as f64);
+    }
+    if !failures.is_empty() {
+        println!("  first failures   :");
+        for f in &failures {
+            println!("{}", f);
+        }
+    }
+    println!("==============================================\n");
+
+    // Smoke contract: at least one fixture ran successfully.
+    assert!(
+        ok > 0 || skipped_no_name == idx.entries.len(),
+        "numerology produced zero ok results across {} named fixtures",
+        idx.entries.len() - skipped_no_name
+    );
+}

--- a/crates/engine-panchanga/tests/humdes_smoke_tests.rs
+++ b/crates/engine-panchanga/tests/humdes_smoke_tests.rs
@@ -1,0 +1,194 @@
+//! Cross-engine smoke validation: run the Panchanga engine against every
+//! humdes fixture and report successes/failures.
+//!
+//! Lives in the `tests/fixtures/humdes/` corpus produced by the
+//! humdes-extractor's `humdes_to_selemene.py` normaliser. The same 89 fixtures
+//! that anchor the HD engine's ground-truth validation (`humdes_validation_tests.rs`
+//! in `engine-human-design`) are reused here as a cheap "every birth-time
+//! survives" smoke test for Panchanga.
+//!
+//! Run only the smoke tests (fast, run on every `cargo test`):
+//!     cargo test --package engine-panchanga --test humdes_smoke_tests
+//!
+//! Run the long-running per-fixture report:
+//!     cargo test --package engine-panchanga --test humdes_smoke_tests \
+//!         -- --ignored --nocapture
+
+use engine_panchanga::PanchangaEngine;
+use noesis_core::{ConsciousnessEngine, EngineInput};
+use serde::Deserialize;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Instant;
+
+// --- Fixture types -------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct HumdesIndex {
+    #[allow(dead_code)]
+    source: String,
+    total_persons: usize,
+    entries: Vec<HumdesEntry>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct HumdesEntry {
+    #[serde(rename = "type")]
+    reading_type: String,
+    reading_hash: String,
+    #[allow(dead_code)]
+    person_index: u32,
+    input: String,
+    has_coords: bool,
+}
+
+// --- Paths ---------------------------------------------------------------
+
+/// Resolve `<workspace_root>/tests/fixtures/humdes`.
+/// CARGO_MANIFEST_DIR points to the engine crate, so we go up two parents.
+fn fixtures_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("tests/fixtures/humdes"))
+        .expect("locate workspace root from crate dir")
+}
+
+fn load_index() -> Option<HumdesIndex> {
+    let path = fixtures_root().join("_index.json");
+    if !path.exists() {
+        return None;
+    }
+    let s = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    Some(serde_json::from_str(&s).expect("parse _index.json"))
+}
+
+fn load_input(rel: &str) -> EngineInput {
+    let path = fixtures_root().join(rel);
+    let s = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    serde_json::from_str(&s).unwrap_or_else(|e| panic!("parse {}: {}", path.display(), e))
+}
+
+// --- Smoke tests (run on every `cargo test`) ----------------------------
+
+#[test]
+fn humdes_fixtures_directory_present() {
+    let root = fixtures_root();
+    assert!(
+        root.exists(),
+        "humdes fixtures missing at {} — run \
+         `python humdes_to_selemene.py` in humdes-extractor first.",
+        root.display()
+    );
+    assert!(root.join("_index.json").exists(), "_index.json missing");
+}
+
+#[test]
+fn humdes_first_3_inputs_deserialize_for_panchanga() {
+    let idx = match load_index() {
+        Some(i) => i,
+        None => {
+            eprintln!("(skipped — no _index.json)");
+            return;
+        }
+    };
+    assert!(idx.total_persons > 0, "no persons in index");
+    let mut checked = 0;
+    for entry in idx.entries.iter().filter(|e| e.has_coords).take(3) {
+        let input = load_input(&entry.input);
+        let bd = input
+            .birth_data
+            .as_ref()
+            .unwrap_or_else(|| panic!("missing birth_data in {}", entry.input));
+        bd.validate()
+            .unwrap_or_else(|e| panic!("invalid birth_data in {}: {}", entry.input, e));
+        // Panchanga needs date + time + tz; assert those exist.
+        assert!(!bd.date.is_empty(), "empty date in {}", entry.input);
+        assert!(bd.time.is_some(), "missing time in {}", entry.input);
+        assert!(!bd.timezone.is_empty(), "empty timezone in {}", entry.input);
+        checked += 1;
+    }
+    assert!(checked > 0, "no coordinated fixtures found");
+}
+
+// --- Full smoke report (long-running, ignored by default) ----------------
+
+#[tokio::test]
+#[ignore = "long-running: runs Panchanga engine on every humdes fixture (~89 persons)"]
+async fn humdes_panchanga_smoke_all_fixtures() {
+    let idx = load_index().expect("humdes fixtures missing — run humdes_to_selemene.py first");
+    println!(
+        "\n========== HUMDES Panchanga smoke ==========\
+         \n  source persons : {}\
+         \n  fixtures path  : {}\n",
+        idx.total_persons,
+        fixtures_root().display()
+    );
+
+    let engine = PanchangaEngine::new();
+    let mut ok = 0_usize;
+    let mut fail = 0_usize;
+    let mut skipped_no_coords = 0_usize;
+    let mut failures: Vec<String> = vec![];
+    let mut total_ms = 0.0_f64;
+
+    for (i, entry) in idx.entries.iter().enumerate() {
+        let id = format!(
+            "{:3}/{:3} {} {}",
+            i + 1,
+            idx.entries.len(),
+            entry.reading_type,
+            &entry.reading_hash[..10.min(entry.reading_hash.len())],
+        );
+
+        if !entry.has_coords {
+            skipped_no_coords += 1;
+            continue;
+        }
+
+        let input = load_input(&entry.input);
+        let start = Instant::now();
+        match engine.calculate(input).await {
+            Ok(out) => {
+                ok += 1;
+                total_ms += out.metadata.calculation_time_ms;
+            }
+            Err(e) => {
+                fail += 1;
+                if failures.len() < 5 {
+                    failures.push(format!(
+                        "  {}  {}  err={:?}  wall={:.2}ms",
+                        id,
+                        entry.input,
+                        e,
+                        start.elapsed().as_secs_f64() * 1000.0
+                    ));
+                }
+            }
+        }
+    }
+
+    println!("--- panchanga humdes smoke ---");
+    println!("  ok                : {}", ok);
+    println!("  fail              : {}", fail);
+    println!("  skipped (no coords): {}", skipped_no_coords);
+    if ok > 0 {
+        println!("  avg calc ms       : {:.3}", total_ms / ok as f64);
+    }
+    if !failures.is_empty() {
+        println!("  first failures    :");
+        for f in &failures {
+            println!("{}", f);
+        }
+    }
+    println!("==============================================\n");
+
+    // The report is diagnostic; don't fail the test on per-fixture errors.
+    // Smoke contract: at least one fixture ran successfully. If the index
+    // ever loses every coord-bearing entry, that's a separate fixture bug.
+    assert!(
+        ok > 0 || skipped_no_coords == idx.entries.len(),
+        "panchanga produced zero ok results across {} coord-bearing fixtures",
+        idx.entries.len() - skipped_no_coords
+    );
+}

--- a/tests/fixtures/humdes/README.md
+++ b/tests/fixtures/humdes/README.md
@@ -295,7 +295,7 @@ Recommended flow:
 
 The same input.json files validate every engine that takes birth data:
 - engine-panchanga
-- engine-numerology (date only)
+- engine-numerology (date + name only)
 - engine-biorhythm (date only)
 - engine-vimshottari
 - engine-gene-keys (re-uses HD gates)
@@ -303,10 +303,43 @@ The same input.json files validate every engine that takes birth data:
 - engine-face-reading (no birth data needed — separate corpus)
 - engine-transits
 
-Add `tests/humdes_cross_engine.rs` that runs each engine on the same 89
-fixtures and reports calc-time + non-empty-output rate. Even without
-humdes ground truth for non-HD engines, this catches "engine X errors on
-all charts from 1960 due to ephemeris range" type bugs cheaply.
+Each engine's crate carries a small `tests/humdes_smoke_tests.rs` with
+the same shape: 1-2 cheap smoke tests on every `cargo test`, plus one
+`#[tokio::test] #[ignore]` "full report" that exercises all 89 fixtures
+and prints ok / fail / latency. Even without humdes ground truth for
+non-HD engines, this catches "engine X errors on all charts from 1960
+due to ephemeris range" type bugs cheaply.
+
+#### Current cross-engine status (HV-T03, issue #855)
+
+Both initial cross-engine smokes land green:
+
+| Engine     | Test file                                                    | Smoke | Full report (89 fixtures) |
+|------------|--------------------------------------------------------------|-------|---------------------------|
+| panchanga  | `crates/engine-panchanga/tests/humdes_smoke_tests.rs`        | 2 pass | ok = 89 / 89, fail = 0, avg ≈ 0.07 ms/calc |
+| numerology | `crates/engine-numerology/tests/humdes_smoke_tests.rs`       | 2 pass | ok = 89 / 89, fail = 0, avg ≈ 0.01 ms/calc |
+
+Reproduce:
+
+```bash
+cargo test --package engine-panchanga  --test humdes_smoke_tests   # smoke only
+cargo test --package engine-numerology --test humdes_smoke_tests   # smoke only
+
+cargo test --package engine-panchanga  --test humdes_smoke_tests -- --ignored --nocapture
+cargo test --package engine-numerology --test humdes_smoke_tests -- --ignored --nocapture
+```
+
+Notes:
+- Panchanga gates on `has_coords` (needs lat/lng/time/tz). All 89 humdes
+  fixtures carry coords today, so nothing is skipped.
+- Numerology requires `birth_data.name + date` and ignores `has_coords`.
+  All 89 fixtures carry a non-empty name today.
+- Both reports are diagnostic — they only fail the test if zero fixtures
+  ran successfully. Per-fixture failures are listed in stdout, not as
+  assertion failures, so a single engine bug doesn't block the suite.
+
+Remaining engines (biorhythm / vimshottari / gene-keys / vedic-clock /
+transits) follow the same template — left as follow-up work.
 
 ## Open work
 


### PR DESCRIPTION
Closes #855

## Summary
- New `tests/humdes_smoke_tests.rs` in `engine-panchanga` and `engine-numerology`, mirroring the HD validation harness pattern.
- Each file ships:
  - **Smoke tests** (run on every `cargo test`): fixtures-directory present, first 3 inputs deserialize into the shape the engine needs.
  - **Long-running report** (`#[tokio::test] #[ignore = "long-running"]`): runs the engine over all 89 humdes fixtures and prints ok / fail / per-failure context / average calc time.
- README's "Tier 4 — Cross-engine validation" section updated with current numbers, reproduce commands, and notes on what each engine requires.
- No engine source touched — HV-T03 allowed edit surface honoured.

## Reports

```
=== panchanga humdes smoke ===
  ok                : 89
  fail              : 0
  skipped (no coords): 0
  avg calc ms       : 0.069
```

```
=== numerology humdes smoke ===
  ok               : 89
  fail             : 0
  skipped (no name): 0
  avg calc ms      : 0.0095
```

Both engines run end-to-end on all 89 humdes fixtures with zero failures.

## Findings
- No engine panics or errors. No child issues filed.
- Numerology requires `birth_data.name`; all 89 fixtures carry a non-empty name today (the `humdes_to_selemene.py` normaliser preserves `person_name`), so nothing is skipped.
- Panchanga requires `has_coords`; all 89 fixtures are coordinated. Nothing is skipped.
- Smoke contract intentionally tolerant: the `--ignored` report only fails the test if *zero* fixtures ran successfully. Individual failures are listed in stdout. This keeps a single engine bug from blocking the suite while still surfacing the regression.

## Verification

```
cargo test --package engine-panchanga  --test humdes_smoke_tests                          # 2 pass / 1 ignored
cargo test --package engine-numerology --test humdes_smoke_tests                          # 2 pass / 1 ignored
cargo test --package engine-panchanga  --test humdes_smoke_tests -- --ignored --nocapture # ok = 89
cargo test --package engine-numerology --test humdes_smoke_tests -- --ignored --nocapture # ok = 89

rustfmt --check --edition 2021 \
  crates/engine-panchanga/tests/humdes_smoke_tests.rs \
  crates/engine-numerology/tests/humdes_smoke_tests.rs                                    # clean
cargo clippy --package engine-panchanga  --test humdes_smoke_tests -- -D warnings         # clean
cargo clippy --package engine-numerology --tests                  -- -D warnings          # clean
```

Pre-existing lint/fmt drift on `main` in `engine-panchanga/src/lib.rs`, `engine-human-design/tests/humdes_validation_tests.rs`, and a few noesis-api/data files is **not** touched by this PR (those files are forbidden surface for HV-T03). They are tracked separately.

## Edit surface
- `crates/engine-panchanga/tests/humdes_smoke_tests.rs` (new)
- `crates/engine-numerology/tests/humdes_smoke_tests.rs` (new)
- `tests/fixtures/humdes/README.md` (Tier-4 status, repro commands)

Both crates already had `tokio` + `serde_json` in `[dev-dependencies]` — no Cargo.toml changes needed.