### PR TITLE
fix(noesis-web): use turbopack.root for monorepo, restore .next/ path

### DIFF
--- a/apps/noesis-web/next.config.mjs
+++ b/apps/noesis-web/next.config.mjs
@@ -8,13 +8,19 @@ const __dirname = path.dirname(__filename);
 const nextConfig = {
   output: "standalone",
   reactStrictMode: true,
-  // ─── Monorepo workspace root ─────────────────────────────────────────
+  // ─── Monorepo workspace root (Turbopack-specific) ─────────────────────
   // This repo is an npm-workspaces monorepo with multiple package.json
-  // files. Without this explicit setting, Next.js 16 + Turbopack throws
-  // "inferred your workspace root, but it may not be correct" during
-  // production build. Pin it to the repo root (two levels up from this
-  // app: apps/noesis-web → apps → repo root).
-  outputFileTracingRoot: path.join(__dirname, "../../"),
+  // files. Without explicitly setting `turbopack.root`, Next.js 16
+  // Turbopack throws "inferred your workspace root, but it may not be
+  // correct" during production build. We pin it to the repo root (two
+  // levels up: apps/noesis-web → apps → repo root).
+  //
+  // We deliberately do NOT set `outputFileTracingRoot` here — doing so
+  // moves the .next/ output above the app directory, which breaks the
+  // Vercel CLI deploy that expects .next/ relative to the CWD.
+  turbopack: {
+    root: path.join(__dirname, "../../"),
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Reverts outputFileTracingRoot (set in #864) and uses turbopack.root instead. The previous fix moved .next/ output above the app dir; Vercel CLI couldn't find routes-manifest.json. This puts .next/ back where Vercel expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)