### PR TITLE
[HV-T04 #856] Tier-2 storage: humdes validation persistence

### DIFF
--- a/crates/noesis-data/Cargo.toml
+++ b/crates/noesis-data/Cargo.toml
@@ -16,3 +16,16 @@ tracing = "0.1"
 
 # Internal dependencies
 noesis-core = { path = "../noesis-core" }
+
+[features]
+# Opt-in writer for the humdes ground-truth validation harness. Gates the
+# `humdes_validation` module + the `record_humdes_run` example binary so the
+# default build of dependents carries no reference to validation persistence.
+# See: migrations/031_humdes_validation.sql and issue #856.
+record-validation = []
+
+# One-shot binary that demonstrates the writer end-to-end. Compiled only when
+# the `record-validation` feature is active so it never enters the default build.
+[[example]]
+name = "record_humdes_run"
+required-features = ["record-validation"]

--- a/crates/noesis-data/examples/record_humdes_run.rs
+++ b/crates/noesis-data/examples/record_humdes_run.rs
@@ -1,0 +1,67 @@
+//! One-shot binary that invokes the humdes-validation writer with a tiny
+//! synthetic payload. Useful for:
+//!   1. Smoke-testing migration 031 against a scratch Postgres
+//!   2. Documenting the call shape future test harnesses should adopt
+//!
+//! Run with:
+//!   DATABASE_URL=postgres://... \
+//!     cargo run --package noesis-data --features record-validation \
+//!         --example record_humdes_run
+//!
+//! Idempotency: each invocation creates a fresh run row with a new UUID, so
+//! repeated runs are safe (each just appends another row).
+
+use std::env;
+
+use chrono::Utc;
+use noesis_data::{create_pool, humdes_validation};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let database_url = env::var("DATABASE_URL").map_err(|_| {
+        "DATABASE_URL is required — point at a scratch Postgres with migration 031 applied"
+    })?;
+
+    let pool = create_pool(&database_url).await?;
+
+    let run = humdes_validation::ValidationRun {
+        run_at: Utc::now(),
+        engine_version: env!("CARGO_PKG_VERSION").to_string(),
+        selemene_commit: env::var("SELEMENE_COMMIT").unwrap_or_else(|_| "unknown".to_string()),
+        fixtures_count: 2,
+        per_field_pct: json!({
+            "type": 100.0,
+            "profile": 100.0,
+        }),
+        notes: Some("record_humdes_run example invocation".to_string()),
+    };
+
+    let records = vec![
+        humdes_validation::ValidationRecord {
+            person_id: "example-person-a".to_string(),
+            reading_hash: "deadbeef".to_string(),
+            reading_type: "personal".to_string(),
+            field: "type".to_string(),
+            expected: Some(json!("Generator")),
+            got: json!("Generator"),
+            matched: true,
+            notes: None,
+        },
+        humdes_validation::ValidationRecord {
+            person_id: "example-person-b".to_string(),
+            reading_hash: "cafebabe".to_string(),
+            reading_type: "personal".to_string(),
+            field: "profile".to_string(),
+            expected: Some(json!("1/3")),
+            got: json!("1/3"),
+            matched: true,
+            notes: None,
+        },
+    ];
+
+    let run_id = humdes_validation::record_validation_run(&pool, run, records).await?;
+    println!("inserted humdes_validation_runs row id={run_id}");
+
+    Ok(())
+}

