### PR TITLE
fix(ci): let Vercel build noesis-web on its own runners (drop --prebuilt)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -339,11 +339,17 @@ jobs:
         run: npm ci --workspace apps/noesis-web
 
       - name: Deploy to Vercel production
+        # Note: we deliberately use `vercel deploy` WITHOUT `--prebuilt`
+        # so Vercel builds the app on its own runners. The previous
+        # `vercel build --prebuilt` flow was producing an output bundle
+        # that Vercel's serverless runtime couldn't ingest in this
+        # monorepo layout (ENOENT on next-server runtime files). Vercel's
+        # native build environment handles the monorepo workspace
+        # correctly and is the same path that PR previews use.
         run: |
           npm install -g vercel
           vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-          vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-          vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+          vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
         working-directory: apps/noesis-web
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
Drops `vercel build --prebuilt` from the deploy flow. Replaces with native `vercel deploy --prod` which uses Vercel's build environment (same path PR previews use, which has been working all along).

Closes the deploy chain failures starting from PR #862 by removing the source of the conflict (Vercel CLI prebuilt + monorepo path resolution).