### PR TITLE
fix(get-reading): unbreak intake layout — wider stage, smaller witnesses, layered shadows

### DIFF
--- a/apps/noesis-web/app/get-reading/page.tsx
+++ b/apps/noesis-web/app/get-reading/page.tsx
@@ -744,16 +744,19 @@ const s: Record<string, React.CSSProperties> = {
   stage: {
     position: "relative",
     zIndex: 3, // above the witness figures
-    width: "min(560px, 92vw)",
+    // Was min(560px, 92vw) — too narrow on wide viewports, forced the
+    // heading to wrap to 5 short lines. Widened to ~820px so the prompt
+    // copy has room to breathe between the two witnesses.
+    width: "min(820px, 92vw)",
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
     gap: "clamp(1.25rem, 2.5vh, 2rem)",
-    // Add backdrop blur behind the center column so witness figures
-    // don't visually fight with the dialog text on narrow viewports
+    // Vignette behind the center column so the witness figures recede
+    // visually and the dialog reads cleanly. Widened with the column.
     background:
-      "radial-gradient(ellipse at center, rgba(7,11,29,0.55) 0%, rgba(7,11,29,0.0) 70%)",
-    padding: "clamp(1rem, 3vh, 2.5rem)",
+      "radial-gradient(ellipse at center, rgba(7,11,29,0.62) 0%, rgba(7,11,29,0.0) 70%)",
+    padding: "clamp(1rem, 3vh, 2.5rem) clamp(1rem, 4vw, 3rem)",
     borderRadius: "24px",
   },
   progress: {
@@ -794,18 +797,31 @@ const s: Record<string, React.CSSProperties> = {
     letterSpacing: "0.32em",
     textTransform: "uppercase",
     color: "rgba(240,237,227,0.55)",
-    maxWidth: "44ch",
+    maxWidth: "56ch",
     lineHeight: 1.6,
   },
   question: {
     margin: 0,
     fontFamily: "var(--font-display, 'Panchang', serif)",
     fontVariationSettings: "'wght' 720",
-    fontSize: "clamp(1.7em, min(4.5vw, 7vh), 3em)",
-    lineHeight: 1.06,
+    // Capped at 2.5em (was 3em) so the heading fits 2-3 lines in the
+    // ~770px channel between the two witnesses on wide viewports
+    // instead of breaking to 4-5 lines. Still scales down at smaller
+    // viewports via the clamp lower bound.
+    fontSize: "clamp(1.6em, min(3.6vw, 6vh), 2.5em)",
+    lineHeight: 1.08,
     letterSpacing: "-0.012em",
     color: "#F0EDE3",
-    maxWidth: "20ch",
+    textAlign: "center" as const,
+    // The h1 is a flex-column child under `alignItems: center`, which
+    // makes it collapse to its content's natural width — so a bare
+    // maxWidth never took effect. width:100% forces the h1 to fill
+    // the available column, then maxWidth caps it at the stage width.
+    width: "100%",
+    // Tracks the stage column (820px). Lets the heading wrap on the
+    // natural sentence break ("Coordinates required." / "The date that
+    // anchored your arrival.") instead of word-by-word breaks.
+    maxWidth: "min(780px, 100%)",
   },
   field: {
     width: "100%",

--- a/crates/noesis-vedic-api/src/panchang/api.rs
+++ b/crates/noesis-vedic-api/src/panchang/api.rs
@@ -186,7 +186,7 @@ fn karana_type_from_index(idx: u8) -> KaranaType {
     // Kimstughna). The remaining karanas are movable.
     match idx {
         7 => KaranaType::Vishti, // Vishti / Bhadra
-        8 | 9 | 10 => KaranaType::Fixed,
+        8..=10 => KaranaType::Fixed,
         _ => KaranaType::Movable,
     }
 }
@@ -244,7 +244,7 @@ pub fn compute_panchang_native(
     let nakshatra = Nakshatra {
         number: nakshatra_number,
         name_nakshatra: NakshatraName::from_number(nakshatra_number as u32),
-        pada: pada.min(4).max(1),
+        pada: pada.clamp(1, 4),
         start_time: String::new(),
         end_time: String::new(),
         longitude: result.lunar_longitude,

--- a/packages/dyad-ui/src/DyadChamber.tsx
+++ b/packages/dyad-ui/src/DyadChamber.tsx
@@ -254,33 +254,72 @@ function BannerWitness({ side, name, active, submitting }: WitnessFigureProps) {
 }
 
 export function WitnessFigure({ side, name, active, submitting }: WitnessFigureProps) {
-  const opacity = active ? 1 : 0.35;
+  /* Use the canonical front-facing portraits. The side-direction PNGs
+     (*-left, *-right, *-back) are inconsistent — some are profile views
+     of the same character, some are entirely different art assets.
+     The *-front.png views are the canonical Pichet/Aletheios renders
+     and both are already naturally posed gesturing inward, so two
+     front views read as a dyad facing each other. */
+  const imageUrl = `/depth-reading/characters/${name}-front.png`;
+
+  const opacity = active ? 1 : 0.42;
+
+  /* Active witness leans into the room; inactive recedes toward the edge.
+     Combined with the rotateY below this reads as physical orientation,
+     not a CSS scale-up. */
   const translateX = active
-    ? side === "left" ? "8px" : "-8px"
-    : side === "left" ? "-12px" : "12px";
-  const glowColor = name === "pichet" ? "rgba(197,160,23,0.4)" : "rgba(16,181,167,0.4)";
+    ? side === "left" ? "12px" : "-12px"
+    : side === "left" ? "-22px" : "22px";
+
+  /* Very subtle faux-3D rotation. The portraits already include their
+     own body angle in the art, so the CSS rotateY is just a tiny
+     reinforcement (~1.5° toward center when active, slightly away
+     when inactive). Anything stronger reads as "tilted trading card"
+     because the PNG itself stays flat. */
+  const rotateY = active
+    ? side === "left" ? "1.5deg" : "-1.5deg"
+    : side === "left" ? "-4deg" : "4deg";
+
+  /* Goethe-tinted key light cast inward + ambient drop for ground feel.
+     Pichet (left) casts gold to the right; Aletheios (right) casts
+     emerald to the left. Both characters also drop a soft ambient
+     shadow below them so they sit in space, not float. */
+  const keyLight =
+    name === "pichet"
+      ? "drop-shadow(8px 4px 28px rgba(197,160,23,0.45))"
+      : "drop-shadow(-8px 4px 28px rgba(16,181,167,0.45))";
+  const ambient = "drop-shadow(0 26px 36px rgba(0,0,0,0.55))";
+
   const filter = active
-    ? `drop-shadow(0 0 24px ${glowColor})`
-    : "saturate(0.4) brightness(0.6)";
+    ? `${keyLight} ${ambient}`
+    : `saturate(0.35) brightness(0.55) ${ambient}`;
 
   return (
     <div
       style={{
         position: "absolute",
         top: "50%",
-        [side]: "clamp(0px, 4vw, 4rem)",
-        transform: `translateY(-50%) translateX(${translateX})`,
-        height: "clamp(50vh, 75vh, 90vh)",
+        [side]: "clamp(0px, 4vw, 6rem)",
+        /* Sized so two witnesses + center column fit cleanly at 1920px:
+           each ≈ 420px wide leaves ~1080px clear horizontal channel
+           for the form (vs. 770px at the previous 62vh height). */
+        height: "clamp(42vh, 55vh, 70vh)",
         width: "auto",
         aspectRatio: "1 / 1.4",
-        backgroundImage: `url(/depth-reading/characters/${name}-front.png)`,
+        backgroundImage: `url(${imageUrl})`,
         backgroundSize: "contain",
         backgroundRepeat: "no-repeat",
         backgroundPosition: side === "left" ? "left center" : "right center",
         opacity,
         filter,
+        /* perspective() turns rotateY into foreshortening — characters
+           feel like they're standing in a room rather than pasted
+           against the screen. transformOrigin anchored to the edge so
+           the rotation hinges on their outside foot. */
+        transform: `translateY(-50%) translateX(${translateX}) perspective(1400px) rotateY(${rotateY})`,
+        transformOrigin: side === "left" ? "left center" : "right center",
         transition:
-          "opacity 700ms cubic-bezier(0.2,0.7,0.2,1), transform 700ms cubic-bezier(0.2,0.7,0.2,1), filter 700ms cubic-bezier(0.2,0.7,0.2,1)",
+          "opacity 700ms cubic-bezier(0.2,0.7,0.2,1), transform 900ms cubic-bezier(0.2,0.7,0.2,1), filter 700ms cubic-bezier(0.2,0.7,0.2,1)",
         pointerEvents: "none",
         animation: submitting ? "thresholdPulse 1.2s ease-in-out infinite" : undefined,
       }}


### PR DESCRIPTION
## Summary

Production `/get-reading` step 2 was rendering the date prompt
"Coordinates required. The date that anchored your arrival." as
**5 broken lines** in a narrow center column while the witness
portraits ate most of the viewport. This PR uses the existing PNG
assets better — no 3D, no new art, just better space.

Heading drops from **5 lines → 3 lines** on 1920×1080, witnesses
readable without dominating, Goethe-tinted shadows give CSS depth.

(Branched off clean `main`; supersedes #877 which was mid-rebase
conflicting with the #872 squash on its ancestor.)

## Changes

- **`apps/noesis-web/app/get-reading/page.tsx`**
  - Stage column: `min(560px, 92vw)` → `min(820px, 92vw)`
  - Heading: `maxWidth: 20ch` → `min(780px, 100%)` + `width: 100%` so flex `alignItems:center` no longer collapses it to content-width
  - Heading font cap: `3em` → `2.5em`
- **`packages/dyad-ui/src/DyadChamber.tsx` — WitnessFigure**
  - Height: `75vh max` → `55vh max` (~310px more horizontal room)
  - Layered drop-shadows: gold key-light from Pichet, emerald from Aletheios + ambient drop — depth without 3D
  - Subtle CSS perspective + rotateY (1.5°/-4°) for orientation
  - Tested `*-left/right.png` "facing inward" — turns out side PNGs are inconsistent art (aletheios-left is a different character entirely) so reverted to `*-front.png`

## Test plan

- [x] Typecheck clean
- [x] Local screenshot confirms 3-line heading + sized witnesses + visible key/ambient shadows
- [ ] Vercel preview deploy confirms on PR
- [ ] After merge: `noesis.tryambakam.space/get-reading` step 2 reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)