### PR TITLE
docs(engines): per-engine data references (17) + renderer↔runtime audit

### DIFF
--- a/docs/engines/README.md
+++ b/docs/engines/README.md
@@ -1,0 +1,112 @@
+# Engine Data References
+
+> Per-engine data contracts for the Noesis calculation engines: **what each engine outputs, the value ranges/constraints, which component renders it, and how the data maps to (and changes) the visual.**
+> These ground the Wave-2 engine-renderer work (`apps/noesis-web/src/components/engines/*`) the same way `docs/design/biofield-web/` grounds biofield-web.
+
+Source of truth: the Rust engine crates (`crates/engine-*`), the Vedic API (`crates/noesis-vedic-api`), the **TypeScript engines** (`ts-engines/src/engines/*`), the schema registry (`crates/noesis-core/src/types.rs`), the renderers (`apps/noesis-web/src/components/engines/*.tsx`), and the JHora/reference fixtures (`crates/**/tests/**`). **Nothing here is invented** — every field/range is cited to a file, and unknowns are flagged.
+
+---
+
+## The `EngineOutput` envelope (every engine)
+
+All engines return the same envelope (`crates/noesis-core/src/types.rs:39`, TS mirror `packages/noesis-sdk-ts/src/index.ts:52`):
+
+```rust
+pub struct EngineOutput {
+    pub engine_id: String,           // e.g. "panchanga", "gene-keys", "i-ching"
+    pub result: Value,               // engine-specific JSON — the per-engine schema (free-form)
+    pub witness_prompt: String,      // one self-inquiry question generated from the calc
+    pub consciousness_level: u8,     // 0–5, user's development level (gates depth of interpretation)
+    pub metadata: CalculationMetadata, // timing, backend, precision
+}
+```
+TS adds optional `witness_prompts?: string[]` and treats `result` as `Record<string, unknown>`. **`result` is free-form JSON** — the per-engine schema below describes its shape.
+
+---
+
+## ⚠️ Three schema layers + three computation paths
+
+A given engine's output appears in **up to three shapes** that do **not** always agree. Each engine doc records all that apply and names the **runtime truth**.
+
+| Layer | Where | What it is | Trust for |
+|---|---|---|---|
+| **1. OpenAPI stub** | `noesis-core/src/types.rs` `*ResultSchema` (`#[cfg(feature="openapi")]`) | 3 hand-picked example fields, docs only | example values, canonical engine naming — **not** the full field list (often pure fiction, see audit) |
+| **2. Domain struct / producer** | `crates/engine-*/src/{lib,models,types}.rs` (Rust) **or** `ts-engines/src/engines/*/engine.ts` (TS) | the engine's real output type | field names/types/ranges of the engine itself — but check its **serializer**, not just the struct |
+| **3. Runtime JSON** | what the API actually returns → what the **renderer** reads + the **fixtures** | the shape the web consumes | **the real contract** — build against this |
+
+**Three computation paths produce `result`:**
+1. **Rust `engine-*` crates** — 11 engines, wired into the `EngineResultData` enum. ⚠️ The runtime shape is the crate's **`serialize_*` function**, which often differs from the bare struct.
+2. **`noesis-vedic-api`** — the Vedic engines (panchanga, vimshottari, transits, vedic-clock) are *also* served here (JHora-verified, nested/rich JSON). When the vedic-api shape and the `engine-*` struct disagree, the **fixture / vedic-api shape is what ships**.
+3. **`ts-engines` (Bun sidecar, `:3001`)** — 6 engines (Enneagram, Tarot, I Ching, Sacred Geometry, Sigil Forge, Raaga) are TypeScript, reached from Rust via **`noesis-bridge`** (`BridgeEngine::*` → HTTP `{TS_ENGINES_URL}/engines/<id>/calculate`), which passes `result` through verbatim. Their `types.rs` OpenAPI stubs are illustration only and share **no** field names with the real JSON.
+
+---
+
+## ⚠️ Systemic finding — renderers are broken against runtime
+
+The biggest outcome of this audit: **almost every engine renderer reads keys the engine never emits.** This is a static (code-level) analysis — high confidence, but the multi-path Vedic engines (panchanga/vimshottari/transits/vedic-clock) should be confirmed with a **live runtime capture** before fixing, since which of the two paths actually ships isn't provable from code alone. Detail + citations live in each doc's §7.
+
+| Engine | Renderer reads | Runtime emits | Effect today |
+|---|---|---|---|
+| Panchanga | `tithi.name` (nested) | nested via vedic-api ✓ / flat `tithi_name` (crate) | **OK** via vedic-api; crate path differs |
+| Vimshottari | `current_mahadasha`, `upcoming_periods`, `years_remaining` | `current_period`, `upcoming_transitions`, `years` | empty cells + empty table |
+| Transits | `planetary_positions`, `significant_aspects`, `sade_sati.active` | `transit_positions`, `aspects`, `sade_sati.is_active` | 0 planets plotted; empty aspects/Sade-Sati |
+| Vedic Clock | `tcm_organ_clock.*`, `ayurvedic_timing.*` | `current_organ`, `current_dosha` | clock never renders → `GenericEngineView` |
+| Human Design | `result.type`, `strategy`, `not_self_theme` | `hd_type` (others not serialized) | Type cell `—`; several fields blank |
+| Gene Keys | `activation_sequence.spheres[]` | four `[gate,gate]` arrays + `active_keys[]` | every sphere card `—` |
+| Numerology | `result[key].number` | `result[key].value` | numbers render `—` |
+| Biorhythm | `value` as ±100 | `value` ±1.0 (+ `percentage` 0–100) | **all waves flat on the zero line** |
+| Biofield | `coherence`, `chakras[].value` (0–100) | `metrics.coherence`, `chakra_readings[].activity_level` (0–1) | empty/zero panels |
+| Face Reading | `facial_features`, `vitality_score`, `constitution.dosha` | `analysis.constitution.primary_dosha`, `elemental_balance` | near-empty grid |
+| Nadabrahman | `chakra_frequency.mantra/.note/.frequency_hz` | `{chakra_name, solfeggio_hz, binaural_target_hz}` | mantra/Hz/note/element blank |
+| Enneagram | `triad` (+ lookup-mode cells) | `center` | partial blanks |
+| Tarot | `result.cards`, `result.spread` | `{spread, question, positions[], seed}` | cards don't render |
+| I Ching | flat `hexagram_number`, `lines`, `changing_lines` | nested `primary_hexagram.*`, `casting.line_values` | hexagram doesn't render |
+| Sacred Geometry | `meditation_guidance`, `svg_preview` (string) | `meditation.prompt`, `svg_preview{status}` | unwired / empty |
+| Sigil Forge | `vector_path` glyph | method/process text + optional base64 **PNG** (no `vector_path`) | glyph never renders; `dangerouslySetInnerHTML` XSS risk |
+| Raaga | `mood`, `rasa`, `vadi`, `samvadi` | producer emits none of these | those cards always hidden |
+
+**Implication for Wave-2:** the engine renderers can't just be restyled to the brand archetypes — most must first be **re-keyed to the real runtime JSON** (and a few engine serializers enriched). Each doc's §4 (data→visual mapping) is written against the *correct* runtime shape, so it doubles as the fix spec.
+
+---
+
+## Engines
+
+**17 engines.** **11** have dedicated **Rust** `engine-*` crates; **6** (Enneagram, Tarot, I Ching, Sacred Geometry, Sigil Forge, Raaga) are **TypeScript** engines in the `ts-engines` Bun sidecar, proxied via `noesis-bridge`. The first 16 are in the Rust `EngineResultData` enum (`types.rs:369`); **Raaga is not** (TS-only, no stub).
+
+| Engine | `engine_id`¹ | Engine impl | Renderer | Runtime source | Brand archetype (Wave-2 target) |
+|---|---|---|---|---|---|
+| [Panchanga](panchanga.md) | `panchanga` | engine-panchanga | `Panchanga.tsx` | noesis-vedic-api | 5-limb mandala (nakshatra ring + tithi arc) |
+| [Vimshottari](vimshottari.md) | `vimshottari` | engine-vimshottari | `Vimshottari.tsx` | noesis-vedic-api | nested dasha→bhukti time-arc rings |
+| [Transits](transits.md) | `transits` | engine-transits | `Transits.tsx` | noesis-vedic-api | orbital constellation (planets + aspects) |
+| [Vedic Clock](vedic-clock.md) | `vedic-clock` | engine-vedic-clock | `VedicClock.tsx` | engine-vedic-clock | radial day-clock compass (organ + dosha) |
+| [Human Design](human-design.md) | `human-design` | engine-human-design | `HumanDesign.tsx` | engine-human-design | BodyGraph (9 centers · 36 channels · 64 gates) |
+| [Gene Keys](gene-keys.md) | `gene-keys` | engine-gene-keys | `GeneKeys.tsx` | engine-gene-keys | hologenetic sequence rings (shadow/gift/siddhi) |
+| [Numerology](numerology.md) | `numerology` | engine-numerology | `Numerology.tsx` | engine-numerology | digit-spiral nodes (life-path 1–9 + masters) |
+| [Biorhythm](biorhythm.md) | `biorhythm` | engine-biorhythm | `Biorhythm.tsx` | engine-biorhythm | three-wave sine overlay (23/28/33 d) |
+| [Biofield](biofield.md) | `biofield` | engine-biofield (+ -capture, Py CV) | `Biofield.tsx` | engine + Py sidecar + client PIP | cosmogram + mandala (see `docs/design/biofield-web`) |
+| [Face Reading](face-reading.md) | `face-reading` | engine-face-reading | `FaceReading.tsx` | engine-face-reading | face proportion grid + elemental balance |
+| [Nadabrahman](nadabrahman.md) | `nadabrahman` | engine-nadabrahman | `Nadabrahman.tsx` | engine-nadabrahman | harmonic waveform / Solfeggio arc |
+| [Enneagram](enneagram.md) | `enneagram` | ts-engines (TS) | `Enneagram.tsx` | ts-engines (Bun :3001) | 9-point enneagram figure (type · wing) |
+| [Tarot](tarot.md) | `tarot` | ts-engines (TS) | `Tarot.tsx` | ts-engines (Bun :3001) | card-glyph spread compass |
+| [I Ching](iching.md) | `i-ching` | ts-engines (TS) | `IChing.tsx` | ts-engines (Bun :3001) | hexagram line-stack / 64-grid |
+| [Sacred Geometry](sacred-geometry.md) | `sacred-geometry` | ts-engines (TS) | `SacredGeometry.tsx` | ts-engines (Bun :3001) | nested platonic solids / flower-of-life |
+| [Sigil Forge](sigil-forge.md) | `sigil-forge` | ts-engines (TS) | `SigilForge.tsx` | ts-engines (Bun :3001) | sigil construction diagram |
+| [Raaga](raaga.md) | `raaga` | ts-engines (TS) | `Raaga.tsx` | ts-engines (Bun :3001) | swara wheel / tonal arc (not in Rust enum) |
+
+¹ `engine_id` values verified per doc against the producer + `noesis-bridge` + renderer route (note `i-ching`, not `iching`). The fallback renderer `GenericEngineView.tsx` renders any engine whose `result` shape isn't specially handled — which, per the audit above, is the *de-facto* state for most engines today.
+
+---
+
+## Per-engine doc template
+
+Each `<engine>.md` follows this structure:
+
+1. **Identity** — `engine_id`, engine impl path(s), renderer path, fixture path(s), runtime source.
+2. **Output schema** — the runtime JSON (authoritative) as an annotated example, then the domain struct/producer + OpenAPI stub; mismatches called out.
+3. **Ranges, constraints & invariants** — per-field range/enum/unit, nullability, invariants (sums to 1, monotonic dates, index bounds…).
+4. **Component & brand archetype** — what the renderer draws today + the sacred-geometry archetype it should become (brand palette: Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`). Doubles as the re-key/fix spec.
+5. **Data → visual mapping** — table: field → geometry / arc / color / position (against the *correct* runtime shape).
+6. **Dynamics** — one-shot vs live; recompute cadence (e.g. vedic-clock is time-of-day); transitions; baseline/deltas; what re-renders.
+7. **Open questions / assumptions** — flagged uncertainties (schema mismatches, normalization, unverified runtime shapes).
+
+Consciousness level (`0–5`) and `witness_prompt(s)` are envelope-level (above) — engines note only engine-specific deviations.

--- a/docs/engines/biofield.md
+++ b/docs/engines/biofield.md
@@ -1,0 +1,156 @@
+# Biofield — Data Reference
+
+The energetic field around a person, read **two different ways**: a server-side **birth-data analysis** (`engine-biofield`, currently mock) and a client **live camera capture** (`biofield-web` app + `engine-biofield-capture` + a Python CV sidecar). They share vocabulary (coherence, symmetry, fractal dimension, chakras) but are **separate engines with separate `engine_id`s, separate metric sets, and separate runtime producers** — do not conflate them.
+
+> ⚠️ Read [`README.md` §"Three schema layers"](README.md) first. Biofield additionally has **two engines**, so it has *two* domain structs to keep straight.
+
+## 1. Identity
+
+| | (A) Server analysis | (B) Client live capture |
+|---|---|---|
+| `engine_id` | **`biofield`** (`engine-biofield/src/engine.rs:36`) | **`biofield-capture`** (`engine-biofield-capture/src/lib.rs:20`; `biofield-domain.ts:1`) |
+| Domain struct | `BiofieldAnalysis` (`engine-biofield/src/models.rs:98`) wrapping `BiofieldMetrics` (`models.rs:11`, **5 metrics**) | `BiofieldMetrics` (`biofield-domain.ts:63`, **11 metrics**) + `CompositeScores` (`pip/types.ts:27`, **5 live**) |
+| Runtime producer | **mock** today — `generate_mock_metrics` (`engine-biofield/src/mock.rs`); `is_mock_data:true` always (`engine.rs:133,137`). A Vedic path (`VedicBiofieldAnalyzer`, `engine.rs:18`) exists but the standalone engine still returns mock. | **Python CV sidecar** via `noesis-api/src/biofield_client.rs:15` (`BiofieldClient`, `python_biofield_url`) → persisted Reading → `engine-biofield-capture` re-exposes it by `reading_id` (`lib.rs:138`). Live in-browser metrics computed by `MetricsCalculator` (`pip/MetricsCalculator.ts:12`). |
+| Renderer | `apps/noesis-web/src/components/engines/Biofield.tsx` | `apps/biofield-web/src/components/BiofieldCosmogram.tsx` + `BiofieldLiveMetrics.tsx` |
+| OpenAPI stub | `noesis-core/src/types.rs:258` (`BiofieldResultSchema` — `dominant_element`, `coherence_score 0.72`, `recommended_practice`) — **describes neither struct accurately** | — |
+| Brand / design (frozen) | [`docs/design/biofield-web/README.md`](../design/biofield-web/README.md) + sheets `02`,`04`,`05`,`06`,`07`,`08`,`09`,`10` | same — biofield-web is the design's primary target |
+
+**How (A) and (B) relate (the bridge):** in the live app, the WebGL viewer runs `MetricsCalculator.compute()` every 100 ms (`MetricsCalculator.ts:7`) producing per-frame `FrameMetrics` → mapped to 5 `CompositeScores` (`MetricsCalculator.ts:152-172`) that drive the on-screen cosmogram in real time. On **capture**, a frame is uploaded; the **Python sidecar** computes the authoritative **11-field `BiofieldMetrics`** + `QualityAssessment`, persisted as a `biofield-capture` reading. `engine-biofield-capture` later resolves that reading by `reading_id` into the standard `EngineOutput` envelope (`lib.rs:75-88`). The **server `biofield` engine (A) is a wholly separate birth-data path** that never sees the camera — it emits its own 5-metric mock `BiofieldAnalysis`. So: **live PIP `CompositeScores` (5, in-browser, approximate) → captured `BiofieldMetrics` (11, sidecar, authoritative) → `biofield-capture` EngineOutput**; and **`biofield` (A) is parallel, not downstream.**
+
+## 2. Output schema
+
+### 2A. Server `BiofieldAnalysis` (`engine_id: "biofield"`)
+
+**Runtime JSON** the API emits (`engine-biofield/src/engine.rs:165-178`, `serialize_result`):
+```jsonc
+{
+  "metrics": {                       // NESTED — note the renderer reads these at top level (mismatch, §7)
+    "fractal_dimension": 1.52,       // 1.0–2.0
+    "entropy": 0.55,                 // 0.0–1.0
+    "coherence": 0.65,               // 0.0–1.0
+    "symmetry": 0.75,                // 0.0–1.0
+    "vitality_index": 0.62,          // 0.0–1.0 composite
+    "timestamp": "2026-…Z"
+  },
+  "chakra_readings": [               // 7, Root→Crown (models.rs:70)
+    { "chakra": "Root", "chakra_name": "Root", "activity_level": 0.6,  // 0.0–1.0
+      "balance": -0.1,              // -1.0..1.0 (neg=left, pos=right; models.rs:48)
+      "color_intensity": "…", "location": "…", "element": "Earth" }    // location/element from wisdom.rs
+  ],
+  "interpretation": "…",            // human-readable string
+  "areas_of_attention": ["…"],
+  "is_mock_data": true,             // ALWAYS true today (engine.rs:309 validates presence)
+  "witness_layer": { … }            // dyad, injected at engine.rs:267-268 (not in BiofieldAnalysis struct)
+}
+```
+`consciousness_level` (0–5) is read from `input.options.consciousness_level` (`engine.rs:236-238`) and rides the **envelope**, not `result`.
+
+**Domain struct** `BiofieldMetrics` (`models.rs:11`) — the 5 fields above + `chakra_readings: Vec<ChakraReading>` + `timestamp`. `ChakraReading` (`models.rs:40`): `chakra`, `activity_level`, `balance`, `color_intensity`. Interpretation thresholds live in `MetricInterpretation` (`wisdom.rs:36`, `optimal_range:(f64,f64)`).
+
+**OpenAPI stub** (`types.rs:258`): `{dominant_element, coherence_score, recommended_practice}` — **none of these fields exist** in `BiofieldAnalysis`. Secondary/illustrative only; ignore for the contract.
+
+### 2B. Client live capture (`engine_id: "biofield-capture"`)
+
+**Authoritative captured metrics** — `BiofieldMetrics` (11 fields, `biofield-domain.ts:63`), produced by the Python sidecar:
+```jsonc
+{
+  "light_quanta_density": 1.2e8,    // ~1e8 scale — NOT 0–1; needs log-normalize (§3, §7)
+  "normalized_area": 0.41,          // 0–1
+  "average_intensity": 0.58,        // 0–1
+  "inner_noise": 0.12,              // 0–1 (lower better)
+  "energy_analysis": { "low": …, "medium": …, "high": …, "total": … },  // EnergyBands (biofield-domain.ts:48)
+  "entropy_form_coefficient": 0.5,  // 0–1
+  "fractal_dimension": 1.5,         // ~1.0–2.0
+  "correlation_dimension": 1.3,     // ~1.0–2.0
+  "body_symmetry": 0.74,            // 0–1
+  "contour_complexity": 0.4,        // 0–1 (scale unverified, §7)
+  "pattern_regularity": 0.6         // 0–1
+}
+```
+Wrapped as `BiofieldCaptureResult` (`biofield-domain.ts:126`): `{reading_id, session_id, analysis_version, metrics, quality_assessment, artifacts}`.
+
+**`QualityAssessment`** (`biofield-domain.ts:55`): `sharpness, contrast, noise_level, exposure` (all 0–1, scale unverified) + `sufficient_quality:boolean` (the gate; surfaced in `BiofieldReadingSummary.quality`, `:90`).
+
+**`CompositeScores`** — the **5 live, in-browser** scores (`pip/types.ts:27`), all clamped 0–1 by `MetricsCalculator.ts:152-172`:
+| Field | Computed from (`MetricsCalculator.ts`) |
+|---|---|
+| `lightQuantaDensity` | `avgLum*0.6 + pixelVariance*0.4` (L154) — **0–1 proxy**, not the sidecar's 1e8 value |
+| `normalizedArea` | `maskWeight/n` (L157), else 0.5 |
+| `bodySymmetry` | combined pixel + face-landmark symmetry (L139,160) |
+| `patternRegularity` | `1 - entropyScore` (L163) |
+| `overallCoherence` | `lum*0.2 + sym*0.3 + (1-entropy)*0.25 + variance*0.25` (L166-171) |
+
+`FrameMetrics` (`pip/types.ts:19`): raw per-frame `averageLuminance, pixelVariance, symmetryScore, entropyScore, timestamp`.
+
+**Capture lifecycle enums** (`biofield-domain.ts`): session status `active|closed|abandoned` (`:3`); capture state `requested|uploaded|analyzed|persisted|rejected|reprocessed` (`:9`). The `biofield-capture` engine validates output has `reading_id`+`analysis` (`lib.rs:181-201`).
+
+**`biofield-capture` EngineOutput** (`lib.rs:75-88`) wraps the persisted reading: `{available, reading_id, engine_id, created_at, session_id, analysis_version, contract_version, quality_assessment, input, analysis}`. `consciousness_level` comes from the stored reading (`lib.rs:169`).
+
+## 3. Ranges, constraints & invariants
+
+| Field | Range / domain | Source | Notes |
+|---|---|---|---|
+| `fractal_dimension` (both) | **1.0–2.0**; optimal 1.4–1.7 | `models.rs:13-14`, `wisdom.rs:347`, `mock.rs:49` | <1.3 depleted, >1.8 chaotic (`wisdom.rs:338-345`) |
+| `correlation_dimension` (B) | **~1.0–2.0** | `biofield-domain.ts:71` | bound inferred from sibling fractal dim; unverified |
+| `entropy` / `entropy_form_coefficient` | **0.0–1.0**; optimal 0.4–0.7 | `wisdom.rs:367` / `biofield-domain.ts:68` | Shannon, normalized |
+| `coherence` (A) / `overallCoherence` (B) | **0.0–1.0**; optimal 0.5–0.8 | `wisdom.rs:387` / `pip/types.ts:31` | >0.9 rare (`wisdom.rs:384`) |
+| `symmetry` (A) / `body_symmetry` / `bodySymmetry` | **0.0–1.0**; optimal 0.6–0.9 | `wisdom.rs:408` | 1.0 rare; slight asymmetry healthy |
+| `vitality_index` (A) | **0.0–1.0**; optimal 0.5–0.8 | `wisdom.rs:428` | composite of the other 4 (`mock.rs:32`) |
+| `light_quanta_density` (B) | **~1e8** (NOT 0–1) | `biofield-domain.ts:64`; test uses `42.0` (`engine-biofield-capture/src/lib.rs:320`) | **needs log-normalize before display** (§7) |
+| `normalized_area`, `average_intensity`, `inner_noise`, `contour_complexity`, `pattern_regularity` (B) | **0–1** (assumed) | `biofield-domain.ts:65-74` | exact bounds not asserted in TS; `inner_noise` lower=better |
+| `energy_analysis` (B) | low/medium/high **bands + total** | `biofield-domain.ts:48` | `EnergyBands`; low/med/high should sum ≈ total (unverified) |
+| `chakra.activity_level` (A) | **0.0–1.0** | `models.rs:46` | renderer treats as 0–100 % (§7 mismatch) |
+| `chakra.balance` (A) | **-1.0…1.0** | `models.rs:48` | neg=left-dominant, pos=right-dominant |
+| 7 chakras (A) | Root→Crown, fixed order | `models.rs:57-66`, `:70` | `Chakra::all()` len 7 (test `models.rs:118`) |
+| `QualityAssessment.*` (B) | 0–1 (assumed) + `sufficient_quality:bool` | `biofield-domain.ts:55` | the capture gate |
+| `consciousness_level` | **0–5** | envelope (README) | (A) from `options` (`engine.rs:236`); (B) from reading (`lib.rs:169`) |
+
+**Invariants:** (A) `vitality_index` is derived, not independent (`mock.rs:32`). (A) `is_mock_data` always `true` and **must be present** (`engine.rs:309`). (B) capture only persists when `sufficient_quality` passes the gate. `MetricInterpretation.optimal_range.0 < .1` (test `wisdom.rs:539`).
+
+## 4. Component & brand archetype
+
+**Today (A) — `Biofield.tsx`:** one "Overall Coherence" number + 7 horizontal **progress bars** (one per chakra, `CHAKRA_COLORS`/`CHAKRA_NAMES` L80-88). This is **off-brand SaaS dashboard chrome** — progress bars + cards are on the design's *master negative* (`docs/design/biofield-web/README.md` §"Banned"). Wave-2 must replace it.
+
+**Today (B) — `BiofieldCosmogram.tsx`:** already on-brand — a **central mandala** (lotus petals, 8-point compass, spinning dot ring) surrounded by **6 floating geometry panels**, one per axis, each an arc-gauge + bespoke geometric icon, no boxes/cards. Brand tokens hard-coded (`BiofieldCosmogram.tsx:23-27`: Gold `#C5A017`, Emerald `#10B5A7`, Violet `#6B3FA0`, Indigo `#0B50FB`, Parchment `#F0EDE3`). Center shows a state word (`ATTUNING`/`BUILDING`/`OPTIMAL`) keyed off coherence (`:308-309`).
+
+**The 6 cosmogram axes** (`BiofieldCosmogram.tsx:10-16`, `300-307`): **ENERGY, COHERENCE, SYMMETRY, COMPLEXITY, REGULATION, COLOR FIELD** — note these are richer than the frozen sheet's `02-cosmogram-spec.png` label "COH/SYM/LUM/REG" (4 axes); the built component went to 6 (§7).
+
+**Brand archetype (target, both):** **cosmogram + mandala** as the unifying form (frozen in `docs/design/biofield-web`). Per the sheet map (`README.md` §Sheets): `CompositeScores`→Metric Node arc-rings (`04`); the 11 `BiofieldMetrics`→a **Biofield Mandala** of Energy/Geometry/Chaos rings (`05`); fractal/correlation dim + entropy→Fractal/Chaos signature (`06`); `QualityAssessment`→radial quality gauge (`07`); `consciousness_level`→5-state Goethe spectrum (`08`); capture flow→capture compass + state stepper (`09`); reading + baseline deltas→result mandala (`10`). Palette is Goethe polarity (Void `#070B1D`, Witness Violet `#2D0050`, Flow Indigo `#0B50FB`, Sacred Gold `#C5A017`, Coherence Emerald `#10B5A7`, Parchment `#F0EDE3`), Kha/Ba/La arc gradients, bioluminescent (light from within, Void canvas). For **(A)**, Wave-2 should bring `Biofield.tsx` onto the same mandala system (chakras as a 7-ring/7-spoke mandala, not bars).
+
+## 5. Data → visual mapping
+
+**(B) live cosmogram** (`BiofieldCosmogram.tsx`):
+| Axis (panel) | Driven by | Visual |
+|---|---|---|
+| ENERGY | `lightQuantaDensity` (`:302`) | gold hexagon icon scales with value + arc gauge |
+| COHERENCE | `overallCoherence` (`:301`) | indigo concentric rings; also sets center state word/color + HRV-style sine wave |
+| SYMMETRY | `bodySymmetry` (`:303`) | emerald nested-diamond icon |
+| COMPLEXITY | `patternRegularity` (`:304`, **proxy** "until fractal dim lands") | violet 5-point star icon |
+| REGULATION | `regulationScore ?? coherence*0.8` (`:305`, **fallback — field absent**, §7) | emerald sine wave |
+| COLOR FIELD | `colorBalance ?? normalizedArea` (`:306`, **fallback — field absent**, §7) | 8-petal multi-color lotus |
+| center | `overallCoherence` | mandala core: emerald≥0.75 OPTIMAL / indigo≥0.5 BUILDING / gold ATTUNING (`:308-309`) |
+
+**(A) server renderer** (`Biofield.tsx`) — *as currently wired* (see §7 mismatch):
+| Field read | Visual |
+|---|---|
+| `result.coherence ?? result.overall_coherence` (`:95`) | "Overall Coherence" number |
+| `result.chakras[].{value\|activation\|energy}` (`:111`) clamped 0–100 | per-chakra horizontal bar % |
+| fallback: `result.{root,sacral,…}` top-level keys (`:136-137`) | bar % when `chakras[]` absent |
+
+## 6. Dynamics
+
+- **(A) `biofield`:** one-shot per birth-data input; not live. Recompute on input change. Returns mock today (`is_mock_data:true`). `consciousness_level` (0–5) gates interpretive depth; a `witness_layer` dyad is injected (`engine.rs:267`).
+- **(B) live PIP:** **continuous** — `MetricsCalculator` recomputes every **100 ms** (`MetricsCalculator.ts:7`, ~10 fps), throttled/cached between samples; `useLiveMetrics` (`pip/useLiveMetrics.ts:28`) pushes `CompositeScores` into the cosmogram each frame. The mandala animates perpetually (spin 90 s, pulse 3.5 s, `BiofieldCosmogram.tsx:359-362`).
+- **(B) capture → persist:** discrete event; gated by `sufficient_quality`. Lifecycle `requested→uploaded→analyzed→persisted` (or `rejected`/`reprocessed`) (`biofield-domain.ts:9`).
+- **Baseline / deltas (B only):** `BiofieldMetricDelta` (`biofield-domain.ts:100`) carries `reading_value`, `baseline_value`, **`absolute_delta`** (always) and **`relative_delta?: number | null`** (optional — null when baseline is 0/undefined). A `BiofieldBaselineComparison` (`:108`) bundles `comparison_version` + baseline summary + `deltas[]`. Baselines aggregate N readings (`CreateBiofieldBaselineRequest.reading_ids`, `:148`). Targets the result-mandala sheet (`10`). **(A) has no baseline/delta concept.**
+
+## 7. Open questions / assumptions
+
+- **Two engines, easily conflated (confirmed):** `biofield` (A, 5 metrics, mock, birth-data) ≠ `biofield-capture` (B, 11 metrics, CV sidecar, camera). Different `engine_id`, struct, producer, renderer. Anyone wiring "biofield" must pick the right one. ✅ flagged.
+- **`Biofield.tsx` ↔ server `biofield` shape mismatch (confirmed, highest risk):** renderer reads **top-level** `result.coherence` and `result.chakras[].value` (0–100), but `engine.rs:165-174` emits `result.metrics.coherence` (**nested**, 0–1) and `result.chakra_readings[].activity_level` (0–1). As wired, the renderer shows the empty fallback (no coherence row, chakra bars at 0%) against real server output. Either the renderer must read `result.metrics.*`/`chakra_readings[].activity_level` and ×100, or the engine must flatten. **Verify which producer actually feeds `Biofield.tsx` before Wave-2.**
+- **`light_quanta_density` normalization (confirmed gap):** sidecar value is **~1e8** (`biofield-domain.ts:64`) but the live `lightQuantaDensity` composite is a **0–1 proxy** (`MetricsCalculator.ts:154`) and the cosmogram clamps 0–1 (`:302`). There is **no log-normalize step** in the read TS. Displaying the raw sidecar `light_quanta_density` on any 0–1 gauge will peg it. **A log-normalize (e.g. `log10(x)/8`) is required and currently missing** — confirm where it should live (sidecar output vs. client mapper).
+- **Cosmogram axes vs `CompositeScores` (confirmed):** `BiofieldCosmogram.tsx:305-306` reads `scores.regulationScore` and `scores.colorBalance` via `as any`, but **neither exists** on `CompositeScores` (only 5 fields, `pip/types.ts:27`). REGULATION and COLOR FIELD therefore always render the fallbacks (`coherence*0.8`, `normalizedArea`). Also COMPLEXITY uses `patternRegularity` as an admitted proxy "until fractal dim lands" (`:304`). The built component has **6 axes**; the frozen sheet `02` names **4** ("COH/SYM/LUM/REG"). Reconcile axis set + add the missing composite fields (or feed the cosmogram the full 11-field `BiofieldMetrics`, which carries real `fractal_dimension`/`pattern_regularity`).
+- **OpenAPI stub is wrong for both (confirmed):** `BiofieldResultSchema` (`types.rs:258`) `{dominant_element, coherence_score, recommended_practice}` matches **neither** struct. Treat as illustrative; do not generate clients against it.
+- **Unverified scales:** `QualityAssessment.{sharpness,contrast,noise_level,exposure}`, `correlation_dimension`, `contour_complexity`, `inner_noise`, and whether `energy_analysis.{low+medium+high}` sums to `total` — bounds inferred, not asserted in source. Confirm against the Python sidecar contract (`biofield-cv/v1`, referenced `engine-biofield-capture/src/lib.rs:318`).
+- **`witness_layer` (A)** is injected post-serialize (`engine.rs:268`) and is **not** part of the `BiofieldAnalysis` struct — consumers must read it off `result`, not the typed struct.
+- **`consciousness_level` source differs:** (A) from `input.options.consciousness_level` (`engine.rs:236`); (B) from the persisted reading (`lib.rs:169`). Same envelope field, two provenance paths.

--- a/docs/engines/biorhythm.md
+++ b/docs/engines/biorhythm.md
@@ -1,0 +1,105 @@
+# Biorhythm — Data Reference
+
+Classic biorhythm: sine cycles seeded at birth, sampled at a target date. Six cycles (physical/emotional/intellectual + intuitive/aesthetic/spiritual), three composites (mastery/passion/wisdom), critical-day detection, an optional forecast window, and an optional two-person compatibility block.
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `biorhythm` (`crates/engine-biorhythm/src/lib.rs:150-151`; asserted in tests L860) |
+| Domain crate | `crates/engine-biorhythm/src/calculator.rs` (math + `BiorhythmResult` L30, `CycleResult` L50, `ForecastDay` L62); `lib.rs` (engine impl, `CompatibilityResult` L63, `CycleCompatibility` L51) |
+| Runtime source | **`engine-biorhythm` crate** — pure native Rust, `backend: "native-rust"` (`lib.rs:279`). No vedic-api path. Output is `serde_json::to_value(BiorhythmResult)` (`lib.rs:252`) with `compatibility` spliced in when requested (L256-268). |
+| Renderer | `apps/noesis-web/src/components/engines/Biorhythm.tsx` |
+| Fixture (real values) | **none found** — no `crates/engine-biorhythm/tests/` dir; values below are derived from the math in `calculator.rs`. |
+| OpenAPI stub | `crates/noesis-core/src/types.rs:214` (`BiorhythmResultSchema` — flat `physical`/`emotional`/`intellectual: f64`, examples only) |
+
+> ⚠️ **Note the duplicate `BiorhythmResult` / `CycleResult` / `ForecastDay` definitions.** `src/types.rs` (the file the task pointed at) declares its own copies, but `lib.rs` re-exports the **`calculator.rs`** versions (`lib.rs:9-13`) and serializes those. `src/types.rs` also omits the `aesthetic`/`spiritual` fields that the live struct carries — it appears to be **stale/unused**. The runtime contract is **`calculator.rs`**. Flagged in §7.
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — `serde` of `calculator::BiorhythmResult`, `lib.rs:233-248`). Illustrative values from the math, not a captured fixture:**
+```jsonc
+{
+  "days_alive": 12950,
+  "target_date": "2026-06-04",                 // YYYY-MM-DD, = input.current_time.date_naive() (lib.rs:173)
+  "physical":     { "value": 0.824, "percentage": 91.2, "phase": "Rising",   "days_until_peak": 3, "days_until_critical": 8,  "is_critical": false, "cycle_day": 4 },
+  "emotional":    { "value": 0.417, "percentage": 70.9, "phase": "Rising",   "days_until_peak": 5, "days_until_critical": 12, "is_critical": false, "cycle_day": 5 },
+  "intellectual": { "value": -0.152,"percentage": 42.4, "phase": "Falling",  "days_until_peak": 25,"days_until_critical": 3,  "is_critical": false, "cycle_day": 17 },
+  "intuitive":    { "value": 0.0,   "percentage": 50.0, "phase": "Critical", "days_until_peak": 9, "days_until_critical": 1,  "is_critical": true,  "cycle_day": 0 },
+  "aesthetic":    { "value": 0.6,   "percentage": 80.0, "phase": "Rising",   "days_until_peak": 4, "days_until_critical": 10, "is_critical": false, "cycle_day": 8 },
+  "spiritual":    { "value": -0.7,  "percentage": 15.0, "phase": "Low",      "days_until_peak": 31,"days_until_critical": 6,  "is_critical": false, "cycle_day": 30 },
+  "mastery":  66.8,                             // (physical.percentage + intellectual.percentage) / 2   (lib.rs:191)
+  "passion":  81.1,                             // (physical.percentage + emotional.percentage)   / 2   (lib.rs:192)
+  "wisdom":   56.7,                             // (emotional.percentage + intellectual.percentage)/ 2   (lib.rs:193)
+  "critical_days": ["2026-06-05", "2026-06-09"],// upcoming dates any PRIMARY cycle crosses zero (calculator.rs:185)
+  "overall_energy": 58.2,                       // equal-weighted mean of all SIX .percentage values (lib.rs:196-202)
+  "forecast": [                                 // present unless forecast_days <= 0; default 7 (lib.rs:205-219)
+    { "date": "2026-06-05", "days_alive": 12951, "physical": 96.0, "emotional": 78.1,
+      "intellectual": 38.7, "intuitive": 41.2, "aesthetic": 83.0, "spiritual": 12.0,
+      "overall_energy": 58.2 }                  // ForecastDay: per-cycle values are PERCENTAGES 0..100 (calculator.rs:217-233)
+  ],
+  "compatibility": {                            // present ONLY if options.partner_birth_date supplied (lib.rs:222-230)
+    "birth_date_a": "1990-01-01", "birth_date_b": "1992-08-14", "target_date": "2026-06-04",
+    "physical":     { "score": 73.4, "period": 23.0, "days_diff": 956 },
+    "emotional":    { "score": 12.1, "period": 28.0, "days_diff": 956 },
+    "intellectual": { "score": 88.0, "period": 33.0, "days_diff": 956 },
+    "intuitive":    { "score": 45.0, "period": 38.0, "days_diff": 956 },
+    "overall": 57.8                             // mean of physical+emotional+intellectual ONLY (lib.rs:120)
+  }
+}
+```
+
+**Domain struct (`calculator::CycleResult`, L50-58)** — each cycle carries **two** scale fields plus phase metadata:
+`value:f64` (raw sine −1..1) · `percentage:f64` (0..100) · `phase:String` · `days_until_peak:i64` · `days_until_critical:i64` · `is_critical:bool` · `cycle_day:i64`.
+
+**OpenAPI stub (`types.rs:214`):** `{ physical:f64=82.4, emotional:f64=41.7, intellectual:f64=-15.2 }` — flat, 3-of-6 cycles, no `CycleResult` nesting, examples on a **signed −100..100** scale that the live struct never emits. Docs only; **do not build against it.**
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `<cycle>.value` | **−1.0 … +1.0** | raw `sin(2π·days_alive/period)` (calculator.rs:79-81); `validate()` rejects outside [−1,1] (lib.rs:315) |
+| `<cycle>.percentage` | **0.0 … 100.0** | `(value+1)/2·100` (calculator.rs:84-86) — **50 = zero crossing, 0 = trough, 100 = peak.** NOT a signed %. `validate()` rejects outside [0,100] (lib.rs:322) |
+| `<cycle>.phase` | `Peak`\|`Low`\|`Rising`\|`Falling`\|`Critical` | `Critical` wins if within 1 day of a crossing; else Peak `value>0.95` / Low `<−0.95` / sign of cosine (calculator.rs:89-106) |
+| `<cycle>.days_until_peak` | **1 … period** | next sin=1 (phase 0.25); never 0 (wraps to `period`) (calculator.rs:110-124) |
+| `<cycle>.days_until_critical` | **1 … period** | next zero crossing (phase 0.0 or 0.5) (calculator.rs:128-151) |
+| `<cycle>.is_critical` | bool | `|value| < |sin(2π·1/period)|` — within ~1 day of a crossing (calculator.rs:154-161) |
+| `<cycle>.cycle_day` | **0 … period−1** | `days_alive.rem_euclid(period as i64)` (calculator.rs:171) |
+| Cycle periods (days) | P **23** · E **28** · I **33** · intuitive **38** · aesthetic **43** · spiritual **53** | `calculator.rs:14-19` (constants). All six are computed (lib.rs:183-188). |
+| `mastery`/`passion`/`wisdom` | **0 … 100** | composites of `.percentage` (lib.rs:191-193); validate enforces [0,100] (lib.rs:338) |
+| `overall_energy` | **0 … 100** | mean of all six `.percentage` (lib.rs:196-202) |
+| `days_alive` | **≥ 0** | `target − birth` in days; negative ⇒ hard error (lib.rs:175-180) |
+| `critical_days` | array of `YYYY-MM-DD`, len ≤ `forecast_days` | only **physical/emotional/intellectual** crossings counted (calculator.rs:195-197) |
+| `forecast[*]` cycle fields | **0 … 100** (percentages) | `ForecastDay.physical…spiritual` are `to_percentage(...)` (calculator.rs:217-222) — different scale from `CycleResult.value` |
+| `compatibility.<cycle>.score` | **0 … 100** | `50·(1+cos(2π·days_diff_mod_period/period))`; 100 = same phase, 0 = half-period apart (lib.rs:81-94) |
+| `compatibility.overall` | **0 … 100** | mean of physical+emotional+intellectual **only** (intuitive excluded despite being present) (lib.rs:120) |
+
+**Invariants.** All cycles seeded at `days_alive=0` ⇒ every `value=0`, `percentage=50` at birth (tests L415, L431). Cosine derivative drives Rising/Falling. The six cycles are mutually independent (different coprime-ish periods); only `days_alive` couples them. `consciousness_level` is hard-coded `0` (lib.rs:276) and `required_phase=0` (lib.rs:158-160) — ungated.
+
+## 4. Component & brand archetype
+**Today** (`Biorhythm.tsx`): a stat-cell grid (one cell per cycle, value + optional peak/trough sub-labels) above a **600×180 SVG line chart** — a 60-day window (30 past / 30 future, `TOTAL_DAYS`/`PAST_DAYS` L43-44), horizontal zero axis, day gridlines at −30…+30, ±100 amplitude labels, a dashed **"today" vertical marker** at x=300 (L262-270), per-cycle dots at today's value (L273-288), and one `<polyline>` sine per cycle (L248-259). Colors: physical `#ef6b73` (off-brand coral), emotional `var(--c-indigo,#0B50FB)`, intellectual `var(--c-gold,#C5A017)` (`CYCLES` L32-36). **Only 3 of the 6 cycles are drawn** (intuitive/aesthetic/spiritual ignored). The wave is reconstructed client-side from a single current value via `asin` phase inference (L60-89) — the engine's `cycle_day`/`phase` are not used.
+
+**Wave-2 target:** three-wave (extensible to six) sine overlay on Void `#070B1D`, each cycle a luminous sinusoid in its brand hue across the time window, a bright **today marker** at the zero-line intersection, glow on the present-value nodes; brand palette (Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`) — repaint physical to Emerald or Violet (drop the coral) and assign the three secondary cycles their own hues. Waves animate in via stroke-dashoffset on load.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `<cycle>.value` (intended driver) | y-position of the sine + today-dot; **but renderer expects −100..100, struct emits −1..1** — see §7 |
+| `<cycle>.percentage` (0..100) | unused today; the correct signed amplitude is `(percentage−50)/50` → −1..1 |
+| cycle `period` (23/28/33…) | wavelength of each `<polyline>` (`CYCLES[].period`, L82) |
+| `is_critical` / zero crossing | (target) flagged where a wave meets the zero axis; today-marker emphasis |
+| `phase` (Rising/Falling/Peak/Low) | (target) node icon / arrow; today inferred from `asin` branch instead (L74) |
+| `days_until_peak` / `_critical` | (target) "▲ Peak / ▼ Trough" sub-labels — renderer reads non-existent `next_peak`/`next_trough` (L145-146), so these are **always hidden** today |
+| `critical_days[]` | (target) tick marks on the future half of the axis |
+| `forecast[*]` | (target) the future half could be drawn from real forecast points instead of pure client-side sine |
+| `today` marker | fixed dashed vertical at x=`TODAY_X`=300 (L262-270) |
+
+## 6. Dynamics
+**One-shot per (birth_date, target_date).** `target_date = input.current_time.date_naive()` (lib.rs:173) — date-granular, so the result only changes **once per day** (or when birth date / `forecast_days` / `partner_birth_date` options change). Not live/sub-day. `cache_key` hashes engine_id + birth date + target date + `forecast_days` (lib.rs:357-377) — note compatibility/partner is **not** in the cache key. The renderer recomputes the whole 60-day curve from the single current value on each render; nothing animates perpetually today (Wave-2 adds a one-time line-draw). No baseline/delta semantics.
+
+## 7. Open questions / assumptions
+- **🔴 AMPLITUDE-SCALE MISMATCH (confirmed defect, the headline risk).** The renderer treats `result.<cycle>.value` as **−100…+100**: it clamps `val/100` (Biorhythm.tsx:66), plots `sin(asin(val/100))·amplitude`, prints `{val}%`, and labels the axis ±100. But the engine emits `value` on **−1.0…+1.0** (calculator.rs:79-86; enforced [−1,1] at lib.rs:315). So in production `val/100 ≈ ±0.008` → `asin ≈ 0` → **all waves render as near-flat lines on the zero axis and the stat cells read "+1% / −0% / +0%"** instead of the intended ±80%. The correct signed amplitude already exists as `(percentage − 50)/50`. **Fix path (renderer-side, do NOT change in this docs task):** either (a) read `percentage` and map `(percentage−50)/50` → −1..1, then plot `·amplitude` directly (drop the `/100` and `asin`); or (b) multiply `value` by 100 before feeding the existing code. Option (a) is cleaner — `percentage` is the field meant for display.
+- **🔴 Renderer reads fields the engine never emits.** `next_peak`, `next_trough` (L145-146) and `phase_days`/`phaseDays`/`day_in_cycle` (L147) don't exist on `CycleResult`; the engine provides `days_until_peak`, `days_until_critical`, `cycle_day`, `phase`. Consequence: peak/trough sub-labels are always hidden, and phase is inferred via `asin` (principal/ascending branch only, L74) rather than read from `cycle_day`/`phase`. To draw the *correct* curve direction the renderer should use `cycle_day` as the phase seed: `phase = 2π·cycle_day/period`.
+- **🟠 Six cycles emitted, three rendered.** Engine computes physical/emotional/intellectual **+ intuitive(38) + aesthetic(43) + spiritual(53)** (calculator.rs:14-19, lib.rs:183-188) and they're all in `result`; `Biorhythm.tsx` `CYCLES` lists only the first three (L32-36). Also the composites `mastery`/`passion`/`wisdom`, `overall_energy`, `critical_days`, `forecast`, and `compatibility` are all unrendered. README row ("three-wave sine overlay (23/28/33 d)") and the `lib.rs` module doc-comment (L1-5, says "three composite cycles") both undercount the live output — decide whether Wave-2 surfaces all six + composites or stays at three.
+- **🟠 OpenAPI stub is triply wrong** (`types.rs:214`): flat (no `CycleResult` nesting), only 3 of 6 cycles, and its example values (82.4 / 41.7 / −15.2) are on the renderer's phantom signed −100..100 scale — matching neither `value` (−1..1) nor `percentage` (0..100). Update the stub to nested `CycleResult` with realistic values, or document it as illustrative-only.
+- **🟡 Stale `src/types.rs`.** `crates/engine-biorhythm/src/types.rs` declares `BiorhythmResult`/`CycleResult`/`ForecastDay`/`CompatibilityResult` but `lib.rs` re-exports and serializes the **`calculator.rs`** copies (lib.rs:9-13). The `types.rs` copies lack `aesthetic`/`spiritual` and are not the runtime contract; appears dead. Confirm nothing imports `engine_biorhythm::types::*` before relying on / removing it.
+- **🟡 `compatibility.overall` excludes intuitive.** The intuitive score is computed and serialized but the `overall` average uses only the three primary cycles (lib.rs:120); the doc-comment at lib.rs:74-75 says "four available cycles" — comment/code disagree. Cosmetic; flag for the consumer.
+- **🟡 No fixture exists** for biorhythm (no `tests/` dir; only in-crate `#[cfg(test)]` unit tests). Example JSON above is derived from `calculator.rs` math, not captured output. A golden fixture would pin the contract for the web build.

--- a/docs/engines/enneagram.md
+++ b/docs/engines/enneagram.md
@@ -1,0 +1,118 @@
+# Enneagram — Data Reference
+
+A typology of nine interconnected personality patterns. Given an assessment (45 answers) **or** a direct type number, returns the primary type + adjacent wing + integration/disintegration lines + center/group taxonomy. The Enneagram is framed throughout as *patterns of perception*, **not** fixed identity.
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `enneagram` (verified — `ts-engines/src/engines/enneagram/engine.ts:87`, bridge `crates/noesis-bridge/src/lib.rs:273`, renderer router `apps/noesis-web/app/readings/[id]/page.tsx:49`) |
+| Crate | **— (no Rust engine; OpenAPI stub + renderer)** |
+| Runtime source | **TypeScript engine** `ts-engines/src/engines/enneagram/engine.ts` (`EnneagramEngine`), registered `ts-engines/src/index.ts:25`, served `POST /engines/enneagram/calculate` (`ts-engines/src/server/app.ts:145`). Reached from Rust via `noesis-bridge` `BridgeEngine::enneagram()` (`crates/noesis-bridge/src/lib.rs:267-273`) → HTTP `{TS_ENGINES_URL}/engines/enneagram/calculate` (`lib.rs:368`, default `http://localhost:3001`, `lib.rs:42`). **Not** "unconfirmed" — README.md:58 predates this trace; correct it. |
+| Renderer | `apps/noesis-web/src/components/engines/Enneagram.tsx` |
+| Wisdom data (all 9 types) | `ts-engines/src/engines/enneagram/wisdom.ts:38` (`ENNEAGRAM_TYPES`), connections `wisdom.ts:419` (`ENNEAGRAM_CONNECTIONS`) |
+| Assessment (45 Q + scoring) | `ts-engines/src/engines/enneagram/assessment.ts:39` |
+| OpenAPI stub | `crates/noesis-core/src/types.rs:313` (`EnneagramResultSchema` — `core_type:i32` / `wing:String` / `archetype:String`) |
+| Fixture (real values) | **none found** — no JSON fixture; the wisdom data IS the source of truth |
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — the shape `Enneagram.tsx` reads).** The TS engine emits a `result` object with a `mode` discriminant and up to three sub-objects (`engine.ts:32-37`). The renderer consumes `result.assessment` and `result.typeAnalysis`:
+
+```jsonc
+{
+  "mode": "assessment",                  // "assessment" | "lookup" | "questions"  (engine.ts:33)
+  "assessment": {                        // present in assessment mode (answers provided)
+    "scores": [ { "type": 4, "normalizedScore": 82 }, … ],   // 9 entries, sorted desc
+    "primaryType": { "number": 4, "name": "The Individualist", "description": "…" },
+    "wing":        { "number": 5, "name": "The Investigator",  "description": "…" },
+    "confidence":  0.73,                 // 0–1  (renderer shows Math.round(c*100)%)
+    "tritype":     [4, 8, 6],            // optional; one per center, only when confidence ≥ 0.3
+    "note": "These results indicate pattern tendencies, not fixed identity…"
+  },
+  "typeAnalysis": {                      // present in BOTH assessment & lookup modes
+    "type": {
+      "number": 4, "name": "The Individualist",
+      "coreFear": "Having no identity…", "coreDesire": "To find themselves…",
+      "coreWeakness": "Envy—…",
+      "description": "…", "keyMotivations": ["…"],
+      "healthyTraits": ["…"], "averageTraits": ["…"], "unhealthyTraits": ["…"]
+    },
+    "wings":          [ { "number": 3, "name": "The Achiever" }, { "number": 5, "name": "The Investigator" } ],
+    "integration":    { "type": 1, "name": "The Reformer",  "description": "Fours access objectivity…" },
+    "disintegration": { "type": 2, "name": "The Helper",    "description": "Fours become clingy…" },
+    "center":         "heart",           // gut | heart | head
+    "hornevianGroup": "withdrawn",       // assertive | compliant | withdrawn
+    "harmonicGroup":  "reactive"         // positive | competency | reactive
+  }
+}
+```
+In **lookup mode** (a `type` number was passed, no answers) only `typeAnalysis` is present — no `assessment`, so the renderer's Wing/Confidence/Core-Desire/Core-Fear cells (which read `assessment.*` / `primaryType.*`) go blank; see §7. In **questions mode** `result` is `{ mode, questions: [{id,text,scale}] }` — the 45 assessment items, which the renderer does not handle (falls through to `GenericEngineView`).
+
+**Envelope.** The TS engine returns its own envelope `{ engine_id, result, witness_prompts[], calculated_at, processing_time_ms }` (`engine.ts:207-213`). The bridge maps it into the standard Rust `EngineOutput` (`crates/noesis-bridge/src/lib.rs:439-456`): `witness_prompts[0].prompt` → `witness_prompt`, `consciousness_level` ← `required_phase` (=**1**), `metadata.backend="typescript"`.
+
+**OpenAPI stub** (`types.rs:313`): `{ core_type: 4, wing: "4w5", archetype: "Individualist" }` — examples only. **None of these three field names exist in the runtime JSON** (it uses nested `assessment.primaryType.number` / `wing.number` / `primaryType.name`). The stub is a hand-written illustration, not the contract.
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| type `number` | **1–9** integer | validated `engine.ts:216-229`; renderer guards `>=1 && <=9` (`Enneagram.tsx:182`) |
+| `wing.number` | **adjacent type only** | must equal `n−1` or `n+1` (wrap 9↔1); enforced `engine.ts:242-255`, `assessment.ts:430-434`. Each type's two wings: `wisdom.ts` `wings:[a,b]` |
+| `confidence` | **0–1** | `(top.norm − 2nd.norm)/30`, capped at 1 (`assessment.ts:394-397`); rounded to 2 dp in output (`engine.ts:279`) |
+| `scores[].normalizedScore` | **0–100** | `raw/maxPossible*100`, rounded (`assessment.ts:383`); array length 9, sorted desc |
+| `tritype` | 3 types, one per center | present only when `confidence ≥ 0.3` (`assessment.ts:405`); centers gut[8,9,1]/heart[2,3,4]/head[5,6,7] (`assessment.ts:440-442`) |
+| `center` | `gut` \| `heart` \| `head` | renderer prints `"{center} Center"` (`Enneagram.tsx:200`) |
+| `hornevianGroup` | `assertive` \| `compliant` \| `withdrawn` | static per type (`wisdom.ts`) |
+| `harmonicGroup` | `positive` \| `competency` \| `reactive` | static per type |
+| `integration.type` / `disintegration.type` | **1–9** (or `0`=Unknown fallback) | from `ENNEAGRAM_CONNECTIONS` (`wisdom.ts:419`); `0/"Unknown"` only if lookup fails (`engine.ts:326,333`) |
+| assessment input `answers` | **array of 45**, each **1–5** | clamped to 1–5 (`assessment.ts:425`); 5 questions × 9 types; high-signal questions weighted **1.5**, rest **1.0** (`assessment.ts`) |
+| `required_phase` (consciousness gate) | **1** | engine refuses if `consciousness_level < 1` (`server/app.ts:160`, `engine.ts:91`) |
+
+**Canonical type table** (`wisdom.ts` — name · center · integration→ · disintegration→ · wings):
+
+| # | Name | Center | Integration → | Disintegration → | Wings |
+|---|---|---|---|---|---|
+| 1 | The Reformer | gut | 7 | 4 | 9, 2 |
+| 2 | The Helper | heart | 4 | 8 | 1, 3 |
+| 3 | The Achiever | heart | 6 | 9 | 2, 4 |
+| 4 | The Individualist | heart | 1 | 2 | 3, 5 |
+| 5 | The Investigator | head | 8 | 7 | 4, 6 |
+| 6 | The Loyalist | head | 9 | 3 | 5, 7 |
+| 7 | The Enthusiast | head | 5 | 1 | 6, 8 |
+| 8 | The Challenger | gut | 2 | 5 | 7, 9 |
+| 9 | The Peacemaker | gut | 3 | 6 | 8, 1 |
+
+**Invariants:** integration lines form the two classic cycles — triangle **3→6→9→3** and hexad **1→4→2→8→5→7→1**; disintegration is the reverse traversal of the same edges. The renderer hard-codes these exact paths (`Enneagram.tsx:46-48` `HEXAD`/`TRIANGLE`), independent of the result — so the geometry is always drawn; only the *lit* nodes are data-driven. Wing ⊂ {type's two neighbours}. Tritype picks the top-scoring type from each of the three centers.
+
+## 4. Component & brand archetype
+**Today** (`Enneagram.tsx`): a **9-point enneagram SVG** (220×220, `CX/CY=110`, `R=90`; type 9 at top −90°, clockwise at 40° steps, `typeAngle` L27) drawing the outer circle + gold hexad + gold triangle, with 9 numbered nodes — **active type** node enlarged + emerald fill + glow (`#enn-glow`), **wing** node indigo, others faint gold (`Enneagram.tsx:113-131`). Below: a cell grid (Type number · Archetype+Center · Wing · Triad¹ · Confidence) and two callout bars — **Core Desire** (emerald rule) and **Core Fear** (danger rule). Already on-brand (gold `#C5A017`, emerald `#10B5A7`/`rgba(16,181,167)`, indigo `#0B50FB`, sacred-geometry figure, glow filter).
+
+¹ The renderer reads `primary?.triad` (`Enneagram.tsx:177,208`) but the engine emits **`center`**, not `triad` — the Triad cell is **always blank** (see §7).
+
+**Wave-2 target:** the brand archetype is exactly this figure, elevated — the type node lit as the bioluminescent core, the wing adjacent, and **directional arrows** along the classic geometry: an **integration arrow** (growth) and a **disintegration arrow** (stress) drawn from the type node to `typeAnalysis.integration.type` / `.disintegration.type`, animated in on load (Anime.js stroke-dashoffset). Center (gut/heart/head) tints the three-node arc the type belongs to.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `primaryType.number` (1–9) | active node — emerald fill + 1.6 stroke + glow, radius 10 (`Enneagram.tsx:113-118`); also the big `typeNum` cell |
+| `wing.number` | wing node — indigo fill/stroke, radius 9 (`Enneagram.tsx:119-124`); Wing cell `n · name` |
+| `primaryType.name` / `typeAnalysis.type.name` | Archetype cell (gold) |
+| `center` | "{center} Center" sub-label; (target) tints the gut/heart/head node-triad |
+| `confidence` (0–1) | Confidence cell `round(c·100)%` |
+| `typeAnalysis.type.coreDesire` | emerald-ruled Core Desire callout |
+| `typeAnalysis.type.coreFear` | danger-ruled Core Fear callout |
+| `integration.type` → | (target) growth arrow along hexad/triangle edge |
+| `disintegration.type` → | (target) stress arrow (reverse edge) |
+| hexad `1→4→2→8→5→7→1`, triangle `3→6→9→3` | static gold polylines, drawn regardless of data (`Enneagram.tsx:46-48,84-99`) |
+| (unused) `triad` | Triad cell — never populated (engine emits `center`) |
+| (unused) `scores[]`, `tritype`, `note`, `keyMotivations`, `healthy/average/unhealthyTraits`, `wings[]`, `hornevianGroup`, `harmonicGroup` | computed + returned but **not rendered** today |
+
+## 6. Dynamics
+**One-shot per input.** Two trigger shapes: (a) **assessment** — 45 answers in, full `assessment` + `typeAnalysis` out; (b) **lookup** — a `type` (+ optional `wing`) in, `typeAnalysis` only. Deterministic given inputs (witness-prompt wording uses a seeded RNG, `witness.ts` + `seed` param, `engine.ts:136`; the *result* fields are pure lookups/sums). Not live, no recompute cadence, no baseline/delta. On render the figure should animate in once (line-draw of circle/hexad/triangle, then nodes); no perpetual loop. `consciousness_level` must be **≥1** to call at all (gate, §3); deeper levels could progressively reveal the unused traits/motivations blocks.
+
+## 7. Open questions / assumptions
+- **⚠️ No Rust engine — but a real TS engine produces it (CALL-OUT).** Unlike the Vedic engines there is **no `engine-enneagram` crate**; the registry README (README.md:43,58) lists it as "stub only / runtime source unconfirmed." That is now **confirmed**: the producer is the **TypeScript `EnneagramEngine`** (`ts-engines/src/engines/enneagram/`), invoked over HTTP through `noesis-bridge` (`crates/noesis-bridge/src/lib.rs:267-273,368,439-456`). README.md row 58 should be updated `unconfirmed → ts-engines`. (Same pattern applies to Tarot, I-Ching, Sacred-Geometry, Sigil-Forge — all have `ts-engines/src/engines/*` implementations.)
+- **Stub ≠ contract.** `EnneagramResultSchema` (`types.rs:313`: `core_type`/`wing`/`archetype`) shares **no field names** with the runtime JSON. It is OpenAPI illustration only. Build Wave-2 against the renderer + `engine.ts` shape, not the stub.
+- **Renderer reads `triad`, engine emits `center` (confirmed defect).** `Enneagram.tsx:177,208` → `primary?.triad`; nothing in the result sets `triad`. The Triad cell never shows. Either rename the cell to use `typeAnalysis.center`, or have the engine also emit `triad`. Low-risk doc-flag, not fixed here.
+- **Lookup mode hides half the UI.** In `mode:"lookup"` there is no `assessment` block, so `primaryType`/`wing`/`confidence`/`coreDesire`/`coreFear` are undefined for the renderer (it reads them off `assessment` / `primaryType`, `Enneagram.tsx:167-180`) → only the figure + (empty) cells render. The renderer's `primary = assessment?.primaryType ?? typeAnalysis?.type` fallback (L169) recovers the type node + archetype + core fear/desire (those live on `typeAnalysis.type` too), but **Wing** and **Confidence** stay blank in lookup mode. Confirm which mode the reading pipeline actually uses.
+- **Instinctual variants (sp/so/sx) are absent.** The domain commonly adds a self-preservation/social/sexual subtype; the engine does **not** compute or emit it. Not a gap in this doc — just noting it's out of scope of the current data model. Health *levels* (1–9) are also not numerically emitted; instead the engine gives `healthy/average/unhealthyTraits` lists (`wisdom.ts`).
+- **No fixture.** Unlike the Vedic engines there's no reference JSON; correctness rests on the `wisdom.ts` tables + assessment math. The orchestrator's `mock_enneagram_output` (`crates/noesis-orchestrator/src/workflow/synthesis/self_inquiry.rs:648`) is a **test mock**, not a runtime producer — don't mistake it for the contract.

--- a/docs/engines/face-reading.md
+++ b/docs/engines/face-reading.md
@@ -1,0 +1,104 @@
+# Face Reading — Data Reference
+
+Constitutional analysis from facial features, fusing **Ayurvedic dosha** typing, **TCM Five Elements (Mian Xiang)**, and **Western physiognomy** — into a constitution, an elemental balance, personality traits, and per-zone health indicators. **Stub engine:** no image processing yet; output is deterministic-heuristic / mock (`crates/engine-face-reading/src/lib.rs:8-11`).
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `face-reading` (verified `engine.rs:40`; asserted `engine.rs:412-413`) |
+| Domain crate | `crates/engine-face-reading/src/models.rs` (`FaceAnalysis`, L12) + `src/wisdom.rs` (`FaceZoneWisdom`, L12) |
+| Runtime source | **`crates/engine-face-reading/src/engine.rs`** — `serialize_analysis()` L143-199 builds the JSON; values from `mock.rs` (`generate_mock_analysis` L15) or `engine.rs` heuristics (`heuristic_from_seed` L45) |
+| Renderer | `apps/noesis-web/src/components/engines/FaceReading.tsx` |
+| Fixture (real values) | **none** — no `tests/` dir in the crate; runtime values come from the mock/heuristic generators (see §3) |
+| OpenAPI stub | `noesis-core/src/types.rs:280` (`FaceReadingResultSchema` — `constitutional_type`/`confidence`/`key_observation`) |
+
+> ⚠️ The renderer is **not yet wired into any router** (no file imports `FaceReading.tsx` except itself; same for the other Wave-2 renderers). It is a draft to build against, not yet mounted.
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — exactly what `serialize_analysis` emits, `engine.rs:147-198`):**
+```jsonc
+{
+  "analysis": {
+    "constitution": {
+      "primary_dosha":   "vata",          // enum, snake_case (models.rs:168)
+      "secondary_dosha": "pitta",         // enum | null  (Option<Dosha>, models.rs:31)
+      "tcm_element":     "metal",          // enum, snake_case (models.rs:197)
+      "body_type":       "ectomorph",      // enum, snake_case (models.rs:243)
+      "descriptions": { "dosha": "...", "element": "...", "body_type": "..." } // prose, engine.rs:154-158
+    },
+    "personality_indicators": [            // 3–5 items (mock.rs:160) | exactly 2 (heuristic, engine.rs:85-99)
+      { "trait_name": "Analytical Thinker", "facial_indicator": "high forehead", "description": "..." }
+    ],
+    "elemental_balance": {                 // five f64 proportions that SUM TO 1.0 (see §3)
+      "wood": 0.21, "fire": 0.18, "earth": 0.23, "metal": 0.19, "water": 0.19,
+      "dominant": "earth"                  // ⚠️ injected at serialize (engine.rs:173) — NOT a struct field
+    },
+    "health_indicators": [                 // 2–3 items (mock.rs:265) | exactly 2 (heuristic, engine.rs:101-115)
+      { "zone": "forehead", "associated_organ": "Bladder/Small Intestine", "observation": "..." }
+    ],
+    "is_mock_data": true                   // true for mock path; false for birth/image heuristic (engine.rs:116, mock.rs:26)
+  },
+  "notice":       "This is simulated analysis...",   // varies by path (engine.rs:184-188)
+  "traditions":   ["Chinese Mian Xiang", "Ayurvedic Face Analysis", "Western Physiognomy"],
+  "future_capabilities": ["Real-time facial landmark detection", "Photo-based analysis", ...],
+  "disclaimer":   "...not...for medical diagnosis..."  // engine.rs:197
+}
+```
+
+**Domain struct `FaceAnalysis` (models.rs:12):** `constitution: ConstitutionAnalysis` (L27) · `personality_indicators: Vec<PersonalityTrait>` (L40) · `elemental_balance: ElementalBalance` (L51) · `health_indicators: Vec<HealthIndicator>` (L107) · `is_mock_data: bool`. The struct has **no `confidence`, no `vitality`, no `facial_features`/`face_shape`/`eyes`** — see §7.
+
+**OpenAPI stub:** `{ constitutional_type:"vata-pitta", confidence:0.81, key_observation:"soft jawline with high brow curvature" }` — examples only. **None of these three field names exist in the runtime JSON** (§7).
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `constitution.primary_dosha` | `vata` \| `pitta` \| `kapha` | Ayurvedic dosha, single (models.rs:169-173) |
+| `constitution.secondary_dosha` | same enum **\| `null`** | `Option` — present ~60% in mock (`gen_bool(0.6)`, mock.rs:38); never equals primary (mock.rs:39) |
+| `constitution.tcm_element` | `wood`\|`fire`\|`earth`\|`metal`\|`water` | mock correlates element to dosha (mock.rs:46-50) |
+| `constitution.body_type` | `ectomorph`\|`mesomorph`\|`endomorph` | Western somatotype (models.rs:244-248) |
+| `elemental_balance.{wood,fire,earth,metal,water}` | `f64`, **proportions in (0,1)** | **sum = 1.0** (invariant) — *not* 0–100, *not* integers |
+| `elemental_balance` per-value | ≈ **0.07–0.57** in practice | mock draws each in `0.1..0.4` then normalizes (mock.rs:176-188); heuristic draws `(seed%97)/100` floored at 0.1 then normalizes (engine.rs:69-76) |
+| `elemental_balance.dominant` | element enum | `argmax` of the five (models.rs:77-90); ties → first-max |
+| `personality_indicators[]` | 3–5 (mock) or 2 (heuristic) | each `{trait_name, facial_indicator, description}` strings (models.rs:40-47) |
+| `health_indicators[].zone` | one of **10** `FaceZone` | `forehead, eyebrows, eyes, nose, cheeks, mouth, chin, ears, jawline, temples` (models.rs:119-130) |
+| `health_indicators[]` | 2–3 (mock) or 2 (heuristic) | each `{zone, associated_organ, observation}` strings (models.rs:107-114) |
+| `is_mock_data` | `bool` | ⚠️ doc-comment says "Always true" (models.rs:21) but is **false** on birth/image paths (engine.rs:116) |
+| `consciousness_level` | **0–5** envelope; engine default **2** | read from `options` (engine.rs:255-260); witness buckets span 0–6 (witness.rs:28-33), exceeding the envelope's 0–5 |
+| ~~`confidence`~~ | — | **does not exist** in runtime (stub-only, types.rs:283) |
+
+**`ElementalBalance` sums to 1.0 — confirmed three ways:** `normalize()` divides by the sum (models.rs:93-102); both generators normalize (mock.rs:182-188, engine.rs:76); test `test_elemental_balance_sums_to_one` asserts `(sum-1.0).abs() < 0.001` (mock.rs:324-329). **Render as proportions (0–1), scale ×100 for display.**
+
+**Determinism:** same `seed` → same constitution (engine.rs:472-483; mock.rs:291-303). Three input paths pick the generator (engine.rs:234-252): `image_data` → image heuristic; else `birth_data` → birth heuristic; else → seeded/entropy mock. The two heuristic paths emit fixed 2-trait / 2-indicator lists (engine.rs:85-115); only the mock path uses the rich 14-trait / 13-indicator pools (mock.rs:87-263).
+
+## 4. Component & brand archetype
+**Today** (`FaceReading.tsx`): a flat **card grid** — Primary Dosha (+secondary sub), Element, Vitality, Face Shape, Eyes — plus a "Facial Features" key/value list (first 8 entries). Pure text, brand gold (`var(--gold)`) on `var(--field)` cards; **no geometry**. Critically, it reads a *different schema* than the engine emits (§7), so against real output most cells render `—` and the feature list is empty → it falls through to `GenericEngineView` (the guard at `FaceReading.tsx:26` fires only if `analysis`/`constitution`/`features` are all absent; `analysis` **is** present, so it renders the near-empty grid instead).
+
+**Wave-2 target (brand archetype):** **face proportion grid + elemental balance** — a **three-zone face map** (forehead / midface / jaw) drawn with measurement ticks (calliper aesthetic), the active zones lit on the Ba-Arc; **vata / pitta / kapha as arc gauges** (radial sweeps, *not* bars) for the constitution; the **five TCM elements as a pentagon / radar** whose vertices read the `elemental_balance` proportions; `dominant` element = bioluminescent core. Brand palette: Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`. Health-zone observations attach as tooltips on the corresponding face-map zone (data the engine already emits but the current renderer drops).
+
+> Note: the three-zone face map (forehead/midface/jaw) is the **brand** model; the engine's `FaceZone` enum has **10** zones (§3) — map the 10 zones onto the 3 bands (e.g. forehead+eyebrows+temples → upper; eyes+nose+cheeks → mid; mouth+chin+jawline+ears → lower).
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `constitution.primary_dosha` | dominant arc gauge (largest sweep) + center label; hue per dosha |
+| `constitution.secondary_dosha` | second arc gauge (smaller); hidden when `null` |
+| `elemental_balance.{wood…water}` (5 × 0–1) | pentagon/radar vertices, radius = proportion ×100; or 5 arc gauges |
+| `elemental_balance.dominant` | lit vertex + bioluminescent core color |
+| `constitution.tcm_element` | accent color of the elemental ring (Wood→green, Fire→red, Earth→gold, Metal→white, Water→indigo) |
+| `constitution.body_type` | face-map silhouette proportion (ecto=narrow/long, meso=defined, endo=round/soft) — cf. `dosha_facial_signs()` shapes (wisdom.rs:420-444) |
+| `health_indicators[].zone` (10→3 bands) | corresponding face-map zone lit; `observation` + `associated_organ` as tooltip |
+| `personality_indicators[]` | labelled callouts pinned to `facial_indicator` region (e.g. "high forehead" → upper band) |
+| `is_mock_data` / `notice` | "simulated" badge / disclaimer banner — must stay visible while stubbed |
+
+## 6. Dynamics
+**One-shot.** Not live. Recompute when the input changes — `image_data`, then `birth_data`, else `seed` (engine.rs:234-252; `cache_key` keys on seed-or-birth-fragment, engine.rs:352-377). No baseline/delta semantics. On render the arc gauges + radar should animate in once (line-draw / sweep); an optional slow core breath on the `dominant` vertex is fine — no perpetual loop. `consciousness_level` (default 2) gates only the **witness prompt** depth (foundational 0-2 / awareness 3-4 / integration 5-6, witness.rs:28-33), not the `result` payload — every level emits the same analysis fields. Engine `required_phase = 1` (engine.rs:218-220): needs self-reflection capacity.
+
+## 7. Open questions / assumptions
+- **ElementalBalance normalization — RESOLVED: sums to 1.0** (proportions, not percentages, not integers). Cited three ways in §3. Multiply ×100 only for display.
+- **Renderer ↔ engine schema mismatch (CONFIRMED, the big one):** `FaceReading.tsx` reads `analysis.facial_features` / `face_shape` / `eyes` / `eye_type` / `vitality_score` and `constitution.dosha` + top-level `element` (tsx L22-33) — **none of which the engine emits.** The engine emits `constitution.primary_dosha`, nested `constitution.tcm_element` (no top-level `element`), and `personality_indicators` / `health_indicators` / `elemental_balance` (which the renderer **ignores entirely**). The renderer was clearly built against an anticipated MediaPipe shape, not the current stub. **Wave-2 must rebuild the renderer against the §2 runtime JSON** (or the engine must change). Until then it shows a near-empty grid.
+- **Stub ↔ runtime field mismatch:** OpenAPI `FaceReadingResultSchema` (types.rs:280-287) advertises `constitutional_type` ("vata-pitta"), `confidence` (0.81), `key_observation` — **all three absent from runtime.** Runtime splits dosha into `primary_dosha` + `secondary_dosha`, has **no confidence score anywhere**, and has no single `key_observation` (closest is `personality_indicators[].facial_indicator`). If the API contract promises `confidence`, the engine does not produce it. Treat the stub as aspirational naming only.
+- **`is_mock_data` semantics:** doc-comment "Always true for stub implementation" (models.rs:21) contradicts the code, which sets it **false** for birth-data and image-data paths (engine.rs:116) and `true` only for the pure mock path (mock.rs:26). The "non-mock" paths are still heuristic, not real CV — the `false` flag could mislead the UI into hiding the simulated-data disclaimer. Confirm intended UX.
+- **`elemental_balance.dominant` is serialization-only** (engine.rs:173) — present in JSON, absent from the `ElementalBalance` struct and from the OpenAPI stub. Safe to read from runtime JSON; don't expect it in any Rust-typed mirror.
+- **`witness.rs` wisdom is under-used:** `FaceZoneWisdom` (wisdom.rs:12) and `dosha_facial_signs()` (wisdom.rs:420) carry rich per-zone TCM/Ayurvedic/emotional correlations and per-dosha facial shapes that **never reach `result`** (only used to phrase witness prompts). A richer renderer could surface these, but it would need the engine to include them in the payload first.
+- **No fixture:** unlike Panchanga, there is no reference JSON to diff against; the §2 example is hand-derived from `serialize_analysis`. Generating a `tests/` fixture (e.g. `seed=42`) would give Wave-2 a stable target.

--- a/docs/engines/gene-keys.md
+++ b/docs/engines/gene-keys.md
@@ -1,0 +1,114 @@
+# Gene Keys — Data Reference
+
+The 64 Gene Keys derived from the Human Design gates: each gate becomes a contemplative archetype with a **Shadow → Gift → Siddhi** frequency spectrum and a **Line (1–6)**, organised into sequences. This engine emits the **Activation Sequence** (the four prime gifts) plus every active key enriched with frequency data.
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `gene-keys` (verified — `engine.rs:36`, and dispatcher `app/readings/[id]/page.tsx:38` `case "gene-keys"`) |
+| Domain crate | `crates/engine-gene-keys/src/` (`GeneKeysChart`, `models.rs:172`) |
+| Runtime source | **`crates/engine-gene-keys/src/engine.rs`** — `serialize_chart` (L222) is the literal `result` JSON; depends on `engine-human-design` to derive gates |
+| Renderer | `apps/noesis-web/src/components/engines/GeneKeys.tsx` |
+| Fixture (real values) | `crates/engine-gene-keys/tests/reference_charts.json` (8 charts; HD gates → expected sequence pairs) |
+| OpenAPI stub | `noesis-core/src/types.rs:236` (`GeneKeysResultSchema` — `activation_sequence`/`venus_sequence`/`pearl_sequence`, all `String`) |
+
+> ⚠️ This engine is the strongest example in the repo of the **three-layer mismatch** from the [README](README.md#️-three-schema-layers-read-this-before-trusting-any-one-source). Runtime, renderer, and stub describe three *incompatible* shapes. Read §7 before building.
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — exactly what `serialize_chart` emits, `engine.rs:248-257`):**
+```jsonc
+{
+  "activation_sequence": {                 // an OBJECT of four gate-pairs (NOT a string, NOT spheres)
+    "lifes_work": [17, 18],                // [personality_sun, personality_earth]
+    "evolution":  [45, 26],                // [design_sun,      design_earth]
+    "radiance":   [17, 45],                // [personality_sun, design_sun]
+    "purpose":    [18, 26]                 // [personality_earth, design_earth]
+  },
+  "active_keys": [                         // one per HD gate activation (models.rs:54 GeneKeyActivation)
+    {
+      "key_number": 17,                    // 1–64
+      "line": 4,                           // 1–6
+      "source": "PersonalitySun",          // Debug-formatted enum, e.g. "DesignEarth" (engine.rs:231)
+      "name": "The Eye",                   // present only if gene_key_data was attached
+      "shadow": "Opinion", "gift": "Far-Sightedness", "siddhi": "Omniscience"
+    }
+    // …
+  ],
+  "frequency_assessments": [               // assess_frequencies(), frequency.rs:82 — per active key
+    {
+      "gene_key": 17, "name": "The Eye",
+      "shadow": "Opinion", "gift": "Far-Sightedness", "siddhi": "Omniscience",
+      "shadow_description": "…", "gift_description": "…", "siddhi_description": "…",
+      "suggested_frequency": "Gift",       // "Shadow"|"Gift"|"Siddhi"|null — gated by consciousness_level
+      "recognition_prompts": { "shadow": ["…"], "gift": ["…"], "siddhi": ["…"] }
+    }
+  ]
+}
+```
+The fixture only asserts the **`activation_sequence` pairs** (`reference_charts.json` `expected.{lifes_work,evolution,radiance,purpose}`); it does not capture `active_keys`/`frequency_assessments` (the engine attaches those at runtime from `wisdom.rs`).
+
+**Domain structs (`engine-gene-keys/src/models.rs`):**
+- `GeneKeysChart` (L172) = `{ activation_sequence: ActivationSequence, active_keys: Vec<GeneKeyActivation> }`. **Note: the struct has no `frequency_assessments` field** — it is added only by `serialize_chart` (engine.rs:246,256), so the runtime JSON is a superset of the struct.
+- `ActivationSequence` (L142) = four `(u8, u8)` tuples `lifes_work / evolution / radiance / purpose`, built by `from_activations(personality_sun, personality_earth, design_sun, design_earth)` (L155).
+- `GeneKeyActivation` (L54) = `{ key_number:u8, line:u8, source:ActivationSource, gene_key_data:Option<GeneKey> }`.
+- `GeneKey` (L8) = `{ number:u8, name, shadow, gift, siddhi, shadow_description, gift_description, siddhi_description, programming_partner:Option<u8>, codon:Option<String>, amino_acid:Option<String>, physiology:Option<String>, keywords:Vec<String>, life_theme:Option<String> }` — but `serialize_chart` only forwards `name/shadow/gift/siddhi` into `active_keys`; the descriptions reach the wire **only** via `frequency_assessments`.
+- `ActivationSource` (L67) = enum of 26 named planet×{Personality,Design} variants + `Other(String)`; serialized via Rust `Debug` (`"PersonalitySun"`, …), **not** snake_case.
+- `FrequencyAssessment` (`frequency.rs:25`) and `RecognitionPrompts` (`frequency.rs:60`) — shapes shown above.
+
+**OpenAPI stub (`types.rs:236`, docs only):** `{ activation_sequence:String, venus_sequence:String, pearl_sequence:String }`. **All three fields are wrong/absent at runtime:** `activation_sequence` is an *object*, not a string; `venus_sequence` and `pearl_sequence` **are never produced** (see §7).
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `key_number` / `gene_key` / sequence pair members | **1–64** | 1:1 with HD gates (`models.rs:9,57`); fixture covers boundaries 1, 2, 63, 64 (Ref 3) |
+| `line` | **1–6** | hexagram line (`models.rs:58`); derived from the gate's positional fraction in the HD engine |
+| `activation_sequence.*` | `[u8; 2]` | each is a **pair of gate numbers**, not a single key; see derivation below |
+| `source` | one of 26 variants + `Other` | `Personality*` / `Design*` × {Sun,Earth,Moon,N/S Node,Mercury,Venus,Mars,Jupiter,Saturn,Uranus,Neptune,Pluto} (`models.rs:68-95`) |
+| `suggested_frequency` | `Shadow` \| `Gift` \| `Siddhi` \| `null` | from `consciousness_level`: 0–2→Shadow, 3–4→Gift, 5–6→Siddhi, else null (`frequency.rs:116-123`) |
+| `frequency_assessments[].*_description` | non-empty strings | archetypal copy from `wisdom.rs` (`get_gene_key`) |
+| `recognition_prompts.{shadow,gift,siddhi}` | `string[]` | self-inquiry prompts, not predictions (`frequency.rs:5`) |
+
+**Sequence derivation invariant** (`ActivationSequence::from_activations`, `models.rs:155-167`, confirmed by every fixture row):
+```
+lifes_work = (personality_sun,   personality_earth)
+evolution  = (design_sun,        design_earth)
+radiance   = (personality_sun,   design_sun)
+purpose    = (personality_earth, design_earth)
+```
+So the four sequences are the **2×2 grid** of {Personality,Design}×{Sun,Earth}: rows = the two activation pairs, columns = Sun-axis (Radiance) and Earth-axis (Purpose). The four pairs reuse exactly four distinct gates — they are not independent.
+
+**Frequency-band semantics** (the spectrum, not a numeric range): every key has three named bands — **Shadow** (reactive/unconscious), **Gift** (conscious/constructive), **Siddhi** (transcendent) — `models.rs:15-23`, mirrored by `Frequency` enum `frequency.rs:12`. There is **no birth-determined frequency**: the module is explicit that frequency depends on lived consciousness and must be self-identified (`frequency.rs:3-5`). `required_phase()` for this engine is **2** (`engine.rs:278`) — deeper than HD.
+
+## 4. Component & brand archetype
+**Today** (`GeneKeys.tsx`): a responsive **grid of "Sphere" cards** (`sphereGrid`, `auto-fit minmax(240px,1fr)`). Each card shows a name, an optional `Gate {n}`, and a **`<Spectrum>`** — a fixed three-stop gradient bar (Shadow `#C65D3B` terracotta → Gift `#10B5A7` emerald → Siddhi `#C5A017` gold, `SPECTRUM_GRADIENT` L5) with three labelled tick columns. It renders the four named spheres `["Life's Work","Evolution","Radiance","Purpose"]` (L109) and an optional **Programming Partner** line. **It is purely text + a static bar — no rings, no per-key geometry, no line (1–6) shown.** Colours already match brand (terracotta/emerald/gold).
+
+**Critical:** the renderer reads `activation.spheres` / per-sphere objects with `{gate, shadow, gift, siddhi}` **strings** — a shape the engine **does not emit** (see §7). Against real runtime JSON every card currently shows gate `—` and Shadow/Gift/Siddhi `—`.
+
+**Wave-2 target — hologenetic sequence rings.** The three sequences as **constellation paths** between spheres on a circle: each Gene Key a **node** plotted by gate (1–64 → angle), with edges drawn as the sequence paths. Activation Sequence = the four prime nodes joined into the 2×2 grid (Life's Work–Evolution rows, Radiance–Purpose columns). Each node renders its **Shadow→Gift→Siddhi** as a short radial gradient spoke (reuse the existing terracotta→emerald→gold ramp), with the **line 1–6** as a 6-tick subdivision on the node. Brand palette: Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`. Paths drawn-in on load (Anime.js `stroke-dashoffset`). **Venus and Pearl sequences are aspirational** (named in the stub) — do not render rings for them until the engine emits them (§7).
+
+## 5. Data → visual mapping
+| Field | Visual (today → Wave-2) |
+|---|---|
+| `activation_sequence.lifes_work[0]` (= personality_sun gate) | sphere/node "Life's Work"; gate label → node angle on the 64-ring |
+| `activation_sequence.evolution` pair | "Evolution" node(s); edge along the Design row |
+| `activation_sequence.radiance` pair | "Radiance" node(s); edge along the Sun column |
+| `activation_sequence.purpose` pair | "Purpose" node(s); edge along the Earth column |
+| `frequency_assessments[].{shadow,gift,siddhi}` | the three labels under each spectrum bar (today the renderer reads sphere-level strings instead — broken; should read these) |
+| `frequency_assessments[].suggested_frequency` | (target) which band of the node's spectrum spoke is lit |
+| `active_keys[].line` (1–6) | **not rendered today**; Wave-2: 6-tick subdivision on the node |
+| `active_keys[].source` | (target) node grouping / label (Personality vs Design ring) |
+| `GeneKey.programming_partner` | `Programming Partner` text line (`partner`, GeneKeys.tsx:206,245) — **note:** engine `serialize_chart` does **not** emit `programming_partner`, so this line is always hidden at runtime (§7) |
+
+## 6. Dynamics
+**One-shot per birth chart.** Computed from `birth_data` (via the HD engine, `engine.rs:284-295`) or directly from supplied `hd_gates` options (`engine.rs:473`). Not live; recompute only if birth data changes. The **only** dynamic input is envelope `consciousness_level` (0–5; engine validates ≤6, `engine.rs:386`): it sets `suggested_frequency` per key (`frequency.rs:116`) — i.e. raising the user's level shifts highlighted bands Shadow→Gift→Siddhi without recomputing gates. `witness_prompt` is generated from the chart + level (`witness.rs`, via `generate_witness_prompt`, engine.rs:322). On render, sequence paths/nodes should animate in once; an optional slow core breath only.
+
+## 7. Open questions / assumptions
+- **Renderer ⟷ runtime mismatch (confirmed, highest priority).** `GeneKeys.tsx` expects `activation_sequence.spheres[]` or per-sphere **objects** `{name,gate,shadow,gift,siddhi}` (L205-242). The engine emits `activation_sequence` as four **gate-pair arrays** (`engine.rs:248-254`) and puts the human-readable shadow/gift/siddhi under **`active_keys[]`** and **`frequency_assessments[]`** — which the renderer **never reads**. Net effect against real output: `spheres` is empty → fallback path reads `activation.lifes_work` = `[17,18]` → `obj()` coerces the array to `{}` → every card shows gate `—` and Shadow/Gift/Siddhi `—`. **Build decision needed:** either (a) renderer maps gate pairs → look up names from `frequency_assessments`, or (b) engine adds a `spheres`/hologenetic block. Recommend (a) — runtime is the contract; do not invent (b) without an engine change.
+- **`venus_sequence` / `pearl_sequence` are stub-only — never produced.** The OpenAPI example (`types.rs:239-242`) and the domain prompt both name three sequences (Activation, Venus, Pearl), but the engine computes **only the Activation Sequence**. No Venus/Pearl code exists in the crate (grep: only `Venus` *planet* references). The `GeneKeysInfo.sequences: Vec<String>` field (`models.rs:194`) is metadata loaded from `archetypes.json` and is **not** part of `GeneKeysChart` output. **Do not render Venus/Pearl rings** — they are aspirational.
+- **Stub `activation_sequence: String` is doubly wrong** (`types.rs:238`): runtime type is an object, and the example value `"Gift of Patience"` matches nothing emitted. Treat the whole stub as non-authoritative for Gene Keys.
+- **No `hologenetic`/`spheres` anywhere in the engine** (grep confirms). The "hologenetic profile spheres" from the domain brief are a Gene Keys *concept* but are **not** in this codebase's output — Wave-2 must synthesise spheres from the gate pairs + `frequency_assessments`, or the engine must grow them.
+- **`programming_partner` not on the wire.** `GeneKey.programming_partner` exists in the struct (`models.rs:34`) and the renderer reads `result.programming_partner` (GeneKeys.tsx:206), but `serialize_chart` never emits it → the Programming Partner line is dead today. Confirm whether to surface it (add to serializer) or drop the renderer branch.
+- **`source` casing.** `active_keys[].source` is Rust `Debug` output (`"PersonalitySun"`, `engine.rs:231`), not `snake_case`/`Personality Sun`. Any renderer label must format it client-side.
+- **`active_keys` length is unverified by fixture.** The number of activations (how many planets × Personality/Design map to keys) isn't asserted in `reference_charts.json`; it comes from the HD engine. Expect up to 26 (the `ActivationSource` variant count) but verify against a live HD output before sizing the ring.
+- **`line` source.** Lines (1–6) live on `GeneKeyActivation.line` from the HD engine; this crate does not compute them — `reference_charts.json` only carries gates, so line values aren't fixture-verified here.

--- a/docs/engines/human-design.md
+++ b/docs/engines/human-design.md
@@ -1,0 +1,87 @@
+# Human Design — Data Reference
+
+The BodyGraph for a moment of birth: Type, Strategy, Authority, Profile, plus the 9 centers (defined/undefined), 36 channels, and 64 gates derived from two activation sets (personality at birth, design ~88° of solar arc before birth).
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `human-design` (`crates/engine-human-design/src/engine.rs:26`, asserted `engine.rs:288`) |
+| Domain crate | `crates/engine-human-design/src/lib.rs` (chart structs in `models.rs:7`, wisdom in `wisdom.rs`) |
+| Runtime source | **`engine-human-design`** — `serialize_chart()` (`engine.rs:60`) produces `EngineOutput.result` |
+| Renderer | `apps/noesis-web/src/components/engines/HumanDesign.tsx` |
+| Fixture (real values) | `crates/engine-human-design/tests/reference_charts.json` (16 charts; synthetic, see §7) |
+| OpenAPI stub | `noesis-core/src/types.rs:225` (`HumanDesignResultSchema` — `type_name`/`authority`/`strategy`) |
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — exactly the 8 keys `serialize_chart` emits, `engine.rs:105`):**
+```jsonc
+{
+  "hd_type":    "ManifestingGenerator",   // Debug-formatted enum (PascalCase, no spaces)
+  "authority":  "Emotional",              // Debug-formatted enum
+  "profile":    "2/5",                    // "conscious/unconscious" line, e.g. 2/5
+  "definition": "Single",                 // Debug-formatted enum
+  "defined_centers": ["Ajna","Root","Sacral","SolarPlexus","Throat"],  // Debug-formatted Center names
+  "active_channels": ["39-55","43-23","59-6"],                         // "gate1-gate2" strings
+  "personality_activations": {            // keyed by planet name (lowercase), 13 planets
+    "sun":   { "gate": 48, "line": 2, "longitude": 191.6 },
+    "earth": { "gate": 21, "line": 2, "longitude": 11.6  }
+    // … moon, northnode, southnode, mercury, venus, mars, jupiter, saturn, uranus, neptune, pluto
+  },
+  "design_activations": { "sun": { "gate": 39, "line": 5, "longitude": … }, "earth": { … }, … }
+}
+```
+
+**Domain struct `HDChart` (`models.rs:7`) — richer than the serialized output:** `personality_activations: Vec<Activation>` · `design_activations: Vec<Activation>` · `centers: HashMap<Center, CenterState>` (`CenterState{defined:bool, gates:Vec<u8>}`, `models.rs:44`) · `channels: Vec<Channel>` (`Channel{gate1,gate2,name,circuitry}`, `models.rs:63`) · `hd_type: HDType` · `authority: Authority` · `profile: Profile{conscious_line,unconscious_line}` (`models.rs:91`) · `definition: Definition`. `Activation{planet,gate,line,longitude}` (`models.rs:19`). **`serialize_chart` drops** per-center gate lists, channel `name`/`circuitry`, and collapses `profile` to a string.
+
+**OpenAPI stub (`types.rs:225`):** `{ type_name:String, authority:String, strategy:String }` — examples only; field name is `type_name`, not `hd_type` or `type`.
+
+**Wisdom layer (NOT in `result`):** `wisdom.rs` defines `GateWisdom` (`:7`), `CenterWisdom`, `ChannelWisdom`, `TypeWisdom` (carries `strategy`, `signature`, `not_self_theme`, `aura`), `AuthorityWisdom`, `ProfileWisdom` (`:74`), `IncarnationCrossWisdom`, etc., loaded from `data/human-design/*.json`. These are interpretive lookups, not part of the engine's calculated output.
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `hd_type` | `Generator` \| `ManifestingGenerator` \| `Projector` \| `Manifestor` \| `Reflector` | `HDType`, `models.rs:71`. Fixture covers only MG/Manifestor/Projector (`reference_charts.json:689`) |
+| `authority` | `Sacral` \| `Emotional` \| `Splenic` \| `Heart` \| `GCenter` \| `Mental` \| `Lunar` | `Authority`, `models.rs:80`. Fixture covers only Emotional/Sacral/Splenic (`:682`) |
+| `definition` | `Single` \| `Split` \| `TripleSplit` \| `QuadrupleSplit` \| `NoDefinition` | `Definition`, `models.rs:97`. **Not present in fixture `expected`** — coverage unverified |
+| `profile` | `c/u`, c,u ∈ **1–6** | `Profile.conscious_line`/`unconscious_line` are `u8` (`models.rs:91`); 12 canonical pairs (1/3,1/4,2/4,2/5,3/5,3/6,4/6,4/1,5/1,5/2,6/2,6/3). Fixture `profiles: 11` (`:687`) |
+| `defined_centers[]` | subset of the **9** Centers | `Head, Ajna, Throat, G, Heart, Spleen, SolarPlexus, Sacral, Root` (`Center`, `models.rs:50`). Length 0–9; Debug names (`SolarPlexus`, `G`) |
+| `active_channels[]` | each `"g1-g2"`, g ∈ **1–64** | up to **36** total channels. Order/direction is the struct's `(gate1,gate2)` — **not normalized** (e.g. fixture has both `"10-34"` and `"34-20"`, `"20-10"`) |
+| `*_activations.<planet>` | 13 planets each set | keys: `sun, earth, moon, northnode, southnode, mercury, venus, mars, jupiter, saturn, uranus, neptune, pluto` (`Planet`, `models.rs:27`, lowercased Debug) |
+| `…gate` | **1–64** | the hexagram/gate |
+| `…line` | **1–6** | line within the gate |
+| `…longitude` | **0–360°** | ecliptic longitude (tropical; Swiss Ephemeris, `engine.rs:192`) |
+
+**Invariants.** A center is *defined* iff a complete channel touching it is active (so `defined_centers` and `active_channels` co-vary — not independent). `profile` lines = the *lines* of personality-Sun (conscious) and design-Sun (unconscious); the incarnation cross = the four gates of personality Sun/Earth + design Sun/Earth. Personality vs design = same chart at birth vs ~88° solar arc earlier (`design_time.rs`). Sacral defined ⟹ Type ∈ {Generator, ManifestingGenerator}.
+
+## 4. Component & brand archetype
+**Today** (`HumanDesign.tsx`): a real **BodyGraph SVG** (`viewBox 0 0 200 270`, `:204`) — 9 center polygons with correct shapes (Head/G diamond, Ajna/SP tri-down, Spleen/Ego tri-up, Throat/Sacral/Root rect; `BODY_CENTERS`, `:114`), lit emerald `rgba(16,185,129,0.6)` when defined else faint (`:194`), plus **10 hardcoded channel lines** between center *pairs* (`CHANNELS`, `:127`) thickened/emerald when both ends defined. Definition is read from `result.defined_centers` (array path, `isCenterDefined`/`definedList`, `:151`) with broad center aliases (`CENTER_ALIASES`, `:76`). Below: a 6-cell stat grid (Type/Strategy/Authority/Profile/Definition/Not-Self Theme) + an Incarnation-Cross block + a 9-row Centers list. **Already substantially on-brand** (sacred-geometry BodyGraph, emerald fills) — but four readouts and the gate/channel detail are placeholders fed by absent fields (see §5/§7).
+
+**Wave-2 target:** the BodyGraph is **load-bearing sacred geometry, not decoration.** Render the *real* 36 channels as composed gate-pairs (each channel = two gates, one per center) and the **64 gates as nodes** on the center perimeters (lit when activated, colored by personality=black / design=red per HD convention). Light a channel only when present in `active_channels`; light a center only when defined. Type/Strategy/Authority/Profile become the readout around the graph; center color = bioluminescent on-brand emerald `#10B5A7` defined vs Void `#070B1D` open. Gates draw-in (Anime.js stroke-dashoffset) on load. Brand palette: Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `defined_centers[]` | the 9 center polygons; named center filled emerald + glow when present, else open outline |
+| `active_channels[]` (`"g1-g2"`) | (target) the specific channel line drawn lit between its two centers; gate nodes at each end lit |
+| `…gate` (1–64) per activation | (target) 64 perimeter gate-nodes; personality set vs design set colored distinctly |
+| `…line` (1–6) | gate-node sub-tick / tooltip; feeds profile |
+| `hd_type` | central readout (Type) — **renderer reads `result.type`, which the engine does not emit (§7)** |
+| `authority` | readout cell (Authority) |
+| `profile` (`"2/5"`) | readout cell; renderer prefers `profile.line1/line2` then falls back to the string |
+| `definition` | readout cell (Single/Split/…) — geometry could tint connected sub-graphs |
+| *strategy* | readout cell — **no runtime field; from `TypeWisdom.strategy` lookup (§7)** |
+| *not_self_theme* | readout cell — **no runtime field; from `TypeWisdom.not_self_theme` (§7)** |
+| *incarnation_cross / sun_gate / earth_gate* | "Incarnation Cross Seed" block — **no runtime field; derivable from `personality_activations.{sun,earth}` (§7)** |
+
+## 6. Dynamics
+**One-shot per birth moment.** `calculate()` (`engine.rs:138`) takes date/time/timezone and computes once; **latitude/longitude are extracted but unused** for the chart (`_latitude, _longitude`, `engine.rs:142`) — unlike Vedic engines, the BodyGraph is location-independent here (houses aren't computed). Not live; recompute only if birth data changes. No baseline/delta semantics. `consciousness_level` (0–5, default 1; `engine.rs:166`) is envelope-level and may gate interpretive depth (gate/channel/type prose) but does not change the geometry. On render, defined centers + active channels + gate nodes should animate in once (line-draw); no perpetual loop except an optional slow core breath.
+
+## 7. Open questions / assumptions
+- **`type` vs `hd_type` (CONFIRMED MISMATCH — highest risk):** the engine emits **`hd_type`** (`engine.rs:106`) and its own `validate()` checks `hd_type` (`engine.rs:212`), but the renderer reads **`result.type`** (`HumanDesign.tsx:308`). The OpenAPI stub uses a *third* name, `type_name` (`types.rs:227`). As written, **the Type cell renders `—`.** Pick one canonical key (recommend `type`) and align engine + stub + renderer.
+- **`strategy` and `not_self_theme` are never serialized.** Neither appears in `serialize_chart`/`chart.rs` (grep: 0 hits); they live only in `TypeWisdom` (`wisdom.rs:50`) keyed off type. The renderer's Strategy and Not-Self cells (`:312`,`:332`) always render `—` until the engine joins wisdom into `result` (or the renderer derives them client-side from Type).
+- **Incarnation cross / `sun_gate` / `earth_gate` absent.** Renderer reads `result.incarnation_cross` / `result.sun_gate` / `result.earth_gate` (`:284`); none are emitted. They are trivially derivable from `personality_activations.{sun,earth}` + `design_activations.{sun,earth}` (already present) — Wave-2 should either add them server-side or have the renderer read the activation objects.
+- **`centers` object vs `defined_centers` array:** renderer supports both (`isCenterDefined`, `:142`) and the engine emits the **array** — fine. But the renderer's per-shape lookup uses key `ego` for the Heart/Will center (`CENTER_ALIASES.ego`, `:84`; display maps "heart"→"ego", `:359`), while the engine's enum + array use **`Heart`** (`models.rs:54`, fixture `"Heart"`). The alias list includes `heart` under `ego`, so it matches — verify this mapping survives any rename.
+- **Channels are pair-of-centers, not real HD channels.** `CHANNELS` (`:127`) hardcodes 10 center-to-center lines; the real model has **36 gate-defined channels**. The rich data (`active_channels`, per-gate activations) exists in `result` but the renderer doesn't yet draw individual channels/gates — the core Wave-2 build.
+- **Channel direction not normalized:** `active_channels` strings follow the struct's `(gate1,gate2)` order, so the same channel can appear as `"10-34"` or `"34-20"` (fixture L222–224). Any gate→channel matching in the renderer must compare unordered pairs.
+- **Fixture is synthetic & partial.** `reference_charts.json` is "Selemene HD Engine (Synthetic Reference Data)… Professional HD software validation pending" (`:696`); covers 3 of 5 types, 3 of 7 authorities, and **omits `definition`** from `expected`. Its `expected` block also uses flat `personality_sun`/`design_sun` keys (`:25`), which is the *test-comparison* shape — the live `result` nests these under `personality_activations.sun` (`engine.rs:112`). Treat `serialize_chart` as the contract, the fixture as value samples. The fixture `name` labels (e.g. "Generator 1/3") frequently disagree with the computed `type`/`profile` (e.g. type `ManifestingGenerator`, profile `2/5`) — labels are descriptive, not assertions.

--- a/docs/engines/iching.md
+++ b/docs/engines/iching.md
@@ -1,0 +1,100 @@
+# I Ching — Data Reference
+
+Hexagram divination: a primary hexagram (1–64, six yin/yang lines), optional changing lines, and a relating (transformed) hexagram, with judgment + image text.
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `i-ching` (confirmed: `ts-engines/src/engines/i-ching/engine.ts:14,147`; `crates/noesis-bridge/src/lib.rs:263`) — **kebab-case, not `iching`** |
+| Crate | **— (no Rust engine; stub + renderer)** |
+| Runtime source | **`ts-engines/src/engines/i-ching/engine.ts`** (`IChingEngine`, TS) — served via the Bun TS-engines server (`http://localhost:3001`) behind `crates/noesis-bridge/src/lib.rs:257-264` (`BridgeEngine::i_ching`) |
+| Data | `ts-engines/src/engines/i-ching/wisdom.ts` (`HEXAGRAMS[]`, `getHexagramByNumber`) — **only 8 of 64 hexagrams have full data; rest are stubs** (`wisdom.ts:16`) |
+| Witness prompts | `ts-engines/src/engines/i-ching/witness.ts` (`generateWitnessPrompts`) |
+| Renderer | `apps/noesis-web/src/components/engines/IChing.tsx` |
+| OpenAPI stub | `crates/noesis-core/src/types.rs:335` (`IChingResultSchema` — `hexagram`/`hexagram_name`/`guidance` only) |
+| Fixture (real values) | none found for the web path; nearest sample is the orchestrator test shape `result.hexagram.{number,name}` (`crates/noesis-orchestrator/tests/synthesis_tests.rs:523`) — a **third** shape, see §7 |
+
+## 2. Output schema
+
+⚠️ **The producer and the renderer disagree on shape.** The runtime producer is the TS engine; the renderer was written against a different (flat) contract. Both are recorded; the mismatch is the headline open question (§7).
+
+**Runtime JSON — what the TS producer actually emits (`engine.ts:119-145`):**
+```jsonc
+{
+  "primary_hexagram": {
+    "number": 24,                 // 1–64
+    "name": "Return",
+    "chinese_name": "復 (Fù)",
+    "meaning": "...",
+    "judgment": "...",
+    "image": "..."
+  },
+  "changing_lines": [1, 4] ,      // 1-based line positions, or null if none (engine.ts:128)
+  "relating_hexagram": {          // present only when changing_lines non-empty; else null
+    "number": 2, "name": "...", "chinese_name": "...",
+    "meaning": "...", "judgment": "...", "image": "..."
+  },
+  "casting": {
+    "method": "three_coins",      // "three_coins" | "yarrow_stalks"
+    "line_values": [7,8,6,9,7,8]  // 6 values, one per line bottom→top; 6/7/8/9
+  },
+  "seed": 123456
+}
+```
+
+**Runtime JSON — what the renderer reads (`IChing.tsx:228-235`):** all **flat / top-level**, none nested:
+```jsonc
+{
+  "hexagram_number": 24,          // OR "number" OR "hexagram"  (IChing.tsx:228)
+  "hexagram_name": "Return",      // OR "name"                  (IChing.tsx:229)
+  "judgment": "...",              // OR "judgement"             (IChing.tsx:230)
+  "image": "...",                 //                            (IChing.tsx:231)
+  "lines": [true,false,...],      // 6 booleans bottom→top, true=yang; optional (IChing.tsx:26-31)
+  "changing_lines": [1,4]         // numbers, or [{line:n}] objects (IChing.tsx:49-63)
+}
+```
+
+**OpenAPI stub (`types.rs:335` — examples only):** `{ hexagram: i32 = 24, hexagram_name: String = "Return", guidance: String = "Return to the center…" }`. Note `guidance` is in neither the producer nor the renderer.
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| hexagram number | **1–64** | producer `primary_hexagram.number`; renderer `hexagram_number\|number\|hexagram`. Validated 1–64 in producer (`engine.ts:59`) |
+| `lines` | 6 × boolean | bottom→top, `true`=yang/solid, `false`=yin/broken (`wisdom.ts:13`, `IChing.tsx:25`) |
+| `casting.line_values[i]` | **6,7,8,9** | 6=old yin, 7=young yang, 8=young yin, 9=old yang (`engine.ts:91`) |
+| `changing_lines` | subset of **1–6** | a line changes iff its value is 6 or 9 (`engine.ts:93`); `null`/`[]` when none |
+| `casting.method` | `three_coins` \| `yarrow_stalks` | default `three_coins` (`engine.ts:140`) |
+| `relating_hexagram` | hexagram 1–64 or `null` | present only when `changing_lines` non-empty (`engine.ts:99-112`) |
+| changing-line probability | ~1/4 per line | each line uniform over {6,7,8,9} → P(change)=2/4 in this RNG, *not* the canonical three-coin 1/4 (`engine.ts:91`) — see §7 |
+
+**Invariants.** (a) Lines bottom→top, line 1 = bottom. (b) The relating hexagram *should* equal the primary with every changing line flipped (`engine.ts:102-107` computes `relatingLines` correctly) — **but the emitted `relating_hexagram` is a random hexagram, not that flip** (`engine.ts:109-111`); `relatingLines` is computed and discarded. (c) Renderer, when `result.lines` is absent, reconstructs the 6 lines from its own `KING_WEN` bit table indexed by hexagram number (`IChing.tsx:5-46`) — so given only a number it still draws lines. No trigram data exists anywhere (see §7).
+
+## 4. Component & brand archetype
+**Today** (`IChing.tsx`): an **SVG 6-line hexagram stack** (bottom→top; yang = one solid gold bar `#C5A017`, yin = two gold bars with a gap `rgba(197,160,23,0.4)`; a small gold dot to the right marks a changing line — `IChing.tsx:86-152`) beside a header (`#<number>` + name), then text sections for **Judgment**, **Image**, and a **Changing Lines** list (`IChing.tsx:237-271`). Already partly on-brand (gold lines, display font). No trigram split, no 64-grid, no transformed-hexagram rendering yet.
+
+**Wave-2 target:** the **6-line hexagram stack** (broken/solid bottom→top, changing lines marked) as the hero, with an **optional 64-grid** locating the cast hexagram, and a **primary → transformed** pairing (draw the relating hexagram beside the primary, animate the changing lines flipping). Brand palette: Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `lines[i]` / King Wen of number (1–64) | i-th bar bottom→top: solid (yang) vs split (yin) gold bar (`IChing.tsx:104-137`) |
+| hexagram number | large `#n` label in the header (gold, display font) |
+| hexagram name | name label under the number |
+| `changing_lines` (1–6) | gold dot to the right of each changing bar (`IChing.tsx:140-147`); also a text list |
+| `judgment` | "Judgment" text section |
+| `image` | "Image" text section |
+| `relating_hexagram` | (target) second hexagram stack; flipped lines highlighted → the transformation |
+| hexagram number (1–64) | (target) lit cell in the optional 8×8 / 64-grid |
+
+## 6. Dynamics
+**One-shot per cast.** A reading is generated once from `(hexagram?, method, seed)` (`engine.ts:37-152`); not live, no recompute cadence. **Casting is RNG-driven** (`SeededRandom`, `engine.ts:40,72,91,110`): omit `hexagram` and the primary, the six line values, and the relating hexagram are all drawn from the seed — so a fixed `seed` reproduces a reading, and a new seed yields a new one (`result.seed` echoes it). The natural one-time animation is the line-stack drawing in (stroke/scale) and, for Wave-2, the changing lines flipping into the relating hexagram. `consciousness_level` (envelope, 0–5) may gate how much interpretive text (meaning/judgment/image) is shown.
+
+## 7. Open questions / assumptions
+- **⚠️ NO Rust engine.** I Ching has no `engine-*` crate — only the OpenAPI stub (`types.rs:335`) + the renderer. The real producer is the **TypeScript** `IChingEngine` (`ts-engines/src/engines/i-ching/engine.ts`), reached through `noesis-bridge` → Bun TS server (`:3001`). The README's "runtime source: unconfirmed" is now **confirmed = the TS engine**. (Hexagram 24 "Return" in the stub is just the schema example, matching the King Wen entry.)
+- **⚠️ Producer ↔ renderer schema mismatch (confirmed, likely a real defect).** Producer emits **nested** `result.primary_hexagram.{number,name,judgment,image}`, `relating_hexagram`, `casting.line_values`. Renderer reads **flat** `result.hexagram_number|number|hexagram`, `hexagram_name|name`, `judgment`, `image`, `lines`, `changing_lines`. Against raw producer output the renderer would find none of name/number/judgment/image (they're one level down) and would fall back to all-yang lines + empty text. **Something must reshape the bridge output before the renderer, or the renderer is mis-wired.** No such reshaper was found under `apps/noesis-web/src`; no file imports `IChing.tsx` except itself. Resolve before building Wave-2: either flatten in the producer/bridge, or read the nested shape in the renderer. Build against whichever the API actually returns — **unverified here** (no web-path fixture).
+- **A third shape exists.** Orchestrator/synthesis code reads `result.hexagram.{number,name}`, `result.relating_hexagram`, `result.changing_lines` (`crates/noesis-orchestrator/src/workflow/synthesis/decision_support.rs:230-246`; test data `synthesis_tests.rs:523`) — i.e. `hexagram.*` (singular), not `primary_hexagram.*`. So three contracts are in play: producer (`primary_hexagram`), orchestrator (`hexagram`), renderer (flat). Confirm which the live API emits.
+- **No trigrams.** The task asked to verify upper/lower trigrams; **they do not exist** in the producer (`Hexagram` has only `number,name,chineseName,meaning,judgment,image,lines` — `wisdom.ts:6-14`) nor the renderer. Lines are stored/derived directly, never decomposed into the two trigrams. Trigrams would be new work for Wave-2.
+- **Data is mostly stub.** `wisdom.ts:16` states only the first 8 hexagrams have full meaning/judgment/image; the other 56 carry placeholder text. Real interpretive copy is needed before this is production-grade.
+- **`relating_hexagram` is wrong.** It is a *random* hexagram, not the primary with changing lines flipped (`engine.ts:109-111` discards the correctly-computed `relatingLines`). The transformed-hexagram visual (§4/§5 target) will be meaningless until this is fixed.
+- **Changing-line odds are off.** Each line is uniform over {6,7,8,9} (`engine.ts:91`), giving P(changing)=1/2, not the canonical three-coin 1/4 — and `method` is recorded but never affects the cast (`yarrow_stalks` behaves identically).
+- **`guidance` (stub) is vestigial** — present in `IChingResultSchema` only; neither producer nor renderer uses it. Treat as a stale example field.

--- a/docs/engines/nadabrahman.md
+++ b/docs/engines/nadabrahman.md
@@ -1,0 +1,102 @@
+# Nadabrahman — Data Reference
+
+Raga-based sound therapy: given a moment (and optional dosha / rasa / chakra), recommends Melakarta ragas by **prahar** (3-hour time block), plus a chakra Solfeggio frequency for tuning. "Nāda Brahman" = sound as the substrate of consciousness.
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `nadabrahman` (engine.rs:37; asserted engine.rs:399) |
+| Domain crate | `crates/engine-nadabrahman/src/` — output type `NadaBrahmanAnalysis` (models.rs:55) |
+| Runtime serializer | **`engine.rs:171` `serialize_result`** — the JSON the API actually returns (authoritative; differs from the struct, see §2) |
+| Data files (embedded) | `data/nadabrahman/{melakarta_ragas.json, time_raga_mappings.json, chakra_frequencies.json}` (data.rs:13–15) |
+| Renderer | `apps/noesis-web/src/components/engines/Nadabrahman.tsx` |
+| Renderer raga DB | `apps/noesis-web/src/lib/raaga/melakartas.ts` (`MELAKARTAS`, 72 entries — melakartas.ts:78) |
+| Fixture (real values) | **none** — no `tests/` dir; reference values taken from unit-test assertions (data.rs:255–280, engine.rs:460–465) and the embedded JSON |
+| OpenAPI stub | `noesis-core/src/types.rs:291` (`NadabrahmanResultSchema`) — **fictional, see §7** |
+| Runtime source | `engine-nadabrahman` crate (standalone; no vedic-api path) |
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — exactly what `serialize_result` emits, engine.rs:171–228):**
+```jsonc
+{
+  "time_recommendation": {                          // always present
+    "prahar_name": "Pratah (Morning)",              // models.rs:120-131 — one of 8
+    "prahar_number": 1,                             // 1–8
+    "time_range": "06:00-09:00",                    // models.rs:134-145
+    "primary_raga": { "raga_number": 15, "raga_name": "Mayamalavagowla", "reason": "…" },
+    "dosha_dominance": "kapha",                      // kapha|pitta|vata (engine.rs:147-154)
+    "energy_quality": "ascending"                    // engine.rs:157-168
+    // NOTE: secondary_ragas exists on the struct (models.rs:48) but is NOT serialized here
+  },
+  "recommendations": [                              // always present, ≤5, score-desc
+    {
+      "raga_number": 15, "raga_name": "Mayamalavagowla",
+      "reason": "…", "score": 1.0,                  // f64, see §3
+      "arohanam":  ["sa","ri1","ga3","ma1","pa","dha1","ni3","sa"],  // enriched if raga known (engine.rs:184-189)
+      "avarohanam":["sa","ni3","dha1","pa","ma1","ga3","ri1","sa"],
+      "mood": "devotional", "therapeutic_qualities": ["…"]
+    }
+  ],
+  "chakra_frequency": {                             // OPTIONAL — only if `chakra` option given
+    "chakra_name": "heart",                         // echoes the input string, not Sanskrit
+    "solfeggio_hz": 639.0,                          // Hz, see §3
+    "binaural_target_hz": 8.0                        // Hz beat-frequency
+  },
+  "dosha_recommendation": "vata",                   // OPTIONAL — a STRING (echo of input), not an object
+  "rasa_mapping": "shanta"                          // OPTIONAL — a STRING (echo of input), not an object
+}
+```
+
+**Domain struct `NadaBrahmanAnalysis` (models.rs:55):** `time_recommendation: PraharRecommendation` · `recommendations: Vec<RagaRecommendation>` · `chakra_frequency: Option<ChakraFrequency>` · `dosha_recommendation: Option<String>` · `rasa_mapping: Option<String>`.
+Sub-types: `PraharRecommendation` (models.rs:43) carries `secondary_ragas` + `primary_raga` as full `RagaRecommendation`; `RagaRecommendation` (models.rs:26) = `{raga_number:u32, raga_name:String, reason:String, score:f64}`; `ChakraFrequency` (models.rs:35) = `{chakra_name, solfeggio_hz, binaural_target_hz}`; `Raga` (models.rs:9) = the full 12-field record (number, name, chakra, arohanam, avarohanam, madhyama_type, mood, time_of_day, therapeutic_qualities, dosha_affinity, rasa, consciousness_level) — used to **enrich** recommendations, never serialized whole.
+
+**OpenAPI stub (types.rs:291):** `{ root_frequency_hz: 432.0, suggested_raga: "Bhairavi", mantra_seed: "AUM" }` — **none of these three fields is produced by the engine.** Pure documentation placeholder. See §7.
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `prahar_number` | **1–8** | 3-hour blocks; derived from `current_time.hour()` (engine.rs:44, models.rs:91-103). Boundaries: 1=06–09, 2=09–12, 3=12–15, 4=15–18, 5=18–21, 6=21–00, 7=00–03, 8=03–06 |
+| `prahar_name` | 8 fixed strings | Pratah / Sangava / Madhyahna / Aparahna / Sayahna / Pradosha / Nisha / Brahma Muhurta (models.rs:120-131) |
+| `dosha_dominance` | `kapha`\|`pitta`\|`vata` | prahar→dosha map (engine.rs:147-154); note prahars 7 & 8 are both `vata` |
+| `energy_quality` | enum (8) | ascending/expansive/peak/sustaining/transitional/inward/deep/awakening (engine.rs:157-168) |
+| `raga_number` | **1–72** | Melakarta system; full DB has 72 ragas (data.rs:211). Renderer also clamps 1–72 (Nadabrahman.tsx:38,44) |
+| `recommendations[]` length | **0–5** | truncated to 5 after dedup+sort (engine.rs:103); renderer further `.slice(0,6)` (Nadabrahman.tsx:238) |
+| `score` | **f64, ~0.5–1.0** | primary = `1.0 − i·0.05`; secondary = `0.7 − i·0.1` (data.rs:101,118); dosha/rasa hits = `0.7` (data.rs:146,163); fallback raga = `0.5` (engine.rs:53). **Not normalized**, can be ≤0 for long secondary lists |
+| `solfeggio_hz` | **396 / 417 / 528 / 639 / 741 / 852 / 963 Hz** | the 7-chakra Solfeggio ladder (chakra_frequencies.json; root=396 & heart=639 asserted data.rs:261,278) |
+| `binaural_target_hz` | **0.5 / 4 / 6 / 8 / 10 / 12 / 14 Hz** | beat-frequency per chakra (chakra_frequencies.json); delta/theta/alpha range, not audible tones |
+| `chakra_name` | echo of input string | accepts Sanskrit ("Muladhara") **or** English ("root"); case-insensitive (data.rs:172-202). Unknown chakra → `chakra_frequency` omitted entirely |
+| swaras (`arohanam`/`avarohanam`) | 8-note arrays | ascending/descending scale; tokens `sa ri1 ga3 ma1 pa dha1 ni3 sa` (varianted swaras 1–3) |
+| `dosha_recommendation` / `rasa_mapping` | string or absent | present only when `dosha` / (`rasa`\|`mood`) option supplied (engine.rs:76-98) |
+
+**Invariants.** `recommendations` is sorted score-descending after de-dup by `raga_number` (engine.rs:101-103). `time_recommendation` + `recommendations` are **always** present (validator enforces, engine.rs:300-308); `chakra_frequency`, `dosha_recommendation`, `rasa_mapping` are conditional on input options. The witness prompt is non-empty or the call errors (engine.rs:259-263). **Output co-varies with wall-clock hour** — the same birth data yields a different prahar/raga each 3-hour block (cache key is hour-granular, engine.rs:341-363).
+
+## 4. Component & brand archetype
+**Today** (`Nadabrahman.tsx`): an **all-text** view — a gold mantra box (only if `result.mantra` present, line 204), a 3-cell grid (Chakra+element / Dosha / Rasa+emotion, lines 211-232), and a "Sound Practices" tag row where each resolvable raga gets ▶ **play** and ⬇ **WAV** buttons backed by a real Web-Audio/Strudel synth (`getRaagaPlayer`, lines 234-272). Below: an **audio-source toggle** (Suno recording vs. live Strudel) and a collapsible **V2 control bar** — timbre (sine/sitar/bansuri/sarangi), gamaka (kampita/andolana/kurula/nokku/sphurita), tala (7 options), breath (7 prāṇāyāma patterns), lines 274-355. If none of `chakra_frequency` / `mantra` / `dosha` is present it falls back to `GenericEngineView` (line 200). **No visualization** — zero SVG/canvas, no waveform; it is a player + metadata panel, not a geometric figure.
+
+**Wave-2 target:** a **harmonic waveform / frequency arc** — render `solfeggio_hz` as a base sine and stack its overtone series (2f, 3f, …) as concentric arcs or a layered wave; the active raga's `arohanam` swaras become tick marks / nodes along the arc; chakra color drives hue; the bija mantra + note sit at the core as an acoustic readout (not a decorative glyph). The play button should drive a live amplitude trace. Brand palette: Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`. This is the only engine whose primary output is genuinely **audio**, so the visual should be a faithful spectrogram/oscilloscope of what's playing, time-of-day–tinted by prahar.
+
+## 5. Data → visual mapping
+| Field | Visual (Wave-2 target) |
+|---|---|
+| `chakra_frequency.solfeggio_hz` (Hz) | base wave frequency / radius of the fundamental arc; pitch label at core |
+| overtone series (2f,3f,4f… of solfeggio_hz) | stacked concentric arcs / layered sine partials — the "frequency arc" |
+| `chakra_frequency.binaural_target_hz` (Hz) | slow beat modulation (envelope pulse) of the base wave |
+| `chakra_name` | hue of the wave (root→crown chakra color ramp) |
+| `recommendations[].arohanam` / `avarohanam` | swara nodes/ticks along the arc (ascending vs descending sweep) |
+| `prahar_number` (1–8) | 8-segment day-ring; active prahar lit; overall scene tint |
+| `energy_quality` | amplitude / animation tempo of the trace |
+| `score` (per rec) | node size / opacity in the recommendation row |
+| bija mantra + `note` (from data file) | acoustic readout at the core — **needs engine fix to ship, see §7** |
+
+## 6. Dynamics
+**Time-driven, near-live.** Unlike the one-shot Vedic engines, output depends on `current_time.hour()` → the recommended prahar/raga **changes every 3 hours**; the cache key is hour-granular (engine.rs:341-363), so a re-fetch after a block boundary returns new data. Within a block it's stable. The **audio layer is fully interactive** (client-side): play/stop/download, source switching, and V2 timbre/gamaka/tala/breath all mutate playback live via `getRaagaPlayer()` without re-fetching engine output (Nadabrahman.tsx:104-198). `dosha`/`rasa`/`chakra` are **request options**, not birth data — changing them re-runs the engine. `consciousness_level` (0–5) is envelope-level and may gate interpretive depth; `required_phase` is 0 (available to everyone, engine.rs:249-251). Wave-2: the waveform should animate in sync with actual playback (oscilloscope), idle to a slow breath when stopped.
+
+## 7. Open questions / assumptions
+- **OpenAPI stub is fiction (confirmed).** `NadabrahmanResultSchema` (types.rs:291) advertises `root_frequency_hz` (432.0), `suggested_raga` ("Bhairavi"), `mantra_seed` ("AUM") — **the engine emits none of them.** There is no 432 Hz anywhere (frequencies are the 396–963 Solfeggio ladder), no top-level `suggested_raga` (it's `time_recommendation.primary_raga.raga_name` + `recommendations[]`), and no `mantra_seed`. Do **not** build against the stub. ⚠️
+- **Renderer reads fields the engine never emits (confirmed, highest-impact).** `Nadabrahman.tsx` reads `chakra_frequency.mantra` (81), `.frequency_hz` (82), `.note` (83), `.element` (216); top-level `result.mantra` (81); and treats `rasa_mapping` as an **object** with `.rasa/.name/.emotion` (79,228-229). The engine emits `chakra_frequency` = `{chakra_name, solfeggio_hz, binaural_target_hz}` only (engine.rs:212-216) and `rasa_mapping` as a **plain string** (engine.rs:223). Net effect at runtime: the **mantra box never shows** (no `mantra` field), the **Hz line never shows** (renderer reads `frequency_hz`, engine emits `solfeggio_hz`), `note`/`element` are blank, and the Rasa cell renders `String(undefined)` → "undefined". The data **exists** in `chakra_frequencies.json` (each chakra has `note` C–B, `bija_mantra` LAM/VAM/RAM/YAM/HAM/OM/Silence, `element`) but `serialize_result` drops it. **Fix is one-sided: enrich the serializer** to pass through `note`, `mantra`/bija, `element`, and rename/alias `solfeggio_hz`→`frequency_hz` (or fix the renderer). Until then the panel is mostly empty unless a `chakra` option is sent. ⚠️
+- **`secondary_ragas` is computed but not serialized.** `PraharRecommendation.secondary_ragas` is populated (engine.rs:61) but `serialize_result` omits it from `time_recommendation` (engine.rs:196-207). They do still reach the client folded into the top-level `recommendations[]`. Confirm Wave-2 doesn't need the primary/secondary split.
+- **`score` is unbounded below.** Secondary scores `0.7 − i·0.1` go negative for the 8th+ secondary raga; truncation to 5 usually hides this, but don't assume `score ∈ [0,1]` when mapping to opacity/size.
+- **No fixture exists.** Values in §3 are from unit-test assertions + the embedded JSON, not a captured API response. A golden fixture (`crates/engine-nadabrahman/tests/`) would lock the runtime shape — currently the only guard is the validator (engine.rs:291-339).
+- **Renderer dispatch path unverified.** Could not locate the `engine_id → <Nadabrahman>` mapping via grep (likely a dynamic registry); assumed standard routing on `engine_id === "nadabrahman"`. Confirm in the engine-result router before relying on it.
+- **`chakra_name` is the raw input echo**, not normalized to Sanskrit (engine.rs:113). If the renderer keys colors off a canonical name, normalize first (the lookup already knows both forms, data.rs:182-186).

--- a/docs/engines/numerology.md
+++ b/docs/engines/numerology.md
@@ -1,0 +1,81 @@
+# Numerology — Data Reference
+
+Six core numbers derived from a person's birth date + full name, each reduced to a single digit (1–9) or a preserved master number (11/22/33), with the full reduction chain and a short meaning.
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `numerology` (`engine-numerology/src/lib.rs:317`, `engine_id() -> "numerology"`) |
+| Domain crate | `crates/engine-numerology/src/lib.rs` (`NumerologyEngine`, L266; compute L273) |
+| Domain struct | `crates/engine-numerology/src/types.rs:19` (`NumerologyResult`) + `NumerologyNumber` (L10) |
+| Runtime source | **`engine-numerology`** — pure-Rust, no external API; serialized into `EngineOutput.result` (`lib.rs:334`) |
+| Renderer | `apps/noesis-web/src/components/engines/Numerology.tsx` |
+| Fixtures (real values) | `crates/engine-numerology/tests/reference_validation_tests.rs` (well-known birthdate charts, L81+); inline unit tests `lib.rs:441–688` |
+| OpenAPI stub | `noesis-core/src/types.rs:203` (`NumerologyResultSchema` — `life_path_number`/`expression_number`/`core_theme`) |
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — what the engine serializes via `serde_json::to_value(&NumerologyResult)`, `lib.rs:334`):**
+```jsonc
+{
+  // Each of the 6 keys is a NumerologyNumber object (types.rs:10):
+  "life_path":     { "value": 7, "is_master": false, "reduction_chain": [16, 7], "meaning": "Analysis, wisdom, introspection" },
+  "expression":    { "value": 2, "is_master": false, "reduction_chain": [20, 2], "meaning": "Partnership, diplomacy, sensitivity" },
+  "soul_urge":     { "value": 6, "is_master": false, "reduction_chain": [6],     "meaning": "Responsibility, nurturing, harmony" },
+  "personality":   { "value": 5, "is_master": false, "reduction_chain": [14, 5], "meaning": "Freedom, change, adventure" },
+  "birthday":      { "value": 6, "is_master": false, "reduction_chain": [15, 6], "meaning": "Responsibility, nurturing, harmony" },
+  "chaldean_name": { "value": 9, "is_master": false, "reduction_chain": [18, 9], "meaning": "Compassion, completion, universal love" }
+}
+```
+(Values above are the verified `"John"` / day-15 unit-test results — Expression `lib.rs:555`, Soul Urge L562, Personality L568, Birthday L576, Chaldean L583; `reduction_chain` semantics from `reduce_to_core` L109.)
+
+**Domain struct `NumerologyResult` (`types.rs:19`):** six fields, each a `NumerologyNumber` —
+`life_path` · `expression` · `soul_urge` · `personality` · `birthday` · `chaldean_name`.
+**`NumerologyNumber` (`types.rs:10`):** `value:u32` · `is_master:bool` · `reduction_chain:Vec<u32>` · `meaning:String`.
+
+**OpenAPI stub (`noesis-core/src/types.rs:203`):** `{ life_path_number:i32=7, expression_number:i32=3, core_theme:String="Reflective and analytical" }` — examples only; flat scalars, **none of these field names exist in the real output** (see Open questions).
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `*.value` | **1–9, or 11 / 22 / 33** | enforced by `validate()` (`lib.rs:385–390`); masters via `is_master` (`lib.rs:92`) |
+| `*.is_master` | bool | true ⟺ value ∈ {11,22,33}; consistency checked at `lib.rs:394` |
+| `*.reduction_chain` | non-empty `Vec<u32>`, length ≥ 1 | first element = raw sum, last = `value`; monotone-decreasing after head until single/master (`reduce_to_core` L109–118) |
+| `life_path` | 1–9 / 11 / 22 / 33 | `reduce(year)+reduce(month)+reduce(day)`, then reduce (`lib.rs:186–191`) |
+| `expression` | 1–9 / master | full name, Pythagorean A=1…I=9, J=1…R=9, S=1…Z=8 (`lib.rs:20`, `:195`) |
+| `soul_urge` | 1–9 / master | vowels only (A/E/I/O/U), Pythagorean (`lib.rs:201`) |
+| `personality` | 1–9 / master | consonants only, Pythagorean (`lib.rs:211`) |
+| `birthday` | 1–9 / master | day-of-month reduced (`lib.rs:221`); a day like 29→11 stays master |
+| `chaldean_name` | 1–9 / master | full name, **Chaldean** mapping (1–8, no 9; `lib.rs:55`) |
+
+**Reduction rule (`reduce_to_core`, `lib.rs:109`):** repeatedly digit-sum until the value is a single digit (≤9) **or** a master (11/22/33), which halts reduction. Masters are **preserved** — never collapsed to 2/4/6. Confirmed: `reduce_to_core(29)=11` (L482), `(22)=22` (L489), `(33)=33` (L496), `(48)=3` via 48→12→3 (L504).
+**Life-path master nuance:** components (year/month/day) are each `reduce_to_core`'d *before* summing (`lib.rs:186–188`), so a master month/day (11/22) is kept as 11/22 in the sum — not reduced to 2/4. For `1985-11-22`: year=5, month=11, day=22 → 38 → 11 (master). The engine output is **11** (`reference_validation_tests.rs:93`).
+
+## 4. Component & brand archetype
+**Today** (`Numerology.tsx`): a flat **CSS-grid of cells** (`styles.grid`, auto-fit 200px), one per number — label + big gold value (`styles.number`, `var(--gold)`) + optional meaning. **No geometry, no spiral, no SVG.** It reads scalar `number` and text `meaning`/`interpretation`/`description` (L73–74), defaulting to `—`. It also iterates a **hardcoded 5-key list** (`NUMBERS`, L55): `life_path`, `expression`, `soul_urge`, `personality`, `personal_year` — **not** the engine's 6 keys (see Open questions).
+
+**Wave-2 target:** **digit-spiral / compass** — nodes for 1–9 (+ masters 11/22/33) arranged on a spiral or radial compass; the person's core numbers lit (gold `#C5A017` glow), **life-path as the central node** (bioluminescent core). Reduction chains animate as a path drawing inward (Anime.js stroke-dashoffset) from raw sum → final digit. Brand palette: Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `life_path.value` | central node of the spiral/compass; gold core + glow; label = value + meaning |
+| `expression.value` | digit node on the spiral; lit at its position 1–9 (or master node) |
+| `soul_urge.value` | digit node (inner/vowel ring), lit |
+| `personality.value` | digit node (consonant ring), lit |
+| `birthday.value` | digit node, lit |
+| `chaldean_name.value` | digit node, lit (1–8 range — note: never 9) |
+| `*.is_master` | dedicated 11/22/33 node off the 1–9 ring; brighter/double-ring treatment |
+| `*.reduction_chain` | draw-in path: raw-sum point → … → final-digit node (line-draw on load) |
+| `*.meaning` | tooltip / label text on the active node |
+
+## 6. Dynamics
+**One-shot per (name, date).** Pure math, deterministic — `cache_key` is `sha256(name|date)` (`lib.rs:422`), `precision_achieved:"exact"`, `backend:"native-rust"` (`lib.rs:346`). Not live; no baseline/delta. Recompute only when name or birth date changes. On render, lit nodes + reduction paths should animate in once (line-draw); an optional slow core breath on the life-path node is fine. `consciousness_level` is hardcoded **0** here (`lib.rs:344`) — unlike the 0–5 envelope range — so depth-gating of interpretive text is not driven by the engine today.
+
+## 7. Open questions / assumptions
+- **Enum variant wraps the STUB, not the real struct (confirmed):** `EngineResultData::Numerology(NumerologyResultSchema)` (`noesis-core/src/types.rs:371`) references the 3-field stub, but `calculate()` emits the full nested `NumerologyResult` into the free-form `EngineOutput.result` (`lib.rs:334`). The stub's `life_path_number`/`expression_number`/`core_theme` field names appear **nowhere** in the real output. Build Wave-2 against `NumerologyResult` (nested `{value,is_master,reduction_chain,meaning}`); treat the stub as docs-only example. ✅ flagged.
+- **Renderer reads the wrong shape + wrong keys (confirmed defect-risk):** `Numerology.tsx` expects scalar `result[key].number` (L73) but the engine emits `result[key].value`; so the displayed number is always `—` against real output. It also lists `personal_year` (L60) which the engine **does not produce**, and **omits** `birthday` and `chaldean_name` which it **does**. Renderer needs `.number`→`.value` and the key list realigned to the 6 real keys before it shows anything. ⚠️ likely live bug.
+- **Test-comment vs implementation discrepancy (cosmetic):** `reference_validation_tests.rs:96` describes the life-path method as reducing master month/day to 2/4 ("month 1+1=2, day 2+2=4"), but the code keeps masters (month=11, day=22). For `1985-11-22` both arithmetics happen to yield 11, so the assertion passes; the comment's stated *method* is nonetheless inaccurate. No output impact observed.
+- **`witness_prompt` is life-path-only:** generated solely from `life_path.value` (`lib.rs:242`); the other five numbers don't influence it. Expected, not a defect.
+- **Chaldean range:** `chaldean_name.value` can never be 9 pre-reduction-step (Chaldean map maxes at 8, `lib.rs:55`), but after reduction the *final* value can be 9 (e.g. "John"→18→9, L583). Spiral must still light a 9-node for chaldean.
+- **`engine_id` verified** as `"numerology"` (`lib.rs:317`), matching the README table — no inference needed.

--- a/docs/engines/panchanga.md
+++ b/docs/engines/panchanga.md
@@ -1,0 +1,74 @@
+# Panchanga — Data Reference
+
+The five limbs of Vedic time (pañcāṅga) for a moment + place: tithi, nakshatra, yoga, karana, vara.
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `panchanga` |
+| Domain crate | `crates/engine-panchanga/src/lib.rs` (`PanchangaResult`, L179) |
+| Runtime source | **`crates/noesis-vedic-api/src/panchang/`** (mod.rs, mappers.rs) — JHora-verified |
+| Renderer | `apps/noesis-web/src/components/engines/Panchanga.tsx` |
+| Fixture (real values) | `crates/noesis-vedic-api/tests/fixtures/reference_data/panchang_jhora_reference.json` |
+| OpenAPI stub | `noesis-core/src/types.rs:192` (`PanchangaResultSchema` — vara/paksha/nakshatra only) |
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — the shape the renderer reads & the fixture verifies):**
+```jsonc
+{
+  "tithi":     { "name": "Chaturthi", "paksha": "Shukla", "number": 4 },   // renderer also reads .percentage
+  "nakshatra": { "name": "Revati", "number": 27, "pada": 2, "ruler": "Mercury" }, // renderer reads .lord (alias of ruler?)
+  "yoga":      { "name": "Shiva", "number": 20, "nature": "auspicious" },
+  "karana":    { "name": "Vanija", "type": "Movable" },
+  "vara":      "Monday",                                                    // renderer also accepts result.weekday
+  "muhurta":   { "quality": "auspicious" }                                 // renderer reads result.muhurta.quality | result.quality
+}
+```
+
+**Domain struct `PanchangaResult` (engine-panchanga path — FLAT, different shape):**
+`tithi_index:u8` `tithi_name:String` `tithi_value:f64` · `nakshatra_index:u8` `nakshatra_name` `nakshatra_value` · `yoga_index:u8` `yoga_name` `yoga_value` · `karana_index:u8` `karana_name` `karana_value` · `vara_index:u8` `vara_name` · `solar_longitude:f64` `lunar_longitude:f64` `julian_day:f64`.
+
+**OpenAPI stub:** `{ vara:String, paksha:String, nakshatra:String }` — examples only.
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `tithi.number` | **1–30** | 1–15 Shukla (waxing), 16–30 Krishna (waning); engine `tithi_value` is continuous 0..30 |
+| `tithi.paksha` | `Shukla` \| `Krishna` | waxing / waning fortnight |
+| `nakshatra.number` | **1–27** | engine `nakshatra_index` is 0–26; renderer's `NAKSHATRAS[]` is 0-indexed (number = index+1) |
+| `nakshatra.pada` | **1–4** | quarter of the nakshatra |
+| `nakshatra.ruler` | planet name | renderer reads `.lord` — confirm alias (`ruler` vs `lord`) |
+| `yoga.number` | **1–27** | `yoga.nature` ∈ auspicious/inauspicious/mixed |
+| `karana.number` | **1–11** | engine `karana_index` 0..11; 7 movable + 4 fixed (60 half-tithi slots) |
+| `vara` | Sunday…Saturday | engine `vara_index` 0=Sunday |
+| `solar_longitude`, `lunar_longitude` | **0–360°** | engine path only; sidereal (Lahiri ayanamsa) |
+| tolerance | ±1 on tithi/nakshatra/yoga number | boundary values shift by minutes across ayanamsa/algorithm — see fixture `tolerance` |
+
+Ayanamsa: **Lahiri (Chitrapaksha)**. Invariant: indices are derived from `(lunar−solar)` (tithi/yoga) and `lunar` (nakshatra) longitudes — they co-vary, not independent.
+
+## 4. Component & brand archetype
+**Today** (`Panchanga.tsx`): 6 text cells (tithi/nakshatra/yoga/karana/vara/muhurta-quality) + a **27-segment nakshatra donut ring** (`SEG_DEG=360/27`, active segment emerald-filled + glow) with a **tithi arc** (1–30 → 0–360°, gold) and center label. Already on-brand (gold `#C5A017` + emerald `rgba(16,181,167)`, sacred-geometry ring, glow filter) — only nakshatra+tithi are geometric; yoga/karana/vara are text.
+
+**Wave-2 target:** full **5-limb mandala** — concentric rings for tithi (30), nakshatra (27, exists), yoga (27), karana (11), vara (7), each active segment lit on the Ba-Arc; center = muhurta quality as the bioluminescent core; missing geometry drawn-in (Anime.js stroke-dashoffset) on load.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `nakshatra.number` (1–27) | active segment of the 27-ring (emerald fill + glow); center label = name + `#n · Pada p` |
+| `nakshatra.pada` (1–4) | pada subdivision tick within the active segment |
+| `tithi.number` (1–30) | gold arc sweep 0→(n/30·360°) inside the donut |
+| `tithi.paksha` | arc direction / hue (Shukla waxing vs Krishna waning) |
+| `yoga.number` (1–27) | (target) outer 27-ring active segment |
+| `karana.number` (1–11) | (target) inner 11-ring active segment |
+| `vara` | (target) 7-spoke compass; weekday spoke lit |
+| `muhurta.quality` | core color: emerald=auspicious, gold=neutral, terracotta=inauspicious |
+
+## 6. Dynamics
+**One-shot per (date, time, lat/long, tz).** Not live. Recompute when the moment or place changes. No baseline/delta semantics (unlike biofield). On render, the active segments + tithi arc should animate in (line-draw) once; no perpetual loop except an optional slow core breath (4:7:8) if quality is shown as the core. `consciousness_level` (0–5) may gate how much interpretive text (lords, nature, muhurta guidance) is surfaced.
+
+## 7. Open questions / assumptions
+- **Schema mismatch (confirmed):** renderer + fixture use **nested** objects; `engine-panchanga::PanchangaResult` is **flat**. The web is fed by **noesis-vedic-api** (nested). Build Wave-2 against the nested/fixture shape; treat the flat struct as the alternate engine path. ✅ flagged, not a defect.
+- `nakshatra.ruler` vs renderer's `.lord` — likely the same field under two names; verify in `noesis-vedic-api/src/panchang/mappers.rs` before relying on `.lord`.
+- `tithi.percentage` is read by the renderer but absent from the fixture — confirm vedic-api emits it (else the "% elapsed" line is always hidden).
+- `muhurta` block shape beyond `.quality` (does it carry start/end times?) — not in the sampled fixture; check mappers.