--- a/crates/noesis-data/src/humdes_validation.rs
+++ b/crates/noesis-data/src/humdes_validation.rs
@@ -1,0 +1,185 @@
+//! humdes validation persistence (Tier-2 storage).
+//!
+//! Writer module for the `humdes_validation_runs` / `humdes_validation_records`
+//! tables introduced by migration `031_humdes_validation.sql`.
+//!
+//! Gated entirely behind the `record-validation` Cargo feature so the default
+//! build of `noesis-data` (and any crate that depends on it) carries zero
+//! reference to this code. The intended caller is a one-shot binary or a
+//! future post-test hook that takes a `PgPool`, never the test harness itself.
+//!
+//! See `tests/fixtures/humdes/README.md` (Tier-2 section) and issue #856.
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Canonical field names that the writer will accept in
+/// [`ValidationRecord::field`]. This is a closed set deliberately mirrored
+/// in the migration's column comment so the database documents its own
+/// contract. New fields should be appended here AND in the comment.
+///
+/// Order: Wave-0 cardinal fields, then Wave-1 enrichment fields (HV-T02),
+/// then forward-declared placeholders that the engine doesn't yet emit.
+pub const KNOWN_FIELDS: &[&str] = &[
+    // Wave-0 cardinal fields (engine baseline).
+    "type",
+    "profile",
+    "authority",
+    "personality_sun",
+    "personality_earth",
+    "design_sun",
+    "design_earth",
+    "incarnation_cross",
+    // Wave-1 enrichment (HV-T02 #854).
+    "definition",
+    "strategy",
+    "not_self_theme",
+    // Forward-declared — not yet populated by the engine but reserved so
+    // future runs don't need a schema change.
+    "defined_centers",
+    "active_channels",
+];
+
+/// Returns `true` if `field` is in [`KNOWN_FIELDS`]. Callers are free to
+/// persist unknown fields (the DB doesn't enforce the set), but the writer
+/// uses this to attach a non-fatal note to the row.
+pub fn is_known_field(field: &str) -> bool {
+    KNOWN_FIELDS.contains(&field)
+}
+
+/// One humdes-validation invocation. Maps 1:1 to a row in
+/// `humdes_validation_runs`.
+#[derive(Debug, Clone)]
+pub struct ValidationRun {
+    pub run_at: DateTime<Utc>,
+    pub engine_version: String,
+    pub selemene_commit: String,
+    pub fixtures_count: i32,
+    /// Top-line per-field match percentage, e.g. `{"type": 92.1, "profile": 100.0}`.
+    /// Stored as JSONB so the schema doesn't need updating when fields are added.
+    pub per_field_pct: Value,
+    pub notes: Option<String>,
+}
+
+/// One (person, field) diff inside a run. Maps 1:1 to a row in
+/// `humdes_validation_records`.
+#[derive(Debug, Clone)]
+pub struct ValidationRecord {
+    pub person_id: String,
+    pub reading_hash: String,
+    pub reading_type: String,
+    pub field: String,
+    /// humdes ground-truth value. `None` means humdes had no value for this
+    /// (person, field) pair — written as SQL `NULL`, distinct from `Some(Value::Null)`.
+    pub expected: Option<Value>,
+    pub got: Value,
+    pub matched: bool,
+    pub notes: Option<String>,
+}
+
+/// Persist a validation run with its per-record diffs atomically.
+///
+/// Inserts one row into `humdes_validation_runs` followed by N rows into
+/// `humdes_validation_records`, all inside a single transaction so a partial
+/// failure leaves no orphan run row. Returns the freshly minted `run_id`.
+///
+/// The writer attaches an automatic `[unknown-field]` note tag to any record
+/// whose `field` is not in [`KNOWN_FIELDS`], appended to the caller-supplied
+/// `notes` if any. This makes drift in the field-set visible without
+/// rejecting writes.
+pub async fn record_validation_run(
+    pool: &PgPool,
+    run: ValidationRun,
+    records: Vec<ValidationRecord>,
+) -> Result<Uuid, sqlx::Error> {
+    let run_id = Uuid::new_v4();
+
+    let mut tx = pool.begin().await?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO humdes_validation_runs (
+            id, run_at, engine_version, selemene_commit,
+            fixtures_count, per_field_pct, notes
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        "#,
+    )
+    .bind(run_id)
+    .bind(run.run_at)
+    .bind(&run.engine_version)
+    .bind(&run.selemene_commit)
+    .bind(run.fixtures_count)
+    .bind(&run.per_field_pct)
+    .bind(run.notes.as_deref())
+    .execute(&mut *tx)
+    .await?;
+
+    for record in records {
+        let augmented_notes = match (is_known_field(&record.field), record.notes.as_deref()) {
+            (true, n) => n.map(|s| s.to_string()),
+            (false, Some(existing)) => Some(format!("{existing} [unknown-field]")),
+            (false, None) => Some("[unknown-field]".to_string()),
+        };
+
+        sqlx::query(
+            r#"
+            INSERT INTO humdes_validation_records (
+                id, run_id, person_id, reading_hash, reading_type,
+                field, expected, got, matched, notes
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            "#,
+        )
+        .bind(Uuid::new_v4())
+        .bind(run_id)
+        .bind(&record.person_id)
+        .bind(&record.reading_hash)
+        .bind(&record.reading_type)
+        .bind(&record.field)
+        .bind(record.expected.as_ref())
+        .bind(&record.got)
+        .bind(record.matched)
+        .bind(augmented_notes.as_deref())
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    tx.commit().await?;
+
+    Ok(run_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_fields_includes_wave_1_additions() {
+        // Cardinal
+        assert!(is_known_field("type"));
+        assert!(is_known_field("profile"));
+        assert!(is_known_field("incarnation_cross"));
+        // Wave-1 enrichment (HV-T02)
+        assert!(is_known_field("definition"));
+        assert!(is_known_field("strategy"));
+        assert!(is_known_field("not_self_theme"));
+        // Forward-declared
+        assert!(is_known_field("defined_centers"));
+        assert!(is_known_field("active_channels"));
+        // Not in set
+        assert!(!is_known_field("totally_made_up"));
+        assert!(!is_known_field(""));
+    }
+
+    #[test]
+    fn known_fields_has_no_duplicates() {
+        let mut seen: Vec<&&str> = KNOWN_FIELDS.iter().collect();
+        seen.sort();
+        let len_before = seen.len();
+        seen.dedup();
+        assert_eq!(len_before, seen.len(), "KNOWN_FIELDS contains duplicates");
+    }
+}

--- a/crates/noesis-data/src/lib.rs
+++ b/crates/noesis-data/src/lib.rs
@@ -3,3 +3,9 @@ pub mod models;
 pub mod repositories;
 
 pub use db::{create_pool, DbPool};
+
+/// humdes validation persistence (Tier-2 storage). Gated behind the
+/// `record-validation` feature so only explicit opt-in callers (a one-shot
+/// binary or future post-test hook) pull in the writer. See issue #856.
+#[cfg(feature = "record-validation")]
+pub mod humdes_validation;

--- a/migrations/031_humdes_validation.sql
+++ b/migrations/031_humdes_validation.sql
@@ -1,0 +1,65 @@
+-- Migration 031: humdes validation persistence (Tier-2 storage).
+--
+-- Stores per-invocation results of the humdes ground-truth validation
+-- harness (crates/engine-human-design/tests/humdes_validation_tests.rs)
+-- so we can chart per-engine-version drift over time across the 89-person
+-- humdes fixture corpus.
+--
+-- Writer: crates/noesis-data/src/humdes_validation.rs, gated behind the
+-- `record-validation` Cargo feature. Tests and production paths do NOT
+-- reference this writer unless the feature is enabled by an explicit
+-- one-shot binary (see crates/noesis-data/examples/record_humdes_run.rs).
+--
+-- See: tests/fixtures/humdes/README.md (Tier-2 section) and issue #856.
+-- Reverse: see DOWN block at bottom.
+
+-- ── UP ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE humdes_validation_runs (
+    id              UUID            PRIMARY KEY,
+    run_at          TIMESTAMPTZ     NOT NULL,
+    engine_version  TEXT            NOT NULL,       -- e.g. env!("CARGO_PKG_VERSION")
+    selemene_commit TEXT            NOT NULL,       -- git sha at run time
+    fixtures_count  INT             NOT NULL CHECK (fixtures_count >= 0),
+    per_field_pct   JSONB           NOT NULL,       -- {"type": 92.1, "profile": 100.0, ...}
+    notes           TEXT
+);
+
+CREATE TABLE humdes_validation_records (
+    id              UUID            PRIMARY KEY,
+    run_id          UUID            NOT NULL
+                    REFERENCES humdes_validation_runs(id) ON DELETE CASCADE,
+    person_id       TEXT            NOT NULL,       -- humdes person_id (stable hash)
+    reading_hash    TEXT            NOT NULL,       -- humdes reading hash
+    reading_type    TEXT            NOT NULL,       -- personal|hologenetic|compatibility|business|family
+    field           TEXT            NOT NULL,       -- canonical field name (see writer's KNOWN_FIELDS)
+    expected        JSONB,                          -- humdes ground-truth value; NULL = no ground truth
+    got             JSONB           NOT NULL,       -- engine output value
+    matched         BOOL            NOT NULL,
+    notes           TEXT
+);
+
+-- Hot path: per-run drill-down by field ("which fixtures failed `type` in run X?").
+CREATE INDEX idx_humdes_records_run_field
+    ON humdes_validation_records (run_id, field);
+
+-- Hot path: per-person trajectory across runs ("when did fixture Y start failing?").
+CREATE INDEX idx_humdes_records_person_field
+    ON humdes_validation_records (person_id, field);
+
+COMMENT ON TABLE humdes_validation_runs IS
+  'One row per humdes_validation_tests invocation. Persisted only when the noesis-data record-validation feature is enabled. See issue #856.';
+COMMENT ON TABLE humdes_validation_records IS
+  'One row per (run, person, field) — the fine-grained diff between engine output and humdes ground truth. Cascade-deletes with the parent run.';
+COMMENT ON COLUMN humdes_validation_runs.per_field_pct IS
+  'Top-line per-field match percentage as JSON, e.g. {"type": 92.1, "profile": 100.0}. Convenient for trend dashboards without joining records.';
+COMMENT ON COLUMN humdes_validation_records.field IS
+  'Canonical field name. Closed set, mirrored by noesis_data::humdes_validation::KNOWN_FIELDS: type, profile, authority, personality_sun, personality_earth, design_sun, design_earth, incarnation_cross, definition, strategy, not_self_theme, defined_centers, active_channels.';
+COMMENT ON COLUMN humdes_validation_records.expected IS
+  'humdes ground-truth value. NULL is meaningful — it means humdes had no value for this (person, field), distinct from a JSON null.';
+
+-- ── DOWN ─────────────────────────────────────────────────────────────────
+-- DROP INDEX IF EXISTS idx_humdes_records_person_field;
+-- DROP INDEX IF EXISTS idx_humdes_records_run_field;
+-- DROP TABLE IF EXISTS humdes_validation_records;
+-- DROP TABLE IF EXISTS humdes_validation_runs;

--- a/supabase/migrations/20260518000031_031_humdes_validation.sql
+++ b/supabase/migrations/20260518000031_031_humdes_validation.sql
@@ -1,0 +1,54 @@
+-- Migration 031: humdes validation persistence (Tier-2 storage).
+--
+-- Stores per-invocation results of the humdes ground-truth validation
+-- harness (crates/engine-human-design/tests/humdes_validation_tests.rs)
+-- so we can chart per-engine-version drift over time across the 89-person
+-- humdes fixture corpus.
+--
+-- Writer: crates/noesis-data/src/humdes_validation.rs, gated behind the
+-- `record-validation` Cargo feature. Tests and production paths do NOT
+-- reference this writer unless the feature is enabled by an explicit
+-- one-shot binary (see crates/noesis-data/examples/record_humdes_run.rs).
+--
+-- See: tests/fixtures/humdes/README.md (Tier-2 section) and issue #856.
+
+CREATE TABLE humdes_validation_runs (
+    id              UUID            PRIMARY KEY,
+    run_at          TIMESTAMPTZ     NOT NULL,
+    engine_version  TEXT            NOT NULL,
+    selemene_commit TEXT            NOT NULL,
+    fixtures_count  INT             NOT NULL CHECK (fixtures_count >= 0),
+    per_field_pct   JSONB           NOT NULL,
+    notes           TEXT
+);
+
+CREATE TABLE humdes_validation_records (
+    id              UUID            PRIMARY KEY,
+    run_id          UUID            NOT NULL
+                    REFERENCES humdes_validation_runs(id) ON DELETE CASCADE,
+    person_id       TEXT            NOT NULL,
+    reading_hash    TEXT            NOT NULL,
+    reading_type    TEXT            NOT NULL,
+    field           TEXT            NOT NULL,
+    expected        JSONB,
+    got             JSONB           NOT NULL,
+    matched         BOOL            NOT NULL,
+    notes           TEXT
+);
+
+CREATE INDEX idx_humdes_records_run_field
+    ON humdes_validation_records (run_id, field);
+
+CREATE INDEX idx_humdes_records_person_field
+    ON humdes_validation_records (person_id, field);
+
+COMMENT ON TABLE humdes_validation_runs IS
+  'One row per humdes_validation_tests invocation. Persisted only when the noesis-data record-validation feature is enabled. See issue #856.';
+COMMENT ON TABLE humdes_validation_records IS
+  'One row per (run, person, field) — the fine-grained diff between engine output and humdes ground truth. Cascade-deletes with the parent run.';
+COMMENT ON COLUMN humdes_validation_runs.per_field_pct IS
+  'Top-line per-field match percentage as JSON, e.g. {"type": 92.1, "profile": 100.0}. Convenient for trend dashboards without joining records.';
+COMMENT ON COLUMN humdes_validation_records.field IS
+  'Canonical field name. Closed set, mirrored by noesis_data::humdes_validation::KNOWN_FIELDS: type, profile, authority, personality_sun, personality_earth, design_sun, design_earth, incarnation_cross, definition, strategy, not_self_theme, defined_centers, active_channels.';
+COMMENT ON COLUMN humdes_validation_records.expected IS
+  'humdes ground-truth value. NULL is meaningful — it means humdes had no value for this (person, field), distinct from a JSON null.';

--- a/tests/fixtures/humdes/README.md
+++ b/tests/fixtures/humdes/README.md
@@ -212,9 +212,10 @@ Versioned per-snapshot. Each new `humdes_to_selemene.py` run writes a
 fresh `_index.json`; old `tests/fixtures/humdes/_snapshots/<date>/` could
 preserve history if you cron the refresh.
 
-### Tier 2 — Engine-output deltas (proposed)
+### Tier 2 — Engine-output deltas (HV-T04 / #856)
 
-Add a `noesis-data` table:
+Landed as migration `031_humdes_validation.sql` (mirrored at
+`supabase/migrations/20260518000031_031_humdes_validation.sql`). The schema:
 
 ```sql
 CREATE TABLE humdes_validation_runs (
@@ -223,26 +224,100 @@ CREATE TABLE humdes_validation_runs (
     engine_version  TEXT NOT NULL,            -- env!("CARGO_PKG_VERSION")
     selemene_commit TEXT NOT NULL,            -- git sha
     fixtures_count  INT  NOT NULL,
-    per_field_pct   JSONB NOT NULL,           -- {type: 92.1, profile: 100.0, ...}
+    per_field_pct   JSONB NOT NULL,           -- {"type": 92.1, "profile": 100.0, ...}
     notes           TEXT
 );
 
 CREATE TABLE humdes_validation_records (
     id              UUID PRIMARY KEY,
-    run_id          UUID REFERENCES humdes_validation_runs(id) ON DELETE CASCADE,
-    person_id       TEXT NOT NULL,            -- humdes person_id
+    run_id          UUID NOT NULL
+                    REFERENCES humdes_validation_runs(id) ON DELETE CASCADE,
+    person_id       TEXT NOT NULL,
     reading_hash    TEXT NOT NULL,
-    reading_type    TEXT NOT NULL,            -- personal/holo/compat/business/family
-    field           TEXT NOT NULL,            -- 'type'|'profile'|'authority'|'personality_sun'|...
-    expected        JSONB,                    -- humdes value
+    reading_type    TEXT NOT NULL,            -- personal|hologenetic|compatibility|business|family
+    field           TEXT NOT NULL,            -- see noesis_data::humdes_validation::KNOWN_FIELDS
+    expected        JSONB,                    -- humdes value (NULL = no ground truth)
     got             JSONB NOT NULL,           -- engine value
     matched         BOOL NOT NULL,
     notes           TEXT
 );
+
+CREATE INDEX idx_humdes_records_run_field    ON humdes_validation_records (run_id, field);
+CREATE INDEX idx_humdes_records_person_field ON humdes_validation_records (person_id, field);
 ```
 
-A `cargo test --features=record-validation` invocation could insert into
-these tables (gate behind a feature so normal CI doesn't write). Lets you:
+The writer lives at `crates/noesis-data/src/humdes_validation.rs`, gated
+behind the `record-validation` Cargo feature. The default build of
+`noesis-data` carries no reference to it, so CI and production paths are
+untouched unless the feature is explicitly enabled.
+
+Call shape (intended for a one-shot binary or future post-test hook —
+deliberately not bolted into `humdes_validation_tests.rs` itself):
+
+```rust
+use noesis_data::humdes_validation::{
+    record_validation_run, ValidationRun, ValidationRecord,
+};
+
+let run_id = record_validation_run(&pool, run, records).await?;
+```
+
+A working example is at `crates/noesis-data/examples/record_humdes_run.rs`:
+
+```bash
+DATABASE_URL=postgres://localhost/scratch_humdes \
+    cargo run --package noesis-data --features record-validation \
+        --example record_humdes_run
+```
+
+Top-level trend query — per-engine-version drift on the corpus, newest first:
+
+```sql
+SELECT
+    engine_version,
+    selemene_commit,
+    fixtures_count,
+    (per_field_pct->>'type')::float              AS type_pct,
+    (per_field_pct->>'profile')::float           AS profile_pct,
+    (per_field_pct->>'authority')::float         AS authority_pct,
+    (per_field_pct->>'incarnation_cross')::float AS cross_pct,
+    (per_field_pct->>'definition')::float        AS definition_pct,
+    (per_field_pct->>'strategy')::float          AS strategy_pct,
+    (per_field_pct->>'not_self_theme')::float    AS not_self_pct,
+    run_at
+FROM humdes_validation_runs
+ORDER BY run_at DESC
+LIMIT 20;
+```
+
+Per-fixture drill-down — "which charts started failing `type` in the
+latest run?":
+
+```sql
+WITH latest AS (
+    SELECT id FROM humdes_validation_runs
+    ORDER BY run_at DESC LIMIT 1
+)
+SELECT person_id, reading_hash, reading_type, expected, got, notes
+FROM humdes_validation_records
+WHERE run_id = (SELECT id FROM latest)
+  AND field = 'type'
+  AND NOT matched
+ORDER BY person_id;
+```
+
+Per-person trajectory — "when did fixture X start failing `type`?":
+
+```sql
+SELECT r.run_at, runs.engine_version, r.expected, r.got, r.matched
+FROM humdes_validation_records r
+JOIN humdes_validation_runs runs ON runs.id = r.run_id
+WHERE r.person_id = 'c517b66135'
+  AND r.field = 'type'
+ORDER BY r.run_at DESC;
+```
+
+Lets you:
 - Track regressions across engine versions
 - Quantify drift after each refactor
 - Surface specific birth-times that newly broke
@@ -324,8 +399,9 @@ all charts from 1960 due to ephemeris range" type bugs cheaply.
       and decide whether to align (and which direction).
 - [ ] **Snapshot policy.** Cron `humdes_to_selemene.py` weekly so we have
       history for tracking schema drift on humdes's side.
-- [ ] **Tier 2 table migrations** in `noesis-data` + a writer behind a
-      feature flag.
+- [x] **Tier 2 table migrations** in `noesis-data` + a writer behind a
+      feature flag. *(HV-T04 #856 — migration `031_humdes_validation.sql`
+      and `noesis_data::humdes_validation` behind `record-validation`.)*
 - [ ] **Phase-1 extension for `compatibility`/`family` extra people.**
       Person[2+] doesn't get cardinal gates from `_row.json`; we'd need
       either per-person ravecard fetches or HTML parsing.


### PR DESCRIPTION
Closes #856

## Summary
- New migration **`031_humdes_validation.sql`** (root + supabase mirror): `humdes_validation_runs` + `humdes_validation_records` with run-by-field and person-by-field indexes.
- New module **`noesis_data::humdes_validation`** behind the `record-validation` Cargo feature. Default builds carry zero reference to the writer.
- Single transactional entry point `record_validation_run(pool, run, records) -> Uuid`. `KNOWN_FIELDS` constant mirrors the canonical field set after HV-T01/HV-T02 — including the Wave-1 additions `definition`, `strategy`, `not_self_theme` plus forward-declared placeholders for `defined_centers` and `active_channels`.
- One-shot example **`crates/noesis-data/examples/record_humdes_run.rs`** demonstrates the writer end-to-end. Gated by `required-features = ["record-validation"]`.
- **`tests/fixtures/humdes/README.md`** Tier-2 section rewritten with the trend query + per-fixture drill-down + per-person trajectory snippets.

## Migration convention used
The existing convention in this repo is **single-file `NNN_name.sql`** in the root `migrations/` directory with an inline `-- UP ---` block and a commented-out `-- DOWN ---` block at the bottom (see `028_raga_clips.sql`). Every migration is mirrored as `YYYYMMDDHHMMSS_NNN_name.sql` in `supabase/migrations/` (stripped of inline comments + DOWN block, matching `20260511000028_028_raga_clips.sql`). This PR matches both halves exactly — no new tooling, no new feature-gated drivers.

## Schema (final)

```sql
CREATE TABLE humdes_validation_runs (
    id              UUID            PRIMARY KEY,
    run_at          TIMESTAMPTZ     NOT NULL,
    engine_version  TEXT            NOT NULL,
    selemene_commit TEXT            NOT NULL,
    fixtures_count  INT             NOT NULL CHECK (fixtures_count >= 0),
    per_field_pct   JSONB           NOT NULL,
    notes           TEXT
);

CREATE TABLE humdes_validation_records (
    id              UUID            PRIMARY KEY,
    run_id          UUID            NOT NULL
                    REFERENCES humdes_validation_runs(id) ON DELETE CASCADE,
    person_id       TEXT            NOT NULL,
    reading_hash    TEXT            NOT NULL,
    reading_type    TEXT            NOT NULL,
    field           TEXT            NOT NULL,
    expected        JSONB,
    got             JSONB           NOT NULL,
    matched         BOOL            NOT NULL,
    notes           TEXT
);

CREATE INDEX idx_humdes_records_run_field    ON humdes_validation_records (run_id, field);
CREATE INDEX idx_humdes_records_person_field ON humdes_validation_records (person_id, field);
```

`expected` is nullable on purpose — `SQL NULL` distinguishes "humdes had no ground-truth value for this (person, field)" from "humdes had a JSON null".

## Writer signature

```rust
#[cfg(feature = "record-validation")]
pub mod humdes_validation {
    pub const KNOWN_FIELDS: &[&str] = &[
        "type", "profile", "authority",
        "personality_sun", "personality_earth", "design_sun", "design_earth",
        "incarnation_cross",
        "definition", "strategy", "not_self_theme",
        "defined_centers", "active_channels",
    ];

    pub async fn record_validation_run(
        pool: &PgPool,
        run: ValidationRun,
        records: Vec<ValidationRecord>,
    ) -> Result<Uuid, sqlx::Error>;
}
```

Per the handoff packet's "forbidden surface" constraint, the writer is **not** wired into `humdes_validation_tests.rs`. It is callable from any future post-test hook or one-shot binary — the example in `crates/noesis-data/examples/record_humdes_run.rs` shows the call shape.

## Trend query (added to README)

```sql
SELECT
    engine_version,
    selemene_commit,
    fixtures_count,
    (per_field_pct->>'type')::float              AS type_pct,
    (per_field_pct->>'profile')::float           AS profile_pct,
    (per_field_pct->>'authority')::float         AS authority_pct,
    (per_field_pct->>'incarnation_cross')::float AS cross_pct,
    (per_field_pct->>'definition')::float        AS definition_pct,
    (per_field_pct->>'strategy')::float          AS strategy_pct,
    (per_field_pct->>'not_self_theme')::float    AS not_self_pct,
    run_at
FROM humdes_validation_runs
ORDER BY run_at DESC
LIMIT 20;
```

(Two additional drill-down queries — failed-fixtures-in-latest-run, and per-person-trajectory — are in the same README section.)

## Verification

| Gate | Result |
|---|---|
| `cargo build --package noesis-data` (default — writer NOT compiled) | passes |
| `cargo build --package noesis-data --features record-validation` | passes |
| `cargo build --package noesis-data --features record-validation --examples` | passes |
| `cargo test --package noesis-data --features record-validation --lib` | 18 pass, 2 pre-existing failures (unrelated — see below) |
| `cargo clippy --package noesis-data --features record-validation --tests --examples -- -D warnings` | clean |
| `rustfmt --check` on the two new Rust files | clean |
| Migration applies on scratch Postgres | **NOT verified** — no local Postgres available. Manual verification: `psql -d scratch -f migrations/031_humdes_validation.sql` then drop via the DOWN block. |

**Pre-existing test failures** — `migration_016_exists_in_root_and_supabase` and `migration_017_exists_in_root_and_supabase` reference migrations that don't exist in the tree (016 / 017). Reproduced on `main` HEAD `a8306599` before any of my changes; tracked separately.

## Files changed

| File | Status | Reason |
|---|---|---|
| `migrations/031_humdes_validation.sql` | new | Root migration (UP + commented DOWN) |
| `supabase/migrations/20260518000031_031_humdes_validation.sql` | new | Supabase mirror |
| `crates/noesis-data/src/humdes_validation.rs` | new | Writer module |
| `crates/noesis-data/src/lib.rs` | modified | `#[cfg(feature = "record-validation")] pub mod humdes_validation;` |
| `crates/noesis-data/Cargo.toml` | modified | `[features] record-validation = []` + `[[example]]` gating |
| `crates/noesis-data/examples/record_humdes_run.rs` | new | One-shot proof binary |
| `tests/fixtures/humdes/README.md` | modified | Tier-2 section rewritten with three production queries |

Out of scope per the handoff packet's forbidden surface: any engine source, `humdes_validation_tests.rs`, and `tests/fixtures/humdes/_index.json` / fixtures.