### PR TITLE
fix(get-reading): integrated workflow + Discord OAuth gate

### DIFF
--- a/apps/noesis-web/app/auth/discord/callback/discord-callback-client.tsx
+++ b/apps/noesis-web/app/auth/discord/callback/discord-callback-client.tsx
@@ -106,10 +106,22 @@ export function DiscordCallbackClient() {
           const next = params.get("next");
           destination = next && next.startsWith("/r/") ? next : `/r/${pending.reading_id}`;
         } else {
-          // Generic post-auth redirect — respect `next` if provided
+          // Generic post-auth redirect — respect `next` if provided.
+          // Also check for the `noesis:pending_integrated` flag set by
+          // /get-reading when an anonymous user picks "Sixteen mirrors,
+          // full synthesis": that path requires identity, so the user
+          // was bounced through Discord OAuth and now needs to return
+          // to /get-reading so the auto-replay effect can fire the
+          // integrated workflow with their fresh auth token.
           const params = new URLSearchParams(window.location.search);
           const next = params.get("next");
-          destination = next || "/engines";
+          let pendingIntegrated: string | null = null;
+          try {
+            pendingIntegrated = localStorage.getItem("noesis:pending_integrated");
+          } catch { /* SSR / quota */ }
+          destination =
+            next ||
+            (pendingIntegrated === "1" ? "/get-reading" : "/engines");
         }
         router.replace(destination);
       } catch (err: unknown) {

--- a/apps/noesis-web/app/get-reading/page.tsx
+++ b/apps/noesis-web/app/get-reading/page.tsx
@@ -19,6 +19,13 @@ import {
 } from "@/lib/integrated/witnessAccess";
 import { cacheReading } from "@/lib/integrated/readingCache";
 import type { ReadingPayload } from "@/lib/integrated/payloadLoader";
+import { getApiKey, isAuthenticated } from "@/lib/auth";
+
+/** localStorage key holding `"1"` while the user is in the middle of a
+ *  Discord-OAuth round-trip for the integrated reading. Set just before
+ *  redirecting to /auth, read on /get-reading mount to auto-replay the
+ *  submission once the user comes back authenticated. */
+const PENDING_INTEGRATED_KEY = "noesis:pending_integrated";
 import {
   DyadChamber,
   StepIndicator,
@@ -159,6 +166,22 @@ export default function GetReadingPage() {
         return;
       }
 
+      /* Discord OAuth gate for the integrated (Pichet · Sixteen mirrors)
+         path: the full-spectrum workflow is a heavyweight 17-engine
+         compute meant to be tied to an identity and saved across
+         sessions. If the user is anonymous, we round-trip them through
+         Discord OAuth before running the workflow, then auto-replay on
+         return. Daily-practice stays anonymous-first. */
+      if (workflow === "integrated" && !isAuthenticated()) {
+        try {
+          localStorage.setItem(PENDING_INTEGRATED_KEY, "1");
+        } catch { /* quota — degrade to ungated submit */ }
+        // Persist form state happens via the existing useEffect on
+        // state changes, so the round-trip preserves date/time/place/name.
+        window.location.assign("/auth?next=/get-reading");
+        return;
+      }
+
       setState((s) => ({ ...s, submitting: workflow, error: null }));
 
       const payload: Record<string, unknown> = {
@@ -176,9 +199,21 @@ export default function GetReadingPage() {
         const url = workflow === "integrated"
           ? INTEGRATED_READING_WORKFLOW_URL
           : DAILY_WITNESS_WORKFLOW_URL;
+        const apiKey = workflow === "integrated" ? getApiKey() : null;
+        const headers: Record<string, string> = { "Content-Type": "application/json" };
+        if (apiKey) {
+          // Match the convention used elsewhere (lib/api.ts): keys
+          // prefixed with `nk_` use the x-api-key header; OAuth-derived
+          // tokens (Discord login → JWT) use Authorization: Bearer.
+          if (apiKey.startsWith("nk_")) {
+            headers["x-api-key"] = apiKey;
+          } else {
+            headers["Authorization"] = `Bearer ${apiKey}`;
+          }
+        }
         const res = await fetch(url, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers,
           body: JSON.stringify(payload),
         });
         const body = (await res.json().catch(() => null)) as
@@ -209,6 +244,31 @@ export default function GetReadingPage() {
     },
     [state.birth_date, state.birth_time, state.location_key, state.name],
   );
+
+  /* OAuth round-trip replay: if the user was bounced through Discord
+     login from the integrated path, the PENDING_INTEGRATED_KEY flag
+     is sitting in localStorage. As soon as the hydrated form has the
+     fields it needs (date + location) AND we're now authenticated,
+     fire the integrated submit automatically — the user sees the
+     workflow run without having to re-click. Guarded by a ref so it
+     only fires once per mount. */
+  const integratedReplayedRef = useRef(false);
+  useEffect(() => {
+    if (integratedReplayedRef.current) return;
+    if (!state.birth_date || !state.location_key) return;
+    let pending: string | null = null;
+    try {
+      pending = localStorage.getItem(PENDING_INTEGRATED_KEY);
+    } catch { /* ignore */ }
+    if (pending !== "1") return;
+    if (!isAuthenticated()) return;
+    // All conditions met — clear flag, fire submission.
+    try {
+      localStorage.removeItem(PENDING_INTEGRATED_KEY);
+    } catch { /* ignore */ }
+    integratedReplayedRef.current = true;
+    submit("integrated");
+  }, [state.birth_date, state.location_key, submit]);
 
   // ─── Keyboard nav ────────────────────────────────────────────────────
   useEffect(() => {

--- a/apps/noesis-web/src/lib/integrated/witnessAccess.ts
+++ b/apps/noesis-web/src/lib/integrated/witnessAccess.ts
@@ -10,7 +10,12 @@ export const WITNESS_ORIGIN =
   process.env.NEXT_PUBLIC_WITNESS_ORIGIN ?? "https://48.tryambakam.space";
 
 export const DAILY_WITNESS_WORKFLOW_URL = `${WITNESS_ORIGIN}/api/v1/workflows/daily-practice/execute`;
-export const INTEGRATED_READING_WORKFLOW_URL = `${WITNESS_ORIGIN}/api/v1/workflows/integrated-reading/execute`;
+// Backend orchestrator registers workflow IDs: birth-blueprint, creative-expression,
+// daily-practice, decision-support, full-spectrum, self-inquiry. The 17-engine
+// "Pichet · Sixteen mirrors, full synthesis" path is the `full-spectrum` workflow —
+// `integrated-reading` was never registered, which is why production was returning
+// "WORKFLOW NOT FOUND: INTEGRATED-READING" on the depth-pick step.
+export const INTEGRATED_READING_WORKFLOW_URL = `${WITNESS_ORIGIN}/api/v1/workflows/full-spectrum/execute`;
 
 export interface WitnessLocation {
   key: string;


### PR DESCRIPTION
## Summary

Production `/get-reading` step 5 was showing **"WORKFLOW NOT FOUND: INTEGRATED-READING"** because the frontend was calling a workflow ID the backend never registered. This PR fixes the URL and also adds the Discord OAuth interstitial requested for the heavyweight integrated path.

## Changes

**P0 — `apps/noesis-web/src/lib/integrated/witnessAccess.ts`**
- `INTEGRATED_READING_WORKFLOW_URL`: `integrated-reading` → `full-spectrum`
- Verified against backend listing at https://48.tryambakam.space/api/v1/workflows — `full-spectrum` is the registered 17-engine workflow.

**P1 — Discord OAuth gate (3 files)**
- `app/get-reading/page.tsx`:
  - `submit("integrated")` gates on `isAuthenticated()`. Anonymous users get sent to `/auth` with a `noesis:pending_integrated` flag in localStorage.
  - New `useEffect` auto-replays the integrated submission once the form is hydrated AND the user is now authenticated. Guarded by a `useRef` so it fires only once.
  - Daily-practice path unchanged (still anonymous-first).
- `app/auth/discord/callback/discord-callback-client.tsx`:
  - Honors the `noesis:pending_integrated` flag — routes back to `/get-reading` (not `/engines`) so the auto-replay can fire.

## Resulting flow

| User state | Picks "One witness, one pass" (daily) | Picks "Sixteen mirrors, full synthesis" (integrated) |
|---|---|---|
| Anonymous | Workflow runs immediately, cached locally | → Discord OAuth → back to /get-reading → workflow auto-replays as authed user |
| Authenticated | Workflow runs immediately | Workflow runs immediately with auth header |

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] Vercel preview deploy confirms on PR
- [ ] After merge: `noesis.tryambakam.space/get-reading` integrated path no longer 404s; anonymous users get bounced through Discord OAuth and land back on the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)