### PR TITLE
fix(noesis-web): build with webpack to sidestep Turbopack monorepo issues

### DIFF
--- a/apps/noesis-web/next.config.mjs
+++ b/apps/noesis-web/next.config.mjs
@@ -1,25 +1,6 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  // ─── Monorepo workspace root ─────────────────────────────────────────
-  // This repo is an npm-workspaces monorepo with multiple package.json
-  // files. Without explicitly setting outputFileTracingRoot, Next.js 16
-  // Turbopack throws "inferred your workspace root, but it may not be
-  // correct" during production build. Pin to the repo root (two levels
-  // up: apps/noesis-web → apps → repo root).
-  //
-  // We removed `output: "standalone"` because (a) Vercel deploys via
-  // its own runtime and doesn't need standalone output, and (b) the
-  // combination of standalone + outputFileTracingRoot caused the
-  // Vercel CLI deploy step to compute .next path as
-  // ${CWD}/apps/noesis-web/.next/... (doubled path) and fail.
-  outputFileTracingRoot: path.join(__dirname, "../../"),
 };
 
 export default nextConfig;

--- a/apps/noesis-web/package.json
+++ b/apps/noesis-web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start -p 3002",
     "typecheck": "tsc --noEmit --incremental false"
   },


### PR DESCRIPTION
Root cause of the deploy chain failures (#864 #865 #866): Next.js 16 Turbopack production build requires outputFileTracingRoot in monorepos. Setting it makes Vercel CLI compute a doubled .next path. Removing it makes Turbopack error. The clean fix is to bypass Turbopack for production builds using `next build --webpack`. Dev server still uses Turbopack.