### PR TITLE
fix(noesis-web): drop output:standalone to unblock Vercel CLI deploy

### DIFF
--- a/apps/noesis-web/next.config.mjs
+++ b/apps/noesis-web/next.config.mjs
@@ -6,21 +6,20 @@ const __dirname = path.dirname(__filename);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "standalone",
   reactStrictMode: true,
-  // ─── Monorepo workspace root (Turbopack-specific) ─────────────────────
+  // ─── Monorepo workspace root ─────────────────────────────────────────
   // This repo is an npm-workspaces monorepo with multiple package.json
-  // files. Without explicitly setting `turbopack.root`, Next.js 16
+  // files. Without explicitly setting outputFileTracingRoot, Next.js 16
   // Turbopack throws "inferred your workspace root, but it may not be
-  // correct" during production build. We pin it to the repo root (two
-  // levels up: apps/noesis-web → apps → repo root).
+  // correct" during production build. Pin to the repo root (two levels
+  // up: apps/noesis-web → apps → repo root).
   //
-  // We deliberately do NOT set `outputFileTracingRoot` here — doing so
-  // moves the .next/ output above the app directory, which breaks the
-  // Vercel CLI deploy that expects .next/ relative to the CWD.
-  turbopack: {
-    root: path.join(__dirname, "../../"),
-  },
+  // We removed `output: "standalone"` because (a) Vercel deploys via
+  // its own runtime and doesn't need standalone output, and (b) the
+  // combination of standalone + outputFileTracingRoot caused the
+  // Vercel CLI deploy step to compute .next path as
+  // ${CWD}/apps/noesis-web/.next/... (doubled path) and fail.
+  outputFileTracingRoot: path.join(__dirname, "../../"),
 };
 
 export default nextConfig;


### PR DESCRIPTION
Removes `output: "standalone"` from next.config.mjs. The combination with `outputFileTracingRoot` was causing the Vercel CLI deploy step to compute a doubled .next path. Vercel deploys via its own runtime and doesn't need standalone output.