--- a/docs/engines/raaga.md
+++ b/docs/engines/raaga.md
@@ -1,0 +1,100 @@
+# Raaga — Data Reference
+
+Carnatic **melakarta** sound-therapy: takes a melakarta number/name (or auto-selects by dosha × time-of-day) and returns its just-intonation swaras, shruti indices, chakra/dosha context, prahar timing, and Strudel-compatible ratio arrays so the web `RaagaPlayer` can render the raga as sound. Distinct from NadaBrahman (which *recommends* a raga); Raaga gives a chosen melakarta its full musical + therapeutic profile (`engine.ts:1-10`).
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `raaga` (confirmed: `ts-engines/src/engines/raaga/engine.ts:9,29,202`; `crates/noesis-bridge/src/lib.rs:303,726,816`; renderer route `apps/noesis-web/app/engines/page.tsx:247`) — **lowercase, not kebab** |
+| Crate | **— (no Rust engine; TypeScript engine)** |
+| Runtime source | **`ts-engines/src/engines/raaga/engine.ts`** (`RaagaEngine`, TS) — served via the Bun TS-engines server (`http://localhost:3001`, `crates/noesis-bridge/src/lib.rs:42`) behind `crates/noesis-bridge/src/lib.rs:297-303` (`BridgeEngine::raaga`) → registered in the bridge manager at `lib.rs:542` |
+| Data | `ts-engines/src/engines/raaga/wisdom.ts` — all **72 melakartas generated algorithmically** (Venkatamakhin/Katapayadi, `MELAKARTAS`, `wisdom.ts:180-207`) over a 22-shruti just-intonation table (`SHRUTIS`, `wisdom.ts:19-43`); dosha + prahar tables (`wisdom.ts:231-264`) |
+| Witness prompts | `ts-engines/src/engines/raaga/witness.ts` (`generateWitnessPrompts`) |
+| Renderer | `apps/noesis-web/src/components/engines/Raaga.tsx` (routed as `RaagaView`, `apps/noesis-web/app/engines/page.tsx:247-248`, `apps/noesis-web/app/readings/[id]/page.tsx:52`) |
+| Web data libs | `apps/noesis-web/src/lib/raaga/` (`RaagaPlayer`, `MELAKARTAS`, `SHRUTIS` — mirror of the backend data; `index.ts:1-3`); V2 audio (`lib/raaga/v2/`) |
+| OpenAPI stub | **— (not in `EngineResultData` enum; no `*ResultSchema`)** — confirmed absent from all of `crates/noesis-core/` |
+| Fixture (real values) | none found |
+
+## 2. Output schema
+
+The bridge passes the TS result through **verbatim** — `result: ts_response.result` (`noesis-bridge/src/lib.rs:441`), `witness_prompts[]` → envelope `witness_prompt` (first only, `lib.rs:442-447`), `consciousness_level` = the engine's `required_phase` = **0** (`lib.rs:448`; `engine.ts:37`). So the renderer receives the producer's exact `result` shape, un-reshaped.
+
+**Runtime JSON — what the TS producer emits (`engine.ts:178-199`):**
+```jsonc
+{
+  "melakarta": { "num": 15, "name": "Mayamalavagaula", "chakra": 3, "ma_type": "shuddha" }, // ma_type ∈ "shuddha"|"prati"
+  "swaras": [                                  // 8 entries, Sa Re Ga Ma Pa Dha Ni Sa' (engine.ts:143-155)
+    { "swara": "Sa", "shruti_index": 0, "ratio_num": 1, "ratio_den": 1, "ratio_decimal": 1.0, "hz": 220.0 }
+    // …7 more; hz = root_hz · ratio_decimal
+  ],
+  "strudel_ratios": [1.0, 1.066…, 1.25, 1.333…, 1.5, 1.6, 1.875, 2.0], // == swaras[].ratio_decimal; → RaagaPlayer.play(num,{rootHz})
+  "root_hz": 220,
+  "arohana_indices":  [0, 1, 7, 9, 13, 14, 20, 22],  // shruti indices, ascending (engine.ts:189)
+  "avarohana_indices":[22, 20, 14, 13, 9, 7, 1, 0],  // descending — arohana reversed (wisdom.ts:192)
+  "prahar": { "num": 1, "label": "Sunrise", "is_recommended_time": true }, // current 3-h watch (engine.ts:191-195)
+  "dosha_affinities": { "vata": true, "pitta": false, "kapha": false },    // which doshas list this raga (engine.ts:163-167)
+  "alternate_ragas": [ { "num": 22, "name": "Kharaharapriya", "chakra": 4, "ma_type": "shuddha" } ], // only if include_alternates && dosha (engine.ts:170-176)
+  "total_melakartas": 72
+}
+```
+
+**Inputs (all optional, `engine.ts:38-70`):** `melakarta` (1–72), `name` (partial match, overrides number), `dosha` (`vata|pitta|kapha`), `root_hz` (default 220 = A3), `include_alternates` (bool). With none given it auto-selects by current prahar; with `dosha` only, by dosha × prahar (`engine.ts:96-131`).
+
+**Envelope note (TS vs Rust):** the TS `EngineOutput` is `{ engine_id, result, witness_prompts[], calculated_at, processing_time_ms }` (`ts-engines/src/types/engine.ts:32-43`) — it has **no** `consciousness_level`/`metadata`; the bridge synthesizes those (`lib.rs:439-456`). The README envelope describes the post-bridge Rust shape.
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `melakarta.num` | **1–72** | validated integer 1–72 (`engine.ts:110`); 1–36 = shuddha Ma, 37–72 = prati Ma (`wisdom.ts:181`) |
+| `melakarta.chakra` | **1–12** | indu(1)…aditya(12); = `chakraInSet + (prati?7:1)` (`wisdom.ts:197`) |
+| `melakarta.ma_type` | `shuddha` \| `prati` | shuddha = M1 (shruti 9), prati = M2/tivra (shruti 12) (`wisdom.ts:188,201`) |
+| `swaras` | **8 entries** | labels `Sa Re Ga Ma Pa Dha Ni Sa'` (`engine.ts:143`); one per arohana degree |
+| `swaras[].shruti_index` | **0–22** | index into the 22-shruti table (+Sa' at 22) (`wisdom.ts:19-43`) |
+| `swaras[].ratio_num/den` | JI integers | hard-coded parallel arrays indexed by `shruti_index` (`engine.ts:147-152`) — **must stay in sync with `SHRUTIS`** (§7) |
+| `swaras[].ratio_decimal` | **1.0 → 2.0** | one octave; monotonic non-decreasing along arohana; = `m.ratios[i]` (`engine.ts:153`) |
+| `swaras[].hz` | `root_hz · ratio_decimal` | rounded to 3 dp (`engine.ts:154`); with default root_hz 220 → 220.0…440.0 |
+| `arohana_indices` / `avarohana_indices` | 8 shruti indices each | avarohana = arohana reversed (`wisdom.ts:192`) — melakartas are sampurna (all 7 swaras, both directions) |
+| `prahar.num` | **1–8** | 8 watches × 3 h; `getPraharForHour` (`wisdom.ts:255-276`) |
+| `prahar.is_recommended_time` | bool | true iff this melakarta is in the current prahar's `recommended[]` (`engine.ts:160`) |
+| `dosha_affinities.{vata,pitta,kapha}` | bool each | from the `DOSHA_AFFINITY` table (`wisdom.ts:231-238`); a raga may match 0, 1, or several |
+| `root_hz` | > 0 (default 220) | not range-validated; echoes input (`engine.ts:80`) |
+
+**Invariants.** (a) `swaras` (8), `arohana_indices` (8), `strudel_ratios` (8) are all derived from the same `m.arohana` — they co-vary, never independent (`engine.ts:144,189; wisdom.ts:190`). (b) The melakarta is fully determined by `num` via the Venkatamakhin formula (R-G pair from chakra-set, D-N pair from position, Ma from >36) — name/swaras/ratios are pure functions of `num` (`wisdom.ts:180-203`). (c) Auto-selection is **time-dependent** (reads `new Date().getHours()`, `engine.ts:120,128,158`) — same inputs at a different hour can pick a different raga and always recompute `prahar`. (d) The renderer recomputes the descending row itself (`avaroha`, `Raaga.tsx:75-78`) and **ignores** the producer's `avarohana_indices`.
+
+## 4. Component & brand archetype
+**Today** (`Raaga.tsx`): a text-card grid (melakarta #+name, chakra, Ma-type, root Hz, current prahar, dosha tags, vadi·samvadi, rasa/mood) + two **8-cell swara strips** — Ārohana (`Raaga.tsx:197-209`) and Avarohana (muted, `:212-224`), each cell = swara name + Hz — plus a Strudel **audio bar** (Play/Stop/WAV) with an optional **V2 panel** (timbre, gamaka, tala, breath selectors; `Raaga.tsx:237-296`). On-brand colors via CSS vars (`--gold`, `--gold-soft`, `--line-gold`), but **no geometry yet** — the swaras are a flat grid, not an arc/ring; chakra, prahar, vadi/samvadi are text only. Falls back to `GenericEngineView` when `result.melakarta` is missing (`Raaga.tsx:144`).
+
+**Wave-2 target (tonal arc / swara wheel):** the 7 swaras placed on an **octave arc/ring** (Sa→Sa', 1.0→2.0), the raga's **present notes lit on the Ba-Arc** (shruti positions from `arohana_indices`), the **vadi/samvadi emphasized** as the dominant nodes, and the **current prahar shown as the wheel's orientation** (time-of-day rotation). Melodic, sacred-geometry, not decorative. Brand palette: Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `swaras[].ratio_decimal` (1.0→2.0) | angular position of each swara node on the octave arc/ring (target) |
+| `arohana_indices` (0–22) | shruti slots lit on the Ba-Arc; present notes glow, absent shruti dim (target) |
+| `swaras[].swara` + `.hz` | node label (name) + tooltip/sub (Hz) — today the 8 strip cells (`Raaga.tsx:201-206`) |
+| `vadi` / `samvadi` | (target) two emphasized nodes (vadi = brightest, samvadi at the consonant ~4th/5th) — **producer does not emit these (§7)** |
+| `arohana` vs `avarohana` | ascending vs descending sweep around the ring; today two strips (`Raaga.tsx:197-224`) |
+| `melakarta.ma_type` | Ma node placement: shuddha M1 vs tivra M2 (shruti 9 vs 12); today text `Tīvra/Shuddha Ma` (`Raaga.tsx:158`) |
+| `melakarta.chakra` (1–12) | (target) outer ring sector / hue band; today text (`Raaga.tsx:158`) |
+| `prahar.label` + `.is_recommended_time` | (target) wheel orientation = time-of-day; today the gold prahar box (`Raaga.tsx:165-175`) |
+| `dosha_affinities` | active dosha tags (`Raaga.tsx:176-181`) — could tint the core |
+| `melakarta.num` + `root_hz` | header + Strudel `play(num,{rootHz})` (`Raaga.tsx:109`) |
+
+## 6. Dynamics
+**One-shot per request, but inputs include the wall clock.** A reading is computed once from `(melakarta?|name?, dosha?, root_hz, include_alternates)` (`engine.ts:74-208`); not a live stream. However, when `melakarta`/`name` are omitted the selection and the reported `prahar` depend on `new Date().getHours()` (`engine.ts:120,128,158`), so re-running at a different watch can change the raga — a *soft* time-of-day cadence (unlike vedic-clock's continuous one). Audio is **interactive, not data**: the user drives Play/Stop/WAV and the V2 controls (timbre/gamaka/tala/breath) in the client `RaagaPlayer` (`Raaga.tsx:90-142`) — none of that feeds back into `result`. Natural one-time animation: the swara arc drawing in (stroke/scale), present-note glow, and the ascending→descending sweep. `consciousness_level` is fixed at 0 here (`required_phase`, `engine.ts:37`) so it gates nothing for this engine.
+
+## 7. Open questions / assumptions
+- **⚠️ NO Rust engine, NO OpenAPI stub.** Raaga is absent from the `EngineResultData` enum and has no `*ResultSchema` anywhere in `crates/noesis-core/` (verified). Its only producer is the **TypeScript** `RaagaEngine`, reached through `noesis-bridge` (`lib.rs:297-303`) → Bun server (`:3001`). The bridge passes `result` through unchanged (`lib.rs:441`), so the producer + renderer are the **only two contracts** — both authoritative.
+- **⚠️ Producer ↔ renderer mismatch — `mood` / `rasa` / `vadi` / `samvadi` are read but never emitted (likely a real gap; the headline issue).** The renderer reads `result.mood`, `result.rasa`, `result.vadi`, `result.samvadi` (`Raaga.tsx:69-72`) and renders Vadi·Samvadi and Rasa/Mood cards (`Raaga.tsx:182-193`). **The producer's `result` object contains none of these** (`engine.ts:178-199`) — and `wisdom.ts` carries no rasa/vadi/samvadi data at all (the `Melakarta` interface is `num,name,chakra,arohana,avarohana,ratios,ma_type`, `wisdom.ts:170-178`). So today those cards are **always hidden**. This directly blocks the Wave-2 "vadi/samvadi emphasized" archetype: the data must be added to `wisdom.ts` + emitted in `engine.ts`, or the renderer must derive/drop them. **Resolve before building the swara wheel.**
+- **Domain facts the task asked to verify — what actually exists vs not:**
+  - *Raga name / thaat:* this is the **Carnatic melakarta** system (72 parent scales), the South-Indian analogue of Hindustani **thaat** — the melakarta *is* the parent scale (`engine.ts:1-7`; `wisdom.ts:73-92`). Individual `name`s are the canonical Venkatamakhin set (`wisdom.ts:95-168`).
+  - *Swaras (Sa Re Ga Ma Pa Dha Ni):* present as the 8-degree arohana with shruti variants — komal/shuddha/tivra encoded as **shruti indices** (e.g. shuddha Ma = 9, tivra Ma = 12; R/G/D/N variants via the `SW` map, `wisdom.ts:52-70`), **not** as komal/tivra labels. The renderer surfaces only Ma-type as a word (`Raaga.tsx:158`).
+  - *Aroha / avaroha:* yes — `arohana_indices` / `avarohana_indices` (`engine.ts:189`); melakartas are sampurna so avarohana = arohana reversed (`wisdom.ts:192`).
+  - *Vadi / samvadi:* **NOT present** anywhere (see mismatch above) — would be new data.
+  - *Time-of-day:* yes — 8 prahars (`PRAHARS`, `wisdom.ts:255-264`), reported as `prahar.{num,label,is_recommended_time}`.
+  - *Season / rasa:* **NOT present** (no season field; rasa only read, never produced).
+  - *Root frequency:* yes — `root_hz`, default **220 Hz (A3)** for Sa (`engine.ts:80`; `Raaga.tsx:158-164`).
+- **`prahar.num` shape match:** producer emits `prahar.num` (`engine.ts:192`) and renderer reads `prahar.num` as optional (`Raaga.tsx:57`) — ✅ aligned (no mismatch here).
+- **Duplicate/divergent data sources.** The 22-shruti table + 72 melakartas exist **twice** — backend `ts-engines/.../wisdom.ts` and web `apps/noesis-web/src/lib/raaga/{shrutis,melakartas}.ts` (the renderer's `RaagaPlayer` uses the web copy, `lib/raaga/index.ts:1-3`). The header comment claims they're kept "numerically identical" (`wisdom.ts:8-9`), but that's a manual invariant — **drift risk** (e.g. the hard-coded `ratio_num/ratio_den` arrays in `engine.ts:147-152` must also track `SHRUTIS`). Not verified equal here.
+- **Vivadi aliases / "missing" geometry.** Some shruti slots collapse (R3≡G1 at index 5, D3≡N1 at index 18 — `wisdom.ts:36,38,52-70`); a swara-wheel must decide whether to draw 22 distinct positions or the collapsed 16. Flag for the Wave-2 ring design.
+- **`avarohana_indices` is emitted but unused.** The renderer recomputes the descending row from `swaras` reversed (`Raaga.tsx:75-78`) rather than reading the producer's `avarohana_indices` — harmless today (melakarta avarohana = reverse), but the producer field is dead from the web's perspective.

--- a/docs/engines/sacred-geometry.md
+++ b/docs/engines/sacred-geometry.md
@@ -1,0 +1,94 @@
+# Sacred Geometry — Data Reference
+
+A contemplative engine: pick (or randomly seed) one sacred geometric **form** — Flower of Life, Metatron's Cube, Sri Yantra, a Platonic solid… — and return its symbolism, elements, a numerology number, and a meditation prompt. The brand's core motif: the whole design system *is* sacred geometry, so this renderer is its most literal expression.
+
+> ⚠️ **The README lists this engine as "stub only / runtime source unconfirmed." That is wrong.** There is no Rust `engine-*` crate, but there **is** a fully-implemented **TypeScript** producer (`ts-engines/src/engines/sacred-geometry/`). The Rust side is an HTTP proxy. See §1 and §7.
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `sacred-geometry` (confirmed: TS `metadata().id` engine.ts:34; Rust bridge lib.rs:283; SDK list client.rs:30) |
+| Rust crate | **— (no Rust engine; OpenAPI stub + HTTP-proxy bridge + renderer)** |
+| **Runtime source** | **`ts-engines/src/engines/sacred-geometry/engine.ts`** (`SacredGeometryEngine.calculate`, L56) — the real producer, a Bun HTTP service |
+| Producer catalog | `ts-engines/src/engines/sacred-geometry/wisdom.ts` (`SACRED_FORMS[]`, L16 — 13 forms) · `witness.ts` (prompts) |
+| Bridge (Rust→TS) | `crates/noesis-bridge/src/lib.rs:277` (`BridgeEngine::sacred_geometry`, `required_phase=0`) → POST `…/engines/sacred-geometry/calculate` at `DEFAULT_TS_SERVER_URL` `http://localhost:3001` (lib.rs:42; env `TS_ENGINES_URL` lib.rs:558) |
+| Renderer | `apps/noesis-web/src/components/engines/SacredGeometry.tsx` (⚠️ not wired into any grid/router yet — no importer found in `apps/noesis-web/src`) |
+| Fixture (real values) | **none found** — no JHora/reference fixture; nearest sample is the orchestrator mock `mock_geometry_output()` (synthesis/creative_expression.rs:645) |
+| OpenAPI stub | `crates/noesis-core/src/types.rs:346` (`SacredGeometryResultSchema` — `pattern`/`point_count`/`symbolic_theme`) |
+
+**Two name spaces, one engine.** The TS metadata `id` is `sacred-geometry` (engine.ts:34) — the same string the Rust bridge registers. (Some grep tooling renders the class/path as `ln`; that is a display artifact, the source reads `SacredGeometryEngine` / `sacred-geometry`.)
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — what the TS producer emits, engine.ts:89–105):**
+```jsonc
+{
+  "form": {
+    "id":          "flower-of-life",            // enum, see §3 (13 ids)
+    "name":        "Flower of Life",
+    "description": "An ancient symbol composed of …",
+    "symbolism":   "Unity, creation, and the interconnectedness …",
+    "elements":    ["circle", "hexagon", "vesica piscis"],  // string[]
+    "numerology":  6                            // int 0–20 (per-form constant; NOT point_count)
+  },
+  "meditation": { "prompt": "Allow your awareness to rest …", "duration_suggestion": "5-15 minutes" }, // OBJECT
+  "intention":   null,                          // string | null (echo of question/parameters.intention)
+  "svg_preview": { "status": "absent" },        // OBJECT {status:'absent'|'accepted'|'rejected', reason?} — NOT a string
+  "seed":        123456
+}
+```
+This `result` is wrapped in the standard `EngineOutput` envelope (engine_id, result, witness_prompts[], calculated_at, processing_time_ms — TS types `ts-engines/src/types/engine.ts:35`; Rust mirror `TsEngineResponse` ts_client.rs:28 → mapped to core `EngineOutput` lib.rs:439).
+
+**OpenAPI stub `SacredGeometryResultSchema` (types.rs:346 — docs only, ⚠️ does NOT match the producer):**
+`{ pattern:String="flower-of-life", point_count:i32=144, symbolic_theme:String="Harmonic expansion" }`. **None of these three fields exist in the runtime JSON.** `pattern`≈`form.id`; `point_count` and `symbolic_theme` are invented examples — do not build against them.
+
+**Renderer's read shape (`SacredGeometry.tsx`)** — tolerant, with fallbacks for a *flatter* shape that the producer does not emit (mismatches in §7):
+`result.form.{name,category,elements,symbolism,golden_ratio_present,description}` (preferred) **OR** flat `result.{form_name|primary_form, form_id, category, elements, symbolism, golden_ratio, description}`; plus `result.intention`, `result.svg_preview` (read as **string** → `dangerouslySetInnerHTML`), `result.meditation_guidance` (read as **string**). Pattern art is chosen by `detectForm(name)` (SacredGeometry.tsx:27) string-matching the form name.
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `form.id` | **13-value enum** (wisdom.ts:16) | `flower-of-life`, `seed-of-life`, `metatrons-cube`, `sri-yantra`, `vesica-piscis`, `tetrahedron`, `cube`, `octahedron`, `dodecahedron`, `icosahedron`, `golden-spiral`, `torus` — **12 listed; README "platonic solids" = the 5 solids** (tetra/cube/octa/dodeca/icosa). Input `form` validated against this set or 400 `INVALID_SACRED_FORM` (engine.ts:69) |
+| `form.numerology` | **int 0–20** | per-form constant, not a count: torus=0, golden-spiral=1, vesica-piscis=2, tetra=4, flower/cube=6, seed=7, octa=8, sri-yantra=9, dodeca=12, metatron=13, icosa=20 (wisdom.ts) |
+| `form.elements` | `string[]` (1–7) | building blocks, e.g. metatron = circle/line + 5 Platonic solids (wisdom.ts:50) |
+| `meditation.duration_suggestion` | constant `"5-15 minutes"` | engine.ts:100 |
+| `svg_preview.status` | `absent`\|`accepted`\|`rejected` | `absent` unless caller passes `parameters.svg_template`; rejected if not a complete `<svg>…</svg>` or contains `<script`/`onload=` (XSS guard, engine.ts:12–30) |
+| `intention` | string \| `null` | from `input.question` ?? `parameters.intention` (engine.ts:61) |
+| `seed` | u64 | echoed; drives random form pick + witness template choice (engine.ts:63,77) |
+| `consciousness_level` | required_phase **0** | lowest gate — always accessible (engine.ts:39; bridge lib.rs:283) |
+
+**Stub-only fields** (`point_count`, `symbolic_theme` — types.rs:349-352): **invented**, no producer emits them. Renderer-only fields (`category`, `golden_ratio_present`/`golden_ratio`): **not emitted** by the producer → those renderer cells are always hidden today.
+
+**Orchestrator vocabulary divergence:** the Creative Expression workflow's Rust `SacredForm` enum (creative_expression.rs:30) uses **underscore** ids (`flower_of_life`, `metatrons_cube`, `platonic_solids`) and adds `circle`/`merkaba`/`fibonacci_spiral`/`platonic_solids` not in the TS catalog — that enum feeds *workflow options/synthesis*, not the engine's own id set (hyphenated). When sending `parameters.form` to the engine, use the **hyphenated** TS ids.
+
+## 4. Component & brand archetype
+**Today** (`SacredGeometry.tsx`): renders a **200×200 SVG** of the detected form (emerald stroke `rgba(16,181,167)` on a Void `#070B1D` field) — hand-built generators for flower-of-life (center + hex ring), Metatron's cube (13 centers, all interconnecting lines), Sri Yantra (3 up + 3 down nested triangles + bindu), Fibonacci (golden-spiral arcs + φ-rectangle), seed-of-life, vesica-piscis, merkaba (two tetrahedra), torus (tilted ellipses), and a default mandala — plus a text grid (Form, Symbolism, Golden Ratio, Elements), held-intention line, description, and a gold meditation-guidance card. If `result.svg_preview` is a (truthy) string it is injected raw and replaces the generator. **Already on-brand** (emerald sacred-geometry line-art on Void) but **static** — no draw-in animation, and several reads don't match the producer (§7).
+
+**Wave-2 target:** **nested Platonic solids / Flower-of-life construction drawn from the data** — Anime.js **self-drawing** (`stroke-dashoffset`) construction on load: the active `form.id` selects the geometry, `form.elements` drives which sub-figures nest (e.g. Metatron → draw the 13 circles, then the connecting lattice, then the 5 inscribed solids in sequence), `form.numerology` sets the node/petal count, gold `#C5A017` for the φ/golden-ratio elements. This engine should be the **most literal** sacred-geometry renderer in the system.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `form.id` / `form.name` | selects the construction (`detectForm` → generator); center label = name |
+| `form.numerology` | (target) node / vertex / petal count of the drawn figure |
+| `form.elements` | (target) which sub-figures are nested & drawn in sequence (circle→hexagon→solids) |
+| `form.symbolism` | text cell (gold) |
+| `form.description` | description panel |
+| golden-ratio forms (`golden-spiral`, `dodecahedron`) | (target) φ elements drawn in gold `#C5A017`; renderer's "Golden Ratio ◈" cell — but see §7, field not emitted |
+| `meditation.prompt` | (target) gold meditation card — **renderer currently reads `meditation_guidance`, a different path** (§7) |
+| `intention` | "Held intention: …" line |
+| `svg_preview` (if `accepted`) | server-supplied SVG injected raw, replacing the generator |
+
+## 6. Dynamics
+**One-shot per (form, intention, seed).** Not live; no time/place inputs (unlike Vedic engines), no baseline/delta (unlike biofield). Output is **deterministic given `seed`** — same seed + same form ⇒ identical witness prompts (SeededRandom, engine.ts:77,82); omit `form` and the seed also picks the form. On render, the construction should animate in once (Anime.js line-draw); an optional slow core "breath" (4:7:8) suits the bindu/center. `consciousness_level` is `0` (always available); deeper levels could gate how much symbolism/meditation text is surfaced, but the producer returns the full block regardless today.
+
+## 7. Open questions / assumptions
+- **⚠️ Missing-engine premise is FALSE / README is stale (highest priority).** README lists Sacred Geometry as crate `—` with runtime source **`unconfirmed`** (README.md:43,61). In fact there is **no Rust crate** but a **fully-implemented TS producer** (`ts-engines/.../engine.ts`) reached via `noesis-bridge` HTTP proxy to `:3001`. **Action:** update README's Sacred Geometry row → runtime source = `ts-engines (bridge)`; same correction almost certainly applies to the other four "stub only" engines (Enneagram, Tarot, I Ching, Sigil Forge — all have `BridgeEngine` factories lib.rs:248–293 and `ts-engines/src/engines/*` dirs).
+- **⚠️ Stub fields are fiction.** `point_count: 144` and `symbolic_theme` (types.rs:349-352) appear in **no** producer or renderer. The real per-form scalar is `form.numerology` (0–20). Don't build the Wave-2 "144 nodes" idea on the stub — derive node count from `numerology`/`elements`.
+- **⚠️ Renderer ↔ producer schema mismatches (real bugs, confirmed):**
+  1. `meditation`: producer emits **object** `{prompt, duration_suggestion}` (engine.ts:98); renderer reads **`result.meditation_guidance`** as a string (SacredGeometry.tsx:361) → meditation card **never shows**. Renderer should read `result.meditation.prompt`.
+  2. `svg_preview`: producer emits **object** `{status, reason?}` (engine.ts:103); renderer treats it as a **string** and feeds `dangerouslySetInnerHTML` (SacredGeometry.tsx:309,372) → object is truthy, so it would inject `[object Object]`-ish / break. Renderer should gate on `svg_preview.status==='accepted'` and use the (separately-returned) markup — note the producer **validates** but does not currently return the SVG body, only status.
+  3. `form.category` and `form.golden_ratio_present`/`golden_ratio` are read by the renderer (SacredGeometry.tsx:366,369) but **not emitted** → those cells are dead today. Either add them to the producer or drop the cells.
+- **No fixture.** Unlike panchanga, there's no reference JSON. The orchestrator mock (`mock_geometry_output`, synthesis/creative_expression.rs:645) is the only sample shape and is **not** authoritative — verify any field against `engine.ts`/`wisdom.ts`, not the mock.
+- **Renderer is orphaned.** No file under `apps/noesis-web/src` imports `SacredGeometry.tsx` (grep finds only self-references) — confirm how/whether it's mounted before relying on it as "the renderer in production."
+- **Synthesis reads a 3rd shape.** `extract_geometry_themes` reads `result.{available, form (string), qualities[]}` (synthesis/creative_expression.rs:357) — `available`/`qualities` are **not** in the producer's output either; that path likely expects a different envelope. Flag for the orchestrator owners.

--- a/docs/engines/sigil-forge.md
+++ b/docs/engines/sigil-forge.md
@@ -1,0 +1,112 @@
+# Sigil Forge — Data Reference
+
+Guided sigil creation: turns a present-tense **intention** into a chosen **method** (word-elimination, rose-wheel, pictographic, chaos-star) with process steps, charging suggestions, and witness prompts — plus an *optional* AI-generated sigil image (NVIDIA NIM, base64 PNG). It does **not** auto-generate a vector glyph.
+
+> ⚠️ **Read [§7](#7-open-questions--assumptions) first.** The OpenAPI stub (`sigil_id` / `intention` / `vector_path`) describes a glyph-generating engine that **does not exist in this repo**. No code anywhere produces a `vector_path` / SVG `d` string. Build against the **TS producer** + **renderer**, not the stub.
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `sigil-forge` (confirmed — producer `metadata().id` & output `engine_id`, `ts-engines/src/engines/sigil-forge/engine.ts:59,303`) |
+| Crate | **— (no Rust engine; OpenAPI stub + renderer)** |
+| Runtime source | **`ts-engines/src/engines/sigil-forge/engine.ts`** (`SigilForgeEngine`, L32) — TS sidecar, registered `ts-engines/src/index.ts:27` |
+| Renderer | `apps/noesis-web/src/components/engines/SigilForge.tsx` |
+| Fixture (real values) | **none found** (no `tests/fixtures` for sigil-forge; output shape taken from producer + `engine.test.ts`) |
+| OpenAPI stub | `crates/noesis-core/src/types.rs:357` (`SigilForgeResultSchema` — `sigil_id`/`intention`/`vector_path`) — **examples only, and they do not match runtime** |
+
+Supporting TS modules: `wisdom.ts` (4 `SIGIL_METHODS`, 5 `CHARGING_METHODS`, `processWordElimination`), `prompt-builder.ts` (`buildSigilPrompt`/`buildSigilEditPrompt`, NIM prompt + style), `witness.ts` (`generateWitnessPrompts`), `utils/nvidia-image.ts` (`generateImage`/`editImage`/`isImageGenAvailable`).
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — what `SigilForgeEngine.calculate()` returns in `result`, `engine.ts:255-300`):**
+```jsonc
+{
+  "intention": "I attract peace and clarity",        // cleaned input string (present-tense statement)
+  "method": {                                          // selected sigil method (object, NOT a string)
+    "id": "word-elimination",                          // ∈ word-elimination | rose-wheel | pictographic | chaos-star
+    "name": "Word Elimination Method",
+    "description": "…",
+    "steps": ["…", "…"]                                // ordered how-to steps
+  },
+  "processing": {                                       // ONLY when method.id === "word-elimination"; else null
+    "type": "word_elimination",
+    "original": "I attract peace and clarity",
+    "remaining_letters": "TRCPL",                       // dedup'd consonants (processWordElimination)
+    "letter_count": 5
+  },
+  "charging_suggestions": [                             // exactly 2, sampled from CHARGING_METHODS
+    { "name": "Meditation Gnosis", "description": "…" },
+    { "name": "Destruction Charging", "description": "…" }
+  ],
+  "guidance": {
+    "note": "This engine provides the process… the actual visual sigil must be created by you.",
+    "next_steps": ["…", "…"]                            // branches on whether an image was generated
+  },
+  "svg_preview": { "status": "absent" },               // OBJECT {status, reason?} — NOT an SVG string. status ∈ absent|accepted|rejected
+  "generated_image": null,                             // null unless generate_image/edit_image_b64 set (see §3)
+  "image_gen_available": false,                        // isImageGenAvailable() — NVIDIA_API_KEY present?
+  "seed": 1234567890                                    // SeededRandom seed (input.seed ?? getDefaultSeed())
+}
+```
+Envelope is the **TS** shape (`engine.ts:302-308`): `{ engine_id, result, witness_prompts: string[], calculated_at, processing_time_ms }` — note `witness_prompts` (plural array), `calculated_at`/`processing_time_ms`, **not** the Rust `EngineOutput` (`witness_prompt`, `consciousness_level`, `metadata`). Whatever proxies the sidecar into the Rust envelope is unconfirmed.
+
+**OpenAPI stub (`types.rs:357` — DOES NOT MATCH runtime; treat as fiction, not even valid examples):**
+```rust
+pub struct SigilForgeResultSchema {
+    pub sigil_id: String,    // example "SIG-20260303-9A7"  ← no producer emits this
+    pub intention: String,   // example "clarity"           ← runtime key matches, value is a full sentence
+    pub vector_path: String, // example "M1 L10,2 L15,8 …"  ← NO code generates an SVG path anywhere
+}
+```
+Only `intention` overlaps (and even then the stub's one-word `"clarity"` misrepresents the real full-sentence value). `sigil_id` and `vector_path` appear in **zero** runtime code paths (verified: `rg "vector_path|sigil_id"` across `ts-engines` + `crates/*/src` returns nothing outside the stub).
+
+**Renderer's expected shape (`SigilForge.tsx` — a THIRD shape, also not the producer's):**
+Reads `result.sigil.{name,symbol_set,numerological_base,activation_phrase,svg_preview}` *or* flat `result.{sigil_name,symbol_set,numerological_base,activation_phrase,svg_preview}`, plus `result.activated_elements ?? result.elements` and `result.intention_field ?? result.intention`. It expects `svg_preview` to be an **HTML/SVG string** and injects it via `dangerouslySetInnerHTML` (L35). **None** of `sigil.name`, `symbol_set`, `numerological_base`, `activation_phrase`, `activated_elements`, `intention_field` are produced by `SigilForgeEngine`. Only `result.intention` matches. With the real payload the guard at L25 (`if (!sigil && !elements && !intention)`) passes via `intention`, then renders essentially just the Intention Field box — and the `svg_preview` object would be coerced to `[object Object]` text inside `dangerouslySetInnerHTML`.
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `intention` | non-empty string | required; from `input.question` or `parameters.{intention,intent,intent_text,question}` (`engine.ts:115-120`); trimmed; empty → `MISSING_INTENTION` validation error |
+| `method.id` | `word-elimination` \| `rose-wheel` \| `pictographic` \| `chaos-star` | `wisdom.ts:13-75`; unknown `parameters.method` → `INVALID_SIGIL_METHOD` |
+| method auto-select | length>50 → word-elimination; ≤3 words → pictographic; else seeded random pick | `engine.ts:152-161` |
+| `processing` | object \| **null** | non-null only for `word-elimination`; `letter_count == remaining_letters.length` |
+| `charging_suggestions` | **exactly 2** | seeded sample of 5 `CHARGING_METHODS` (`engine.ts:170-171`) |
+| `svg_preview.status` | `absent` \| `accepted` \| `rejected` | `absent` if no `parameters.svg_template`; **rejected** if not a complete `<svg>…</svg>`, or if it contains `<script`/`onload=` (`safeSvgPreview`, `engine.ts:33-51`). Server-side allowlist guard. |
+| `generated_image` | **null** \| `{b64_json?,url?,prompt_used?,style?,model?,error?}` | null in default guidance mode; populated only when `parameters.generate_image=true` (new) or `parameters.edit_image_b64` set (edit). If `NVIDIA_API_KEY` missing → `{error:"…"}` (`engine.ts:193-251`) |
+| `image_gen_available` | boolean | mirrors `NVIDIA_API_KEY` presence |
+| `seed` | number | echoes input seed for reproducibility |
+| `image_style` (input) | `ceremonial`\|`chaos`\|`organic`\|`geometric`\|`runic`\|`ethereal` | NIM style; default method-dependent (`engine.ts:84-89`, `prompt-builder.ts`) |
+
+**Determinism:** identical `(intention, method, seed)` → identical guidance, processing, charging picks, witness prompts. **Image generation is the one non-deterministic, network-dependent, slow (5–15 s) path** (`engine.test.ts:82`). Default mode is pure/fast.
+
+**Invariant the stub violates:** there is **no canonical sigil identifier** and **no generated vector geometry**. The engine's stated contract is that the human draws the glyph ("this personal investment is essential to the magic", `engine.ts:279`).
+
+## 4. Component & brand archetype
+**Today** (`SigilForge.tsx`): if `svg_preview` is a string, inject it raw in `svgBox`; then a small grid of `Sigil` (name + symbol_set) and `Num. Base` cells, an italic **Intention Field** box, **Activated Elements** as gold tags, and a centered **activation phrase**. Falls back to `GenericEngineView` when none of sigil/elements/intention present. Mostly text on `var(--field)` with gold accents — **no geometry today**, and (per §2) most cells stay empty against the real payload.
+
+**Wave-2 target:** a **sigil construction diagram**. Since the producer yields **no `vector_path`**, the brand's "geometry drawing itself" must be sourced one of two honest ways: (a) render the optional **`generated_image.b64_json`** (NIM PNG) as the central glyph; or (b) if/when a real `vector_path` producer is added, draw that SVG `d` string with **Anime.js `stroke-dashoffset`** line-draw. Readout: **intention** + **method.name** + (for word-elimination) the **`remaining_letters`** as the distilled core. Optional faint **construction grid** (rose-wheel / chaos-star geometry implied by `method.id`) behind the drawn form. Charging suggestions become a footer ritual. Brand palette: Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `intention` | center readout / title; the "seed phrase" the glyph encodes |
+| `method.id` | construction-grid template behind the glyph (rose-wheel = petalled wheel, chaos-star = 8-ray star, pictographic = combinatorial, word-elimination = letterform) |
+| `method.name` + `method.steps` | side panel "how this was forged" (step list) |
+| `processing.remaining_letters` | distilled letter-core rendered as the glyph's strokes (word-elimination only); animate draw-in |
+| `generated_image.b64_json` | **the drawn glyph** (NIM PNG) when present — fade/scale-in on load |
+| *(hypothetical) `vector_path`* | **does not exist** — would be the Anime.js `stroke-dashoffset` line-draw target if a producer is added |
+| `charging_suggestions[]` | footer ritual chips (2) |
+| `svg_preview.status` | dev/QA badge only (`accepted`/`rejected`/`absent`) — **never inject `.reason` or template blindly** (see §7) |
+| `seed` | small "reproducible" marker |
+
+## 6. Dynamics
+**One-shot** per `(intention, method, seed)`. Not live; no time-of-day recompute (unlike vedic-clock), no baseline/delta (unlike biofield). Recompute only when the intention/method/seed/image-flags change. Two cost tiers: **default guidance** = synchronous, deterministic, sub-ms-ish; **image mode** (`generate_image`/`edit_image_b64`) = async NIM call, 5–15 s, network- and key-dependent, may return `{error}`. On render: animate the glyph (PNG fade-in, or — if a vector_path ever exists — a single line-draw); no perpetual loop except an optional slow brand "breath." Envelope `consciousness_level` is absent from the TS output, so depth-gating (if any) is applied by whatever wraps the sidecar, not here.
+
+## 7. Open questions / assumptions
+- **🚨 NO DEDICATED ENGINE + STUB IS FICTION (most important).** There is **no Rust `engine-sigil-forge` crate**. The only Rust artifact is the OpenAPI stub `SigilForgeResultSchema` (`types.rs:357`), and its fields **`sigil_id` and `vector_path` are produced by no code in this repo** (verified by grep across `ts-engines` and all `crates/*/src`). The real producer is the **TS sidecar** `ts-engines/src/engines/sigil-forge/engine.ts`. **Do not build anything against `sigil_id`/`vector_path`.** The brief's premise that `vector_path` is "the generated glyph" is **not implemented** — this engine deliberately makes the *human* draw the glyph; the only machine-generated visual is an optional NIM **PNG**, never an SVG path.
+- **Three-way schema divergence (confirmed).** Producer emits `{intention, method{}, processing|null, charging_suggestions[], guidance{}, svg_preview{status}, generated_image|null, …}`. Stub claims `{sigil_id, intention, vector_path}`. Renderer expects `{sigil.{name,symbol_set,numerological_base,activation_phrase,svg_preview}, activated_elements, intention_field}`. **Only `intention` is common to all three.** The renderer would display almost nothing useful from the real payload. Wave-2 must reconcile renderer ↔ producer (rewrite the renderer to the producer shape, or add a mapper).
+- **🔒 SECURITY — injecting a server-provided SVG.** `SigilForge.tsx:35` injects `svg_preview` via **`dangerouslySetInnerHTML`**. If the renderer is ever fed a *string* `svg_preview` (as the renderer expects, and as the stub's "vector_path"/SVG idea implies), that is a stored-XSS vector: a raw `<svg>` can carry `<script>`, `onload=`, `<foreignObject>`/`<a href=javascript:>`, etc. The producer's `safeSvgPreview` (`engine.ts:42-50`) only checks `<svg…</svg>` + blocks `<script`/`onload=` — **substring-based and easily bypassed** (`onerror=`, `onclick=`, `on…` handlers, `<animate>`/`<set attributeName=href>`, encoded payloads). Net: today the renderer receives an *object* (so it stringifies harmlessly to `[object Object]`), but the moment a string path/template flows through, **the current guard is insufficient** — sanitize (e.g. DOMPurify with an SVG profile) before any `dangerouslySetInnerHTML`, or render a typed `vector_path` as an SVG `<path d>` attribute (data-only, never markup) instead of injecting markup. If a `vector_path` producer is added, prefer the **typed `d`-attribute** route precisely to avoid this.
+- **`ln` / `RaagaEngine` red herring.** A stale code-index hit suggested `engine_id: 'ln'` for this engine; the on-disk file is unambiguous — `id:'sigil-forge'` (L59), `engine_id:'sigil-forge'` (L303). The `ln`/`lnEngine` references belong to a *different* (Raaga/Nadabrahman-adjacent) engine and are unrelated to Sigil Forge.
+- **Envelope mismatch.** TS returns `witness_prompts:string[]`, `calculated_at`, `processing_time_ms`; the Rust `EngineOutput` (README envelope) expects `witness_prompt`, `consciousness_level`, `metadata`. The adapter that maps the sidecar response into the canonical envelope (and back to `engine_id "sigil-forge"`) was not located — **unconfirmed**; confirm how `noesis-api` proxies `ts-engines` before relying on envelope fields for this engine.
+- **No fixture.** Unlike the Vedic engines, there's no reference fixture; the schema here is read from the producer source + `engine.test.ts`. Capture a real default-mode response as a fixture during Wave-2.
+- **Synthesis reads other keys.** `creative_expression.rs` probes `sigil_data.{intention_or_intent, energy, keywords, distilled, available}` — **none of which the current producer emits** (those came from an older/mock shape, e.g. `mock_sigil_output` at `creative_expression.rs:622`). So `CreativeExpressionSynthesis` likely degrades to its empty/"available:false" path with real data — confirm and align if synthesis output matters for Wave-2.

--- a/docs/engines/tarot.md
+++ b/docs/engines/tarot.md
@@ -1,0 +1,97 @@
+# Tarot — Data Reference
+
+A seeded card draw laid on a named spread: per-position card (name, arcana, suit, element, upright/reversed) with position meaning + keywords, plus reflective witness prompts. No "synthesis" field is produced at runtime (that's stub-only).
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `tarot` (confirmed — `ts-engines/src/engines/tarot/engine.ts:108`; renderer dispatch `apps/noesis-web/app/readings/[id]/page.tsx:45`) |
+| Crate | **— (no Rust engine; stub + renderer)** |
+| Runtime source | **`ts-engines/src/engines/tarot/` (TypeScript engine)** — `engine.ts` (`TarotEngine.calculate`, L38) registered `ts-engines/src/index.ts:23`, served `POST /engines/tarot/calculate` (`ts-engines/src/server/app.ts:146`) |
+| Renderer | `apps/noesis-web/src/components/engines/Tarot.tsx` |
+| Deck data (in-code, authoritative) | `ts-engines/src/engines/tarot/wisdom.ts` (`MAJOR_ARCANA` L30, `createMinorArcana` L579, `loadTarotDeck` L648) |
+| Reference data (NOT consumed by engine) | `data/tarot/rider_waite.json`, `data/tarot/major_arcana.json` — see Open questions |
+| OpenAPI stub | `crates/noesis-core/src/types.rs:324` (`TarotResultSchema` — `spread_type`/`focal_card`/`synthesis`) |
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — emitted by `engine.ts:79–105`, inside the `EngineOutput.result` envelope):**
+```jsonc
+{
+  "spread": { "type": "three_card", "name": "Three Card Spread",      // type ∈ SpreadType enum (snake_case)
+              "description": "Past, Present, and Future…" },
+  "question": "Should I change careers?",                              // optional; echoes input, may be absent
+  "positions": [                                                       // length = spread's position count
+    {
+      "position": 0,                                                   // NUMBER (0-indexed), not a label
+      "name": "Past",                                                  // human label for the slot
+      "meaning": "What has led to this moment; influences from the past",
+      "card": {
+        "id": "major-9", "name": "The Hermit",
+        "arcana": "major",                                            // "major" | "minor"
+        "suit": "wands",                                              // present only for minor arcana
+        "number": 9, "element": "earth",
+        "isReversed": false,
+        "interpretation": { "meaning": "…upright or reversed text…",  // orientation-resolved
+                            "keywords": ["introspection","solitude","guidance","wisdom"] }
+      }
+    }
+    // … one entry per position
+  ],
+  "seed": 12345                                                       // optional; undefined ⇒ non-deterministic draw
+}
+```
+Envelope also carries `witness_prompts` (see §3 note), `calculated_at`, `processing_time_ms` (`engine.ts:107–113`).
+
+**OpenAPI stub (`types.rs:324`) — examples only, does NOT match runtime:** `{ spread_type:"three-card", focal_card:"The Star", synthesis:"Renewed trust in unfolding" }`. None of these three keys are produced by the engine: runtime uses `spread.type` (`three_card`, underscore), has **no** `focal_card`, and emits **no** `synthesis`. Treat the stub purely as canonical-naming/example bait.
+
+**No Rust domain struct exists** (crateless engine) — the TS `result` object above is the only real contract.
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `spread.type` | `single_card` \| `three_card` \| `celtic_cross` \| `relationship` \| `career` | `SpreadType` enum, `spreads.ts:5`; default `three_card` (`engine.ts:42`) |
+| `positions.length` | **1 / 3 / 10 / 7 / 5** | per spread: single=1, three=3, celtic_cross=10, relationship=7, career=5 (`spreads.ts:196`, counts via `getSpreadPositionCount` L208) |
+| `positions[].position` | **0 … n−1** | integer, 0-indexed slot index (`spreads.ts` position fields) |
+| `card.arcana` | `major` \| `minor` | `wisdom.ts:13` |
+| `card.suit` | `wands` \| `cups` \| `swords` \| `pentacles` | minor only; **absent for major** (`wisdom.ts:6`; major cards omit `suit`) |
+| `card.number` | major **0–21**; minor **1–14** | minor: 1=Ace…10, 11=Page,12=Knight,13=Queen,14=King (`wisdom.ts:260–261,605,622`) |
+| `card.element` | `fire` \| `water` \| `air` \| `earth` ( \| `spirit`) | minor element fixed by suit (`SUIT_ELEMENTS`, `wisdom.ts:253`); major element hand-assigned; `spirit` declared in type but unused by current deck |
+| `card.isReversed` | bool, **p=0.5** per card | `shuffle.ts:35` (`rng.nextBool(0.5)`) |
+| `interpretation.meaning` | string | `card.uprightMeaning`/`reversedMeaning` selected by orientation (`reading.ts:36`) |
+| `interpretation.keywords` | string[] (≈4) | from the drawn card (`reading.ts:62`) |
+| `seed` | uint32 \| absent | when absent ⇒ `getDefaultSeed()` = `Date.now() ^ Math.random()` (`utils/random.ts:61`) — **non-deterministic** |
+
+**Invariants:** deck = **78 cards** (22 major + 56 minor = 4 suits × [10 pip + 4 court]); `loadTarotDeck()` builds `allCards = [...major, ...minor]` (`wisdom.ts:653`). Cards are drawn **without replacement** via Fisher-Yates over a copy (`shuffle.ts:17,29`), so all `card.id` in a reading are distinct. Same `seed` ⇒ identical spread + orientations + prompts (deterministic when seeded).
+
+> **⚠️ Renderer/producer field mismatch (confirmed — see Open questions):** the engine emits `result.positions[]` with `{position:number, name, meaning, card:{…isReversed…}}`, but `Tarot.tsx` reads `result.cards ?? result.spread` (L371), and per-slot reads `raw.card ?? raw`, `raw.position` (as the **label**), `raw.reversed/is_reversed`, `reading.present`, `card.position_description`. The current runtime shape does **not** populate these. No adapter remaps `positions`→`cards` anywhere in `apps/noesis-web` / `packages/noesis-sdk-ts` / `crates/noesis-bridge`.
+
+## 4. Component & brand archetype
+**Today** (`Tarot.tsx`): one `CardSlot` per entry. Reads `result.cards ?? result.spread` (array) else falls back to single-card from the root object. Each slot draws a **bioluminescent card face** (`CardFace`, L188) — 140×233px (`CARD_W`, 5:3, L100), gold border, violet→void radial gradient, inset gold + emerald glow — with a central **suit sigil** (`suitSymbol`: wands `⟁`, cups `◯`, swords `✦`, pentacles `⬡`, else `◈`, L19), card number (top-left), a rotated "Reversed" badge (top-right, terracotta, L160), card name (bottom), and an **element dot** colored by element (fire terracotta / water indigo / air white / earth emerald, `elementColor` L29). Below the face: keyword pills, an italic interpretation blockquote, and Description / Position / Meaning / Reversed-Meaning sections. Position labels come from `raw.position` or the hard-coded `POSITIONS=["Past","Present","Future"]` fallback (L364). Already palette-correct (gold `#C5A017`, emerald `#10B5A7`, violet, indigo) but each card is a **rectangular face**, not yet a geometric glyph, and the **spread has no layout geometry** (cards stack in a flex column).
+
+**Wave-2 target — card-glyph spread compass:** positions laid out on the **actual spread geometry** (three-card row; Celtic Cross's cross+staff; relationship/career bespoke layouts) rather than a vertical list. Each card becomes a **sacred-geometry sigil** (suit/arcana-derived glyph, not photoreal art), drawn-in on load (Anime.js stroke-dashoffset). **Upright/reversed = literal 180° glyph rotation** (not just a badge). The **focal card** (e.g. the Major Arcana key card / `getKeyCards`, `reading.ts:108`) emphasized — larger, brighter bioluminescent core, others dimmed. Element drives glyph accent color; keywords radiate as a small label ring.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `spread.type` | overall layout geometry (row / cross+staff / bespoke) — *target* |
+| `positions[].position` + `.name` | glyph placement on the spread + slot label |
+| `positions[].meaning` | slot caption / "Position" section |
+| `card.arcana` + `card.suit` | which sacred-geometry sigil is drawn (`suitSymbol` today) |
+| `card.element` | accent / element-dot color (`elementColor`) |
+| `card.isReversed` | 180° glyph rotation (today: rotated "Reversed" badge) |
+| `card.number` | corner numeral on the face |
+| `interpretation.keywords` | keyword pills / radial label ring |
+| `interpretation.meaning` | interpretation blockquote |
+| focal / key card | size + glow emphasis — *target* |
+
+## 6. Dynamics
+**One-shot per call.** Inputs: `{ spread, question, seed }` (`engine.ts:42–43`). Unlike biofield/vedic-clock there is no live recompute and no time-of-day dependency — but it is **not idempotent unless a `seed` is supplied**: without `seed`, `getDefaultSeed()` reseeds from wall-clock + `Math.random()` each call, so re-running yields a different spread. With a fixed `seed`, the entire reading (cards, reversals, witness prompts) is reproducible. On render the cards/glyphs should animate in once (line-draw); no perpetual loop except an optional focal-card breath. `consciousness_level` (0–5, envelope) may gate how much meaning text is surfaced; it does **not** change the draw.
+
+## 7. Open questions / assumptions
+- **⚠️ NO dedicated engine crate — producer is the TypeScript `ts-engines` service, not Rust.** The only Rust artifacts are the OpenAPI stub (`types.rs:324`) and the orchestrator's spread-type enum/synthesis helpers (`crates/noesis-orchestrator/src/workflow/decision_support.rs:37`, `…/synthesis/decision_support.rs`). The runtime `result` is produced by `ts-engines/src/engines/tarot/engine.ts`. **Confirm this TS service is the deployed producer for the web** (vs. some other path) — the renderer is wired (`page.tsx:45`) and the TS server exposes `/engines/tarot/calculate`, but the request path from `noesis-api`/`get-reading` to `ts-engines` was not traced here.
+- **⚠️ Renderer ≠ producer schema (confirmed defect, not just naming).** Renderer reads `result.cards`/`result.spread` (array of cards) + `raw.card`, `raw.reversed`, `reading.present`, `position_description`, `key_meaning`, `arcana_number`; producer emits `result.positions[]` + `positions[].card.isReversed` + `interpretation.{meaning,keywords}` and a `spread` **object** (not an array). As written, `Tarot.tsx` would find `result.cards` undefined and `result.spread` an object → `arr()` returns `[]` → it falls into the **single-card branch** and renders one card from the root (mostly empty). **This must be reconciled in Wave-2**: either the renderer reads `positions[]`/`card.isReversed`, or a thin adapter maps producer→renderer. Build Wave-2 against the **producer** shape (it's what actually ships) and fix the renderer.
+- **Spread enum naming drift:** producer uses snake_case (`three_card`); OpenAPI stub example and orchestrator `TarotSpread::as_str()` use other forms (`"three-card"`, `"THREE_CARD"`). The web should normalize via `parseSpreadType` (`spreads.ts:212`, strips `-`/spaces, lowercases) before relying on the value.
+- **`data/tarot/*.json` is dead relative to the engine.** `loadTarotDeck()` builds the deck from in-code constants (`wisdom.ts`); the richer `rider_waite.json` / `major_arcana.json` (astrological correspondences, Hebrew letters, Tree-of-Life paths, `spreads`) are **not loaded** by the TS engine. They're a candidate data source for Wave-2 glyph/correspondence detail — verify before citing any field from them as runtime.
+- **`witness_prompts` shape:** `engine.ts:110` sets `witness_prompts = generateQuestionBasedPrompts(...)`, which returns **`WitnessPrompt[]` objects** `{prompt, context, themes}` (`witness.ts:170–187`), not the `string[]` the envelope's TS `witness_prompts?: string[]` implies (README envelope). Confirm whether the API serializes these objects as-is or flattens to strings before the web reads them.
+- **`focal_card` / `synthesis` (stub) have no runtime source.** If the brand "focal card emphasis" needs a server-chosen focal card, it currently must be derived client-side (e.g. first Major Arcana via `getKeyCards`); the engine does not flag one.

--- a/docs/engines/transits.md
+++ b/docs/engines/transits.md
@@ -1,0 +1,101 @@
+# Transits — Data Reference
+
+Current planetary positions vs. the natal chart: where the 12 grahas sit *now*, the angular aspects they make to their natal placements (conjunction/sextile/square/trine/opposition with orbs), Sade Sati status, and an overall period quality. The orbital constellation engine.
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `transits` (verified — `crates/engine-transits/src/engine.rs:36`, registry `crates/noesis-orchestrator/src/workflow/registry.rs:52`) |
+| Domain crate | `crates/engine-transits/src/models.rs` (`TransitAnalysisResult`, L321); engine + serializer in `src/engine.rs` (`serialize_result`, L112) |
+| Runtime source | **`engine-transits` via the orchestrator** — `EngineOutput.result` = serialized `TransitAnalysisResult` (`engine.rs:219`, `engine.rs:163`). Driven from `crates/noesis-api/src/handlers/witness.rs:106` (`run_engine(&orch, "transits", …)`). A second native facade `crates/noesis-vedic-api/src/transits/api.rs` (`TransitApiResponse`, L61) exists with a **different** wire shape (see §7) |
+| Renderer | `apps/noesis-web/src/components/engines/Transits.tsx` |
+| Fixture (runtime `result`) | **`tests/fixtures/expected_outputs/transits/*.json`** (e.g. `user_mumbai_1992.json`) — full `EngineOutput`, authoritative |
+| Fixtures (raw ephemeris) | `crates/noesis-vedic-api/tests/fixtures/captures/planets_bangalore_1991-08-13.json`, `…/western_houses_bangalore_1991-08-13.json` — vendor-capture position/house format (input side, **not** the engine `result` shape) |
+| OpenAPI stub | `crates/noesis-core/src/types.rs:302` (`TransitsResultSchema` — `dominant_transit`/`intensity`/`next_peak_date`; **none of these fields exist at runtime** — see §7) |
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — `expected_outputs/transits/user_mumbai_1992.json`, produced by `serialize_result` `engine.rs:112`):**
+```jsonc
+{
+  "natal_positions": [        // 12 entries, fixed graha order (see §3)
+    { "planet": "Sun", "longitude": 107.876, "sign": "Cancer",
+      "degree_in_sign": 17.88, "is_retrograde": false }
+    // … Moon, Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune, Pluto, Rahu, Ketu
+  ],
+  "transit_positions": [      // 12 entries — note: carries `speed`, natal does NOT
+    { "planet": "Sun", "longitude": 295.234, "sign": "Capricorn",
+      "degree_in_sign": 25.23, "speed": 1.019, "is_retrograde": false }
+  ],
+  "aspects": [                // transit-planet → natal-planet hits, variable length (0..N)
+    { "transiting_planet": "Pluto", "natal_planet": "Saturn",
+      "aspect_type": "Conjunction", "orb": 4.78,
+      "is_applying": true, "nature": "Neutral" }
+  ],
+  "sade_sati": { "is_active": false, "phase": null,           // phase string only when active
+                 "saturn_sign": "Pisces", "moon_sign": "Libra" },
+  "period_quality": "Favorable",                               // enum-as-string (5 values)
+  "retrograde_planets": ["Rahu", "Ketu"]                       // names of currently-retro transit grahas
+}
+```
+
+**Domain struct `TransitAnalysisResult` (`models.rs:321`) — matches runtime 1:1:**
+`natal_positions: Vec<PlanetaryPosition>` · `transit_positions: Vec<PlanetaryPosition>` · `aspects: Vec<TransitAspect>` · `sade_sati: SadeSatiStatus` · `period_quality: PeriodQuality` · `retrograde_planets: Vec<TransitPlanet>`.
+`PlanetaryPosition` (`models.rs:157`): `planet, longitude:f64, latitude:f64, speed:f64, sign:ZodiacSign, degree_in_sign:f64, is_retrograde:bool` — **`latitude` is dropped by the serializer; `speed` is emitted only on `transit_positions`** (`engine.rs:117` vs `engine.rs:131`).
+`TransitAspect` (`models.rs:256`): `transiting_planet, natal_planet, aspect_type:AspectType, orb:f64, is_applying:bool, nature:AspectNature`.
+`SadeSatiStatus` (`models.rs:290`): `is_active:bool, phase:Option<SadeSatiPhase>, saturn_sign, moon_sign`.
+
+**OpenAPI stub `TransitsResultSchema` (`types.rs:302`):** `{ dominant_transit:String, intensity:String, next_peak_date:String }` — **fictional**; no overlap with the real schema (§7).
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `*_positions[].planet` | enum, **12 grahas** | `Sun, Moon, Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune, Pluto, Rahu, Ketu` (`models.rs:9`, order from `TransitPlanet::all()` L28). Serialized as PascalCase string |
+| `*_positions[].longitude` | **0–360°** | ecliptic longitude, sidereal (Lahiri). Normalized `((lon%360)+360)%360` (`models.rs:90`). Rounded to 3 dp (`engine.rs:119`) |
+| `*_positions[].sign` | 12 signs `Aries…Pisces` | derived `floor(longitude/30)` (`models.rs:89`). String name |
+| `*_positions[].degree_in_sign` | **0–30°** | `longitude % 30` (`models.rs:108`). Rounded to 2 dp |
+| `transit_positions[].speed` | deg/day, **signed** | negative ⇒ retrograde (`models.rs:163`). ~13°/day Moon … ~0.01°/day Pluto (fixture L19–28). Rounded 4 dp. **Absent on `natal_positions`** |
+| `*_positions[].is_retrograde` | bool | `speed < 0`. Sun & Moon never retrograde |
+| `aspects[].aspect_type` | 5 enum strings | `Conjunction`(0°) `Sextile`(60°) `Square`(90°) `Trine`(120°) `Opposition`(180°) (`models.rs:175`, angles L190) |
+| `aspects[].orb` | **0–8°** | actual angular deviation from exact. Max = that aspect's allowed orb: Conj/Opp **8°**, Trine/Square **6°**, Sextile **4°** (`default_orb` `models.rs:201`). Rounded 2 dp |
+| `aspects[].is_applying` | bool | true = separation shrinking (planet moving toward exact) |
+| `aspects[].nature` | 3 enum strings | `Harmonious` (trine/sextile), `Challenging` (square/opposition), `Neutral` (conjunction) (`models.rs:212`) |
+| `sade_sati.phase` | 3 strings \| null | `"Rising (12th from Moon)"`, `"Peak (conjunct Moon)"`, `"Setting (2nd from Moon)"` (Display, `models.rs:278`). Null ⇔ `is_active=false` |
+| `sade_sati.{saturn,moon}_sign` | sign name | comparison basis for the 3-sign Saturn-over-Moon window |
+| `period_quality` | **5 enum strings** | `HighlyFavorable, Favorable, Mixed, Challenging, Difficult` → Display adds spaces: `"Highly Favorable"` (`models.rs:298`/L307) |
+| `retrograde_planets` | subset of the 12, by name | mirrors `transit_positions[].is_retrograde==true` |
+
+Ayanamsa: **Lahiri sidereal**, Swiss Ephemeris (`engine.rs:229` backend `"swiss-ephemeris"`; vedic-api facade defaults `ayanamsa: "lahiri"`, `api.rs:54`). **Invariants:** both arrays are length **12** in graha order (engine `validate()` asserts exactly 12, `engine.rs:278`/L290); `sign`/`degree_in_sign`/`is_retrograde` are all *derived from* `longitude`+`speed` (not independent); each aspect's `orb ≤ default_orb(aspect_type)` by construction.
+
+## 4. Component & brand archetype
+**Today** (`Transits.tsx`): an SVG **zodiac wheel** (`viewBox 0 0 300 300`, center 150,150) — a 12-segment outer ring (`ZodiacWheel`, L202) tinted by element (`ELEMENT_COLORS`: fire/earth/air/water, L22), 30° spoke lines, a dark inner disc labelled "TRANSITS", **planet dots** placed at `sign*30 + degree` on radius 104 with per-planet glyph+color (`PLANET_META`, L34) and a red "R" retrograde marker, plus a **Sade Sati arc** (±20° gold sweep around Saturn, L279). Below: text cells for Planetary Positions, a Significant Aspects list, and a Sade Sati status/phase block. Already partly on-brand (gold `#C5A017` Sun, emerald Venus, Void inner disc) — **aspects are text-only; there are no aspect lines on the wheel, and the wheel only ever plots one position set** (see §5/§7).
+
+**Wave-2 target — orbital constellation:** the 12 grahas as luminous nodes on the zodiac wheel (angle = ecliptic longitude), with **aspect lines drawn chord-to-chord between the planets they connect** (`aspects[]` → line from `transiting_planet` node to `natal_planet` node), the line **hue by `nature`** (emerald harmonious / terracotta challenging / gold neutral) and **weight/opacity by tightness** (`1 − orb/maxOrb`). Node **glow ∝ involvement** (count/closeness of aspects). Show **two concentric position rings** (natal inner, transit outer) so aspect chords visibly bridge the two, with the wheel itself the constellation field; `period_quality` sets the ambient core color, Sade Sati keeps the gold arc.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `transit_positions[].longitude` | planet node angle on the wheel (`zodiacToXY`, L168); currently `sign*30+degree`, equivalent to longitude |
+| natal vs transit ring | (target) inner ring = `natal_positions`, outer ring = `transit_positions`; today only one set is plotted (§7) |
+| `*_positions[].sign` | which 30° element-tinted segment the node falls in |
+| `is_retrograde` / `retrograde_planets` | red "R" glyph beside the node (`Transits.tsx:314`); (target) reversed/dimmed node |
+| `transit_positions[].speed` | (target) node drift/animation rate (fast Moon vs near-static Pluto) |
+| `aspects[]` (`transiting_planet`→`natal_planet`) | **(target) chord line between the two nodes** — the defining constellation geometry; today rendered only as a text row |
+| `aspects[].nature` | line color: emerald harmonious / terracotta challenging / gold neutral |
+| `aspects[].orb` | line weight + opacity (tighter orb ⇒ brighter/thicker) |
+| `aspects[].aspect_type` | line style per angle family (e.g. solid trine, dashed square) + badge label |
+| `sade_sati.is_active` + Saturn position | gold ±20° arc around Saturn on the rim (`Transits.tsx:279`) |
+| `period_quality` | (target) ambient/core hue (HighlyFavorable→emerald … Difficult→terracotta) |
+
+## 6. Dynamics
+**One-shot per (natal birth datetime+place, transit date).** Computed server-side; not a live client stream. The natal half is fixed for a person; the transit half advances with the chosen `transit_date` (the vedic-api facade defaults transit date to *today*, `api.rs:223`), so re-rendering for "now vs next week" is the natural recompute trigger — fast grahas (Moon ~13°/day) move visibly day-to-day, slow ones (Saturn/outer planets) barely. On load, nodes and aspect chords should draw in once (stroke-dashoffset); an optional slow breath on the core (`period_quality`) is the only perpetual motion. `consciousness_level` (0–5, envelope) gates interpretive depth — the witness prompt itself names the dominant aspect (fixture: *"As Pluto deeply transforms… Saturn…"*). No baseline/delta semantics.
+
+## 7. Open questions / assumptions
+- **Renderer ⇄ runtime key mismatch (confirmed, likely a real defect).** The renderer reads `result.planetary_positions ?? result.positions ?? result.transits` for the wheel/positions and `result.significant_aspects ?? result.aspects` for aspects (`Transits.tsx:392`/L393), but the runtime emits **`transit_positions`** + **`natal_positions`** + **`aspects`** (`engine.rs:163`, confirmed by `expected_outputs` fixture). `aspects` is the only key that lines up. Result against today's real payload: **the wheel plots zero planets** (no `planetary_positions`/`positions`/`transits` key) and the **Planetary Positions** text grid is empty; only the aspects list and Sade Sati block render. Flag for Wave-2: renderer must read `transit_positions`/`natal_positions`.
+- **Aspect field-name mismatch (confirmed).** Renderer reads `aspect.planet1 ?? aspect.from`, `aspect.planet2 ?? aspect.to`, `aspect.type ?? aspect.aspect` (`Transits.tsx:445`/L454); runtime emits `transiting_planet`/`natal_planet`/`aspect_type`. So even the aspects list shows `"— —"` / `"—"` today. Building the constellation chords requires reading `transiting_planet`/`natal_planet`.
+- **`sade_sati.active` vs `is_active` (confirmed).** Renderer keys off `sade_sati.active` (`Transits.tsx:400`/L462); runtime emits `is_active`. The Sade Sati block and the gold arc are therefore inert against real data.
+- **OpenAPI stub is fictional (confirmed).** `TransitsResultSchema` (`dominant_transit`/`intensity`/`next_peak_date`, `types.rs:302`) shares **no field** with the real output. Ignore it except as a naming placeholder; it is not the contract.
+- **Two engine paths, two shapes (confirmed).** The orchestrator path (this doc's authoritative shape) emits `natal_positions`+`transit_positions`+`aspects[]`. The separate `noesis-vedic-api` facade `TransitApiResponse` (`api.rs:61`) emits a flat `transits: [{planet, sign, degree, is_retrograde, natal_aspects:[{natal_planet, aspect_type, orb}]}]` + `sade_sati{is_active,…}` + `jupiter_transit{…}` — note it **nests aspects under each transit planet** and has **no natal-position array**. Confirm which path actually backs the web `EngineOutput` for transits before wiring the renderer; the `expected_outputs` fixture says it's the orchestrator/`engine-transits` shape.
+- **Raw capture fixtures are input-side, not `result`.** `planets_bangalore_1991-08-13.json` / `western_houses_…json` are the vendor ephemeris/house capture format (`fullDegree` 0–360, `normDegree` 0–30, `current_sign` **1-indexed** 1=Aries…12=Pisces, `isRetro` as the **string** `"true"`/`"false"`, houses 1–12 with `zodiac_sign.number`). They feed position computation but do **not** match the engine `result` schema (which is 0-indexed enums, real `bool`, no house field). Don't render against them directly.
+- **No house data in the transit `result`.** `PlanetaryPosition` has no house field; houses 1–12 appear only in the raw capture (`house_number`, `western_houses` fixture). If the constellation needs house overlays, that data isn't in the current engine output — flag as a gap.
+- **`latitude` dropped, `speed` natal-absent (confirmed, minor).** `serialize_result` omits `latitude` entirely and emits `speed` only on transit positions (`engine.rs:117` vs L131); fine for a 2-D wheel but note natal retrograde is still carried via `is_retrograde`.

--- a/docs/engines/vedic-clock.md
+++ b/docs/engines/vedic-clock.md
@@ -1,0 +1,99 @@
+# Vedic Clock — Data Reference
+
+A TCM organ clock (12 × 2-hour windows) fused with Ayurvedic dosha periods (3 × two daily cycles) plus optional Panchanga overlays — temporal recommendations for *now* at a place. **Note the naming gap:** the OpenAPI stub describes a *Vedic muhurta / guna* clock (Brahma Muhurta, Sattva…), but the actual engine ships a *TCM-organ + dosha* clock. They are different systems under one `engine_id` (see §2, §7).
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `vedic-clock` (verified: `engine.rs:38`, asserted in tests `vedic_clock_tests.rs:339`) |
+| Domain crate | `crates/engine-vedic-clock/src/models.rs` (`VedicClockResult`, L256) |
+| Runtime source | **`crates/engine-vedic-clock/src/engine.rs`** (`build_result`, L126 — the authoritative serializer) |
+| Renderer | `apps/noesis-web/src/components/engines/VedicClock.tsx` |
+| Fixture (real values) | **none found** (`crates/engine-vedic-clock/tests/vedic_clock_tests.rs` asserts shape, not a JHora reference fixture) |
+| OpenAPI stub | `noesis-core/src/types.rs:269` (`VedicClockResultSchema` — `current_segment`/`guna_bias`/`next_transition_local`); enum variant at `types.rs:377` |
+
+Unlike the other Vedic engines (panchanga/vimshottari/transits), this one is **not** served by `noesis-vedic-api` — it's a self-contained `engine-*` crate. There is **one** computation path: `engine.rs`. The struct, stub, and renderer disagree (§2/§7); **`build_result` is the runtime truth**.
+
+## 2. Output schema
+
+**Runtime JSON (authoritative — exactly what `build_result` emits, `engine.rs:134-188`):**
+```jsonc
+{
+  "current_organ": {                       // engine.rs:135
+    "organ": "Heart",                      // Organ enum → variant string (12 values, models.rs:14)
+    "element": "Fire",                     // Element enum → variant string (models.rs:70)
+    "time_window": "11 AM - 1 PM",         // time_range_display() — NOTE: key is time_window, not time_range
+    "peak_energy": "…",
+    "associated_emotion": "…",
+    "recommended_activities": ["…"]
+  },
+  "current_dosha": { "dosha": "Pitta", "qualities": ["Transformation","Digestion","…"] }, // engine.rs:143
+  "recommendation": {                      // engine.rs:147
+    "time_window": "11 AM - 1 PM",
+    "organ": "Heart", "dosha": "Pitta",
+    "activities": [ { "activity": "…", "quality": "optimal", "reason": "…" } ],
+    "panchanga_quality": null              // string ONLY if tithi_index/nakshatra_index passed (integration.rs:35)
+  },
+  "synthesis": "Heart (Fire) time during Pitta period - harmonious energy. …", // string, integration.rs:159
+  "calculated_for": "2026-03-08T12:43:16+00:00",   // rfc3339 of input.current_time
+  "timezone": { "offset_minutes": 330, "source": "birth_data.timezone", "local_hour": 12 }, // engine.rs:156
+  "activity_timing": {                     // OPTIONAL — only when options.activity set (engine.rs:164)
+    "activity": "Meditation", "is_favorable_now": true, "reason": "…",
+    "optimal_windows": [ { "time_window": "…", "quality": 0.87, "reason": "…" } ]
+  },
+  "upcoming_transitions": [                 // OPTIONAL — JSON key, NOT the struct's `upcoming` (engine.rs:185)
+    { "time": "13:00", "description": "Small Intestine time begins", "new_organ": "SmallIntestine", "new_dosha": null }
+  ]
+}
+```
+
+**Domain struct `VedicClockResult` (models.rs:256) — field names differ from the JSON:** `current_organ:OrganWindow` · `current_dosha:DoshaTime` · `recommendation:TemporalRecommendation` · `upcoming:Option<Vec<UpcomingTransition>>` · `calculated_for:String`. The struct has **no** `synthesis`, `timezone`, or `activity_timing` (those are added ad-hoc in `build_result`), and its `upcoming` is **renamed to `upcoming_transitions`** in the JSON. `OrganWindow` (L134) carries `start_hour`/`end_hour:u8` which are **not** serialized — only the formatted `time_window` string is.
+
+**OpenAPI stub (types.rs:269) — a DIFFERENT clock entirely:** `{ current_segment:"Brahma Muhurta", guna_bias:"Sattva", next_transition_local:"06:12" }`. None of these three fields exists in the runtime JSON. This is the SDK/OpenAPI contract (via `EngineResultData::VedicClock`, types.rs:377) — it does not match what ships.
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| `current_organ.organ` | 12 enum values | `Lung, LargeIntestine, Stomach, Spleen, Heart, SmallIntestine, Bladder, Kidney, Pericardium, TripleWarmer, Gallbladder, Liver` (models.rs:14); cycle starts 3 AM = Lung (models.rs:31) |
+| `current_organ.element` | `Wood\|Fire\|Earth\|Metal\|Water` | models.rs:70. **Mismatch vs renderer** — see §7 (Pericardium/TripleWarmer are Fire in the engine, Wood in the renderer) |
+| organ window length | **2 h**, fixed | every window spans 2 hours (test `test_each_organ_window_is_2_hours`); transitions on **odd** local hours 1,3,5…23 (calculator.rs:60) |
+| `current_dosha.dosha` | `Vata\|Pitta\|Kapha` | models.rs:105 |
+| dosha period length | **4 h**, fixed, 6 periods/day | Vata 2–6 & 14–18; Kapha 6–10 & 18–22; Pitta 10–14 & 22–2 (dosha.rs:14-92); transitions on hours 2,6,10,14,18,22 (engine.rs:215) |
+| `timezone.offset_minutes` | integer minutes, e.g. `0, 330, 345, -480` | resolved options→birth_data→UTC (engine.rs:65); `+05:45` Nepal = 345 (test L595) |
+| `timezone.local_hour` | **0–23** | `get_local_hour` wraps mod 24 (calculator.rs:31) |
+| `recommendation.activities[].quality` | `optimal\|favorable\|neutral\|use caution\|panchanga-favored\|avoid` | string enum from Panchanga rating (integration.rs:63-101) |
+| `activity_timing.optimal_windows[].quality` | **0.0–1.0** f64 | favorability score, sorted descending (`TimeWindow.quality`, models.rs:210; test L193) |
+| `activity` (input + echoed) | `Meditation\|Exercise\|Work\|Eating\|Sleep\|Creative\|Social` | 7 values (models.rs:177); parsed lowercase from `options.activity` (engine.rs:98) |
+| `upcoming_transitions[]` | look-ahead **6 h** | `new_organ` set on organ hops, `new_dosha` on dosha hops; never both (engine.rs:200-224) |
+| `recommendation.panchanga_quality` | `null` or `"Rating: description"` | non-null only when `tithi_index` and/or `nakshatra_index` supplied (integration.rs:35) |
+| `consciousness_level` | **0–5** (envelope) | input `options.consciousness_level`, default **2** (engine.rs:291); gates witness-prompt depth |
+
+**Invariants:** organ + dosha are **pure functions of `local_hour`** (which derives from `current_time` + `timezone.offset_minutes`) — they co-vary, never independent. `local_hour` fully determines `current_organ`, `current_dosha`, `synthesis`, and `upcoming_transitions`. No ephemeris / sidereal longitudes are involved (this is a wall-clock engine, not an astronomical one).
+
+## 4. Component & brand archetype
+**Today** (`VedicClock.tsx`): a **12-segment radial organ clock** (240×240 SVG donut, `SEG_DEG=30`, `R_OUTER=100`/`R_INNER=60`) — each segment colored by TCM element, the active organ filled emerald (`rgba(16,181,167,0.5)`) + bright stroke, organ abbreviations (LU, HT…) rotated to read outward, a live **clock hand** (`new Date()`, 3 AM = top/−90°, 15°/hr), a small center dot, and a center label (organ name + time range). Below the ring: text cells for organ/element, emotion/virtue, recommendation, dosha/period/rasa, and "Peak Organs Today" tags. Palette is already on-brand (gold `#C5A017`, emerald, water-indigo `rgba(11,80,251)`).
+
+**Wave-2 target (brand archetype):** *radial day-clock compass* — the 24h/segment ring exists; finish it by (a) lighting the **current segment** from real data, (b) showing **guna/dosha as the core color** (bioluminescent center), and (c) a **next-transition tick** on the rim driven by `minutes_until_next_transition` (calculator.rs:56, currently unused by the web). Brand palette: Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `current_organ.organ` | active segment of the 12-ring (emerald fill + glow); matched case-insensitively by name (`findActiveIndex`, tsx:94) |
+| `current_organ.element` | inactive segment fill color (Metal grey / Earth gold / Fire coral / Water indigo / Wood emerald, tsx:34) |
+| `current_organ.time_window` | center sub-label + organ cell `time_range` line |
+| `timezone.local_hour` (via `new Date()` today) | clock-hand angle; **target:** drive hand from `local_hour` not browser clock (see §7) |
+| `current_dosha.dosha` | (target) core color of the ring center = guna/dosha bias |
+| `upcoming_transitions[0].time` | (target) next-transition tick on the rim |
+| `recommendation.activities[]` | recommendation text cell |
+| `current_organ.peak_organs`/peaks | "Peak Organs Today" tag row (tsx:310) — **source key unconfirmed**, see §7 |
+
+## 6. Dynamics
+**Time-of-day engine — recompute as the clock advances**, not one-shot. The natural cadence is the **2-hour organ window** (the cache key buckets by `hour/2`, engine.rs:376) with finer **4-hour** dosha and minute-level transition ticks. `minutes_until_next_transition` (calculator.rs:56) and `get_window_progress` (calculator.rs:97) exist in the crate to support a live progress sweep / countdown, but the **web does not call them** — today the only live element is the SVG clock hand, which reads the **browser's** `new Date()` (tsx:152) and is therefore **decoupled from the engine's `timezone`/`local_hour`** (wrong hand position for any non-local tz). For Wave-2: poll/recompute on window boundaries, animate the active segment + a rim countdown to `upcoming_transitions[0]`, and optionally a slow core breath on the dosha color. `consciousness_level` (0–5, default 2) gates witness-prompt depth only.
+
+## 7. Open questions / assumptions
+- **Renderer reads keys the engine never emits (BLOCKER):** `VedicClock.tsx:259-260` reads `result.tcm_organ_clock.*` and `result.ayurvedic_timing.*`, but `build_result` emits **top-level** `current_organ`/`current_dosha` with **no** `tcm_organ_clock`/`ayurvedic_timing` wrapper (grep finds these keys only in the renderer + an old `wave2-task-plan.json` note). Net effect: the guard at `tsx:264` (`if (!tcm && !ayurvedic) return <GenericEngineView/>`) is **always true for this engine's output → the radial clock never renders; it silently falls back to GenericEngineView.** The renderer was built against a planned static `tcm_organ_clock.json` shape that the crate doesn't produce. ⚠️ Must reconcile before Wave-2 — pick one shape (recommend: nest the engine output, or flatten the renderer reads).
+- **Three-way schema disagreement (confirmed):** (1) OpenAPI stub = muhurta/guna (`current_segment`/`guna_bias`/`next_transition_local`); (2) Rust struct `VedicClockResult` = TCM/dosha with field `upcoming`; (3) runtime JSON = TCM/dosha but renames `upcoming`→`upcoming_transitions` and adds `synthesis`/`timezone`/`activity_timing`. The **SDK/OpenAPI contract (`EngineResultData::VedicClock`, types.rs:377) advertises shape (1) while the engine ships shape (3)** — any client typed off the SDK will mis-parse. ⚠️ The brief's stub fields (Brahma Muhurta / Sattva / 06:12) describe a clock this engine does **not** implement.
+- **Element mismatch (confirmed):** engine maps **Pericardium & TripleWarmer → Fire** (models.rs / `wisdom.rs` per test L88-89), but the renderer's `ORGANS[]` tags Pericardium/TripleWarmer (and Gallbladder) as **Wood** (tsx:28-30). Inactive-segment colors will be wrong for those organs. Verify against `wisdom.rs::get_organ_element`.
+- **"Peak Organs Today" source unconfirmed:** renderer reads `tcm_organ_clock.peak_organs[]` (tsx:262) — no such field is produced by `build_result`. Dead UI under the current contract.
+- **No reference fixture:** there is no JHora/golden-value fixture for this engine (only behavioral tests). Ranges above are from the struct + dosha/calculator tables + integration tests; "correct values" for a given timestamp can be reproduced from `engine.rs` but are not pinned to an external authority.
+- **`guna` / `Sattva-Rajas-Tamas` is absent from the implementation** — the brand archetype's "guna as core color" has **no backing field** today; it would map most naturally onto `current_dosha.dosha` (the engine's actual triad) unless a guna calc is added.

--- a/docs/engines/vimshottari.md
+++ b/docs/engines/vimshottari.md
@@ -1,0 +1,106 @@
+# Vimshottari Dasha — Data Reference
+
+The 120-year planetary-period timeline of Vedic time: a fixed cycle of 9 lords, each ruling a major period (Mahadasha) nested into sub-periods (Antardasha/Bhukti → Pratyantardasha …), with the period active *now* and its upcoming transitions.
+
+## 1. Identity
+| | |
+|---|---|
+| `engine_id` | `vimshottari` (verified `crates/engine-vimshottari/src/engine.rs:37`) |
+| Domain crate | `crates/engine-vimshottari/src/models.rs` (`VimshottariChart`, L8); `result` built in `engine.rs:202` |
+| Runtime source | **`crates/noesis-vedic-api/src/vimshottari/`** (types.rs, mappers.rs, current.rs) — JHora-verified, like Panchanga |
+| Renderer | `apps/noesis-web/src/components/engines/Vimshottari.tsx` |
+| Fixture (real values) | `crates/noesis-vedic-api/tests/fixtures/reference_data/dasha_reference.json` (validation charts, **not** the API envelope) |
+| OpenAPI stub | `noesis-core/src/types.rs:247` (`VimshottariResultSchema` — current_mahadasha/current_antardasha/days_remaining only) |
+
+⚠️ **Unlike Panchanga, no single Rust serializer emits exactly what the renderer reads.** Five shapes disagree (see §2 + §7). The renderer's tolerant `??` fallbacks are the only confirmed web contract; treat it as the spec and the engine `result` as the closest producer.
+
+## 2. Output schema
+
+**Renderer contract (authoritative — what the web actually reads, `Vimshottari.tsx:79-123`):**
+```jsonc
+{
+  "mahadasha":  { "planet": "Venus", "years_remaining": 12.4,            // OR top-level result.mahadasha (string)
+                  "start": "2023-07-15", "end": "2043-07-15" },          // OR result.current_mahadasha
+  "antardasha": { "planet": "Sun", "start": "...", "end": "..." },       // OR result.antardasha / result.current_antardasha
+  "upcoming_periods": [                                                   // OR result.periods ; renders first 8
+    { "planet": "Sun", "start": "...", "end": "...", "level": "antardasha" } // planet|name, level|type
+  ]
+}
+```
+Renderer reads only: `mahadasha.{planet,years_remaining,start,end}`, `antardasha.{planet,start,end}`, `upcoming_periods[].{planet|name, start, end, level|type}`. No rings/dates parsed today — all rendered as text (see §4).
+
+**engine-vimshottari `result` (domain path — nested, the closest real producer, `engine.rs:202-216`):**
+```jsonc
+{
+  "birth_nakshatra": { "name": "Ashwini", "number": 1, "moon_longitude": 8.5 },
+  "timeline": { "birth_date": "<rfc3339>", "total_years": 120,
+    "mahadashas": [ { "planet": "Sun", "start_date": "<rfc3339>", "end_date": "<rfc3339>",
+                      "duration_years": 6.0, "antardasha_count": 9 } ] },     // top-level only; nested AD count, not list
+  "current_period": {                                                          // ⚠ not "current_mahadasha"
+    "mahadasha":       { "planet": "...", "start": "<rfc3339>", "end": "<rfc3339>", "years": 6.0 },
+    "antardasha":      { "planet": "...", "start": "...", "end": "...", "years": 1.0 },
+    "pratyantardasha": { "planet": "...", "start": "...", "end": "...", "days": 73.0 } },
+  "upcoming_transitions": [ { "type": "Mahadasha", "from_planet": "...", "to_planet": "...",
+                             "date": "<rfc3339>", "days_until": 1460 } ],      // ⚠ not "upcoming_periods"
+  "period_enrichment": { "mahadasha_themes": [..], "combined_description": "...", "life_areas": [..],
+                         "opportunities": [..], "challenges": [..] }            // null if no current period
+}
+```
+
+**vedic-api `VimshottariTimeline` (runtime crate, `vimshottari/types.rs:165`):** `birth_datetime:NaiveDateTime` · `birth_nakshatra:String` · `birth_dasha_balance:DashaBalance{lord, years:u32, months:u32, days:u32, total_days:i64}` · `mahadashas:Vec<DashaPeriod>`. **`DashaPeriod`** (`types.rs:119`): `lord:DashaLord` · `level:DashaLevel` · `start_date:NaiveDate` · `end_date:NaiveDate` · `duration_days:i64` · `sub_periods:Vec<DashaPeriod>` (recursive; omitted when empty). Note: `lord` (not `planet`), `start_date`/`end_date` (not `start`/`end`), `duration_days` (not `years`).
+
+**Domain struct `VimshottariChart` (`models.rs:8`):** `birth_date:DateTime<Utc>` · `mahadashas:Vec<Mahadasha>` · `current_period:CurrentPeriod` · `upcoming_transitions:Vec<Transition>`. `Mahadasha`(L17): `planet, start_date, end_date, duration_years:f64, antardashas:Vec<Antardasha>, qualities`. `Antardasha`(L28)→`pratyantardashas:Vec<Pratyantardasha>`; `Pratyantardasha`(L38) carries `duration_days:f64`. `CurrentPeriod`(L139): `{mahadasha:CurrentMahadasha, antardasha:CurrentAntardasha, pratyantardasha:CurrentPratyantardasha, current_time}` — Maha/Antar carry `years:f64`, Pratyantar carries `days:f64`.
+
+**Orchestrator reader (a 2nd runtime consumer, `noesis-orchestrator/.../birth_blueprint.rs:195`):** expects `result.current_dasha.{mahadasha, antardasha, years_remaining}` + `result.upcoming_transitions[]` **as strings** — a THIRD shape (`current_dasha`), only seen in test mocks (`birth_blueprint.rs:370`, `synthesis/birth_blueprint.rs:468`), no real serializer.
+
+**OpenAPI stub:** `{ current_mahadasha:String, current_antardasha:String, days_remaining:i64 }` — examples only.
+
+## 3. Ranges, constraints & invariants
+| Field | Range / domain | Notes |
+|---|---|---|
+| lord / planet | 9 grahas | `Ketu, Venus, Sun, Moon, Mars, Rahu, Jupiter, Saturn, Mercury` (`types.rs:11`). vedic-api serializes **lowercase** (`#[serde(rename_all="lowercase")]`, `types.rs:10`); engine path Title-Case (`as_str`, `models.rs:91`). ⚠ case mismatch |
+| Mahadasha `duration_years` | fixed per lord | Ketu 7 · Venus 20 · Sun 6 · Moon 10 · Mars 7 · Rahu 18 · Jupiter 16 · Saturn 19 · Mercury 17 (`models.rs:61`, `types.rs:25`, fixture L229) |
+| cycle total | **120 years** | Σ of the 9 durations = 120 (asserted `types.rs:268-272`; `total_years:120` hard-coded `engine.rs:210`) |
+| sequence order | fixed wheel | `Ketu→Venus→Sun→Moon→Mars→Rahu→Jupiter→Saturn→Mercury→(Ketu)` (`next()` `types.rs:55`, fixture `correct_order` L227) |
+| birth (1st) Mahadasha | **partial** | shortened by `birth_dasha_balance` — Moon's nakshatra longitude sets the entry lord + remaining fraction (fixture `moon_data`, e.g. Sun 3.46 yr L40; `is_birth_dasha:true`); only the first period is < full |
+| `mahadashas` length | **9** | one full wheel from birth lord; `antardasha_count` = 9 per Maha (`engine.rs:149`) |
+| sub-period depth | up to 5 levels | `DashaLevel` = Mahadasha(9) · Antardasha(81) · Pratyantardasha(729) · Sookshma(6561) · Prana (`types.rs:103`). Default = **Antardasha** (`types.rs:107`) |
+| `pratyantardasha.days` / `duration_days` | days | sub-period durations in days, not years (`models.rs:42`, `types.rs:129`) |
+| `days_until` / `days_remaining` | i64 ≥ 0 | days to a future transition (`models.rs:209`); clamped to 0 once past (`types.rs:156`) |
+| `years_remaining` | f64 ≥ 0 | **renderer-only field — no Rust producer emits it** (engine gives `current_period.mahadasha.years` = total, not remaining). ⚠ see §7 |
+| dates | start ≤ end, monotonic | periods are contiguous & non-overlapping; `start_date` of N+1 = `end_date` of N (fixture chains exactly) |
+| `birth_dasha_balance` | y<lord-yrs, m 0–11, d 0–29 | remaining at birth (`types.rs:217`); `total_days` ≈ y·365+m·30+d (`mappers.rs:44`) |
+
+**Ayanamsa: Lahiri** (`dasha_reference.json` `_meta.ayanamsa`). Tolerance: dates drift ±15–30 days across software (fixture `tolerance.date_days`); historical charts ±15 min birth-time uncertainty. **Invariant:** the entire timeline is a deterministic function of birth Moon longitude (entry lord + balance) — all 9 Mahadashas and every sub-period derive from it; nothing is independent.
+
+## 4. Component & brand archetype
+**Today** (`Vimshottari.tsx`): a **2-cell text grid** — Mahadasha (planet · "N years remaining" · From/Until) + Antardasha (planet · From/Until) — plus an **8-row "Upcoming Periods" table** (Planet · Start · End · Level). **Zero geometry, zero brand palette, no SVG** — the least-visual of the Vedic renderers; pure `var(--text)`/`var(--gold)` section title. Furthest of the Wave-2 set from the archetype.
+
+**Wave-2 target:** **nested concentric time-arc rings** — outer ring = the 9 Mahadashas (each lord an arc sized by its years, full 120-yr wheel), middle = the current Maha's Antardashas (Bhukti), inner = Pratyantardashas. The **current period is lit on the Ba-Arc** at each level (Maha/Antar/Pratyantar segment glowing), with **`days_remaining` (or % elapsed) drawn as arc-fill progress** sweeping the active segment. Lord color per graha; transitions animate the boundary crossing (Anime.js stroke-dashoffset). Center = current `Maha-Antar-Pratyantar` display string as the bioluminescent core.
+
+Brand palette: Void `#070B1D`, Gold `#C5A017`, Emerald `#10B5A7`, Indigo `#0B50FB`, Violet `#2D0050`, Parchment `#F0EDE3`.
+
+## 5. Data → visual mapping
+| Field | Visual |
+|---|---|
+| `timeline.mahadashas[].duration_years` (9, Σ=120) | outer ring segment arc-length (years → degrees: `yrs/120·360°`) |
+| `mahadashas[].planet` / `lord` | segment hue (per-graha color); label on hover |
+| current `mahadasha.planet` | outer active segment lit on the Ba-Arc + glow |
+| `mahadasha.years_remaining` / `days_remaining` | arc-fill progress sweeping the active Maha segment |
+| current `antardasha` (Bhukti) | middle ring active segment (subdivides the current Maha) |
+| current `pratyantardasha` | inner ring active segment (`days`-scaled) |
+| `upcoming_transitions[].date` + `days_until` | boundary tick on the ring; nearest transition pulses; animate on crossing |
+| `current_period` display string | center core label (`Venus-Sun-Moon`) |
+| `period_enrichment.*` (engine path) | (target) interpretive text panel, gated by `consciousness_level` |
+
+## 6. Dynamics
+**Hybrid: one-shot timeline + time-sensitive "current".** The full 9-Mahadasha wheel is computed once per (birth date/time, lat/long, tz) and is stable for life. But *which* period is **current** — and `years_remaining`/`days_remaining`/% elapsed — advances with **today's date** (`find_current_period`/`get_current_dashas` take `current_time`/`date`, `current.rs:11`, `engine.rs:296`). Re-resolve the active segment + progress on each render (date-granular; no sub-day ticking needed — a Pratyantardasha lasts weeks). On load, rings draw in once (line-draw) and the active segments light; a slow progress sweep is optional. Period boundaries (Maha every 6–20 yr, Antar months, Pratyantar weeks) are the natural transition events. `consciousness_level` (0–5) gates how much `period_enrichment` (themes, lessons, practices, challenges) is surfaced.
+
+## 7. Open questions / assumptions
+- **Schema mismatch (CRITICAL — renderer ↔ producer key names diverge):** the renderer reads `result.current_mahadasha` / `upcoming_periods` / `mahadasha.years_remaining`, but the engine `result` emits `current_period` / `upcoming_transitions` / `mahadasha.years` (= *total*, not remaining) (`engine.rs:154,177,160`). **As written, none of the renderer's primary keys match any known producer** → the cells fall through to `result.mahadasha`/`result.antardasha` (a bare string) and the Upcoming table renders empty. This is the top Wave-2 blocker: the producer JSON and `Vimshottari.tsx` must be reconciled before any ring work. Verify the live `noesis-vedic-api` engine endpoint's actual `result` shape (none of the 5 shapes here is confirmed as the deployed one).
+- **No `years_remaining` producer anywhere** — renderer-only field; only `years` (total) and `days_until`/`days_remaining` (i64 days) exist in Rust. Either compute it client-side from `end - now`, or add it server-side.
+- **Three+ competing runtime shapes:** (a) engine `result` nested `current_period`; (b) orchestrator expects `result.current_dasha.{...}` as strings (`birth_blueprint.rs:195`) — only in test mocks, no serializer; (c) vedic-api `VimshottariTimeline.mahadashas[].{lord,start_date,...}`; (d) OpenAPI flat strings. Which one `noesis-vedic-api` actually returns to the web is **unconfirmed** — I found no `*ResponseSchema`/handler that serializes `VimshottariTimeline` into the `EngineOutput.result`. Flag for runtime capture.
+- **Lord case mismatch:** vedic-api serializes lords **lowercase** (`types.rs:10`); engine path Title-Case (`engine.rs:145`). Renderer does no normalization → if fed lowercase, color/label lookups keyed on `"Venus"` will miss. Verify casing before keying visuals.
+- **`models.rs` carries dead/duplicate types:** `VimshottariChart` (L8, `current_period`+`upcoming_transitions`) vs the `engine.rs` JSON (same field names — this IS the source) — but `models.rs` also defines `Nakshatra` (L124), `UpcomingTransition` (L204, distinct from `Transition` L184), `PlanetaryPeriodQualities` (L214), `PeriodEnrichment` (L224, mirrors enrichment). `TransitionType` is an alias of `TransitionLevel` (L200). Confirm which are live before relying on them.
+- **Sub-period lists are not in the engine `result`:** `timeline.mahadashas[]` carries only `antardasha_count` (a number), not the nested Antardasha array (`engine.rs:149`) — so a ring drawing Bhukti arcs for *non-current* Mahadashas has **no data** from this path; only the *current* Maha's Antar/Pratyantar are emitted (under `current_period`). Wave-2 nested rings need the server to expose `sub_periods` (the vedic-api `DashaPeriod.sub_periods` recursion supports it; the engine `result` truncates it).
+- **Fixture is a validation reference, not the envelope:** `dasha_reference.json` holds `reference_charts[].expected_mahadashas[]` (`{planet, start_date, end_date, duration_years, is_birth_dasha}`) for cross-checking JHora — useful for ranges/sequence, but it is **not** the API `result` JSON. Don't build the renderer against it.


### PR DESCRIPTION
## What
17 per-engine data references + index in `docs/engines/` — output schema, ranges/constraints/invariants, component+brand archetype, data→visual mapping, dynamics, open questions. Every field cited to file:line.

## Why
Grounds the Wave-2 engine-renderer work the way `docs/design/biofield-web/` grounds biofield-web.

## Key findings
- **3 computation paths**: Rust `engine-*`, `noesis-vedic-api` (ships the 4 Vedic engines), and a `ts-engines` Bun sidecar via `noesis-bridge` (Enneagram/Tarot/I-Ching/Sacred-Geometry/Sigil-Forge/Raaga are TypeScript).
- **~16 of 17 renderers read keys the engine never emits** (key/scale mismatches; e.g. `result.type` vs `hd_type`, `.number` vs `.value`, biorhythm ±1 read as ±100 → flat waves; Sigil Forge `dangerouslySetInnerHTML` XSS risk). Full table in the README; detail per doc §7.
- OpenAPI `*ResultSchema` stubs are mostly illustrative — not the real shape.

Static (code-level) analysis — Vedic multi-path engines need a live runtime capture to confirm the shipped shape. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